### PR TITLE
feat(auth): add organization membership resolution

### DIFF
--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { auth } from './lib/auth';
 import { env } from 'cloudflare:workers';
+import { resolveMembershipResolution } from './lib/auth-organization';
 
 const app = new Hono();
 
@@ -16,6 +17,25 @@ app.use(
     credentials: true,
   }),
 );
+
+app.get('/api/auth/membership-resolution', async (c) => {
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const resolution = await resolveMembershipResolution({
+    currentActiveOrganizationId: session.session.activeOrganizationId ?? null,
+    sessionId: session.session.id,
+    userEmail: session.user.email,
+    userId: session.user.id,
+  });
+
+  return c.json(resolution);
+});
 
 app.on(['POST', 'GET'], '/api/auth/*', (c) => auth.handler(c.req.raw));
 

--- a/apps/backend-hono/src/lib/auth-organization.ts
+++ b/apps/backend-hono/src/lib/auth-organization.ts
@@ -1,9 +1,44 @@
+import { and, asc, eq, gt, sql } from 'drizzle-orm';
 import { getOrgAdapter, type OrganizationOptions } from 'better-auth/plugins';
-import type { User as AuthUser } from '../db/schema';
+import { db } from '../db/client';
+import { invitations, members, organizations, sessions, type User as AuthUser } from '../db/schema';
 
 type OrganizationAuthContext = Parameters<typeof getOrgAdapter>[0];
 
 export type SignUpOrganizationMode = 'direct-signup' | 'invite-signup';
+
+export type MembershipResolutionStatus =
+  | 'active-organization'
+  | 'needs-organization-choice'
+  | 'needs-organization-creation';
+
+export type MembershipResolutionResponse = {
+  status: MembershipResolutionStatus;
+  activeOrganizationId: string | null;
+  organizations: Array<{
+    id: string;
+    name: string;
+    slug: string;
+    role: string;
+  }>;
+  pendingInvites: Array<{
+    id: string;
+    organizationId: string;
+    organizationName: string;
+    role: string | null;
+    expiresAt: string;
+  }>;
+  canCreateOrganization: boolean;
+};
+
+type MembershipOrganization = MembershipResolutionResponse['organizations'][number] & {
+  membershipCreatedAt: Date;
+};
+
+type PendingInvite = Omit<MembershipResolutionResponse['pendingInvites'][number], 'expiresAt'> & {
+  createdAt: Date;
+  expiresAt: Date;
+};
 
 const defaultOrganizationNameSuffix = ' Organization';
 const fallbackOrganizationName = 'Workspace';
@@ -108,16 +143,55 @@ export async function ensureDefaultOrganizationForUser(
   }
 }
 
-export async function getInitialActiveOrganizationId(
-  authContext: OrganizationAuthContext,
-  userId: string,
-): Promise<string | null> {
-  const organizations = await getOrgAdapter(
-    authContext,
-    gatekeeperOrganizationOptions,
-  ).listOrganizations(userId);
+export async function getInitialActiveOrganizationId(userId: string): Promise<string | null> {
+  return (await listMembershipOrganizations(userId))[0]?.id ?? null;
+}
 
-  return organizations[0]?.id ?? null;
+export async function resolveMembershipResolution({
+  currentActiveOrganizationId,
+  sessionId,
+  userEmail,
+  userId,
+}: {
+  currentActiveOrganizationId: string | null;
+  sessionId: string;
+  userEmail: string;
+  userId: string;
+}): Promise<MembershipResolutionResponse> {
+  const [membershipOrganizations, pendingInvites] = await Promise.all([
+    listMembershipOrganizations(userId),
+    listPendingInvites(userEmail),
+  ]);
+  const resolvedActiveOrganizationId = resolveActiveOrganizationId(
+    currentActiveOrganizationId,
+    membershipOrganizations,
+  );
+
+  if (resolvedActiveOrganizationId !== currentActiveOrganizationId) {
+    await db
+      .update(sessions)
+      .set({ activeOrganizationId: resolvedActiveOrganizationId })
+      .where(eq(sessions.id, sessionId));
+  }
+
+  return {
+    status: getMembershipResolutionStatus(resolvedActiveOrganizationId, pendingInvites),
+    activeOrganizationId: resolvedActiveOrganizationId,
+    organizations: orderMembershipOrganizations(
+      membershipOrganizations,
+      resolvedActiveOrganizationId,
+    ).map(({ id, membershipCreatedAt: _membershipCreatedAt, name, role, slug }) => ({
+      id,
+      name,
+      role,
+      slug,
+    })),
+    pendingInvites: pendingInvites.map(({ createdAt: _createdAt, expiresAt, ...invite }) => ({
+      ...invite,
+      expiresAt: expiresAt.toISOString(),
+    })),
+    canCreateOrganization: true,
+  };
 }
 
 export async function shouldCreateDefaultOrganization(
@@ -132,13 +206,13 @@ export function isEmailPasswordSignUp(context: { path?: string } | null): boolea
 }
 
 async function getPendingInvitations(authContext: OrganizationAuthContext, email: string) {
-  const invitations = await getOrgAdapter(
+  const pendingInvitations = await getOrgAdapter(
     authContext,
     gatekeeperOrganizationOptions,
   ).listUserInvitations(email.toLowerCase());
   const now = new Date();
 
-  return invitations.filter(
+  return pendingInvitations.filter(
     (invitation) => invitation.status === 'pending' && invitation.expiresAt > now,
   );
 }
@@ -178,4 +252,92 @@ function slugify(value: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 48);
+}
+
+async function listMembershipOrganizations(userId: string): Promise<MembershipOrganization[]> {
+  return db
+    .select({
+      id: organizations.id,
+      membershipCreatedAt: members.createdAt,
+      name: organizations.name,
+      role: members.role,
+      slug: organizations.slug,
+    })
+    .from(members)
+    .innerJoin(organizations, eq(members.organizationId, organizations.id))
+    .where(eq(members.userId, userId))
+    .orderBy(asc(members.createdAt), asc(members.organizationId));
+}
+
+async function listPendingInvites(userEmail: string): Promise<PendingInvite[]> {
+  const normalizedEmail = userEmail.toLowerCase();
+
+  return db
+    .select({
+      createdAt: invitations.createdAt,
+      expiresAt: invitations.expiresAt,
+      id: invitations.id,
+      organizationId: invitations.organizationId,
+      organizationName: organizations.name,
+      role: invitations.role,
+    })
+    .from(invitations)
+    .innerJoin(organizations, eq(invitations.organizationId, organizations.id))
+    .where(
+      and(
+        eq(sql<string>`lower(${invitations.email})`, normalizedEmail),
+        eq(invitations.status, 'pending'),
+        gt(invitations.expiresAt, new Date()),
+      ),
+    )
+    .orderBy(asc(invitations.expiresAt), asc(invitations.createdAt));
+}
+
+function resolveActiveOrganizationId(
+  currentActiveOrganizationId: string | null,
+  membershipOrganizations: MembershipOrganization[],
+): string | null {
+  if (
+    currentActiveOrganizationId &&
+    membershipOrganizations.some(({ id }) => id === currentActiveOrganizationId)
+  ) {
+    return currentActiveOrganizationId;
+  }
+
+  return membershipOrganizations[0]?.id ?? null;
+}
+
+function getMembershipResolutionStatus(
+  activeOrganizationId: string | null,
+  pendingInvites: PendingInvite[],
+): MembershipResolutionStatus {
+  if (activeOrganizationId) {
+    return 'active-organization';
+  }
+
+  if (pendingInvites.length > 0) {
+    return 'needs-organization-choice';
+  }
+
+  return 'needs-organization-creation';
+}
+
+function orderMembershipOrganizations(
+  membershipOrganizations: MembershipOrganization[],
+  activeOrganizationId: string | null,
+): MembershipOrganization[] {
+  if (!activeOrganizationId) {
+    return membershipOrganizations;
+  }
+
+  const activeOrganization = membershipOrganizations.find(({ id }) => id === activeOrganizationId);
+
+  if (!activeOrganization) {
+    return membershipOrganizations;
+  }
+
+  return [
+    activeOrganization,
+    ...membershipOrganizations.filter(({ id }) => id !== activeOrganizationId),
+  ];
 }

--- a/apps/backend-hono/src/lib/auth.ts
+++ b/apps/backend-hono/src/lib/auth.ts
@@ -67,10 +67,7 @@ export const auth = betterAuth({
             return;
           }
 
-          const activeOrganizationId = await getInitialActiveOrganizationId(
-            context.context,
-            session.userId,
-          );
+          const activeOrganizationId = await getInitialActiveOrganizationId(session.userId);
 
           if (!activeOrganizationId) {
             return;

--- a/apps/backend-hono/test/index.spec.ts
+++ b/apps/backend-hono/test/index.spec.ts
@@ -4,8 +4,9 @@ import { describe, expect, it } from 'vitest';
 
 import app from '../src/index';
 import { db } from '../src/db/client';
-import { users } from '../src/db/schema';
+import { invitations, sessions, users } from '../src/db/schema';
 import { auth } from '../src/lib/auth';
+import type { MembershipResolutionResponse } from '../src/lib/auth-organization';
 
 const authHeaders = {
   origin: 'http://localhost:5173',
@@ -55,6 +56,33 @@ async function signInUser(credentials: ReturnType<typeof createCredentials>) {
     ...authHeaders,
     cookie,
   });
+}
+
+async function createOrganization(
+  headers: Headers,
+  namePrefix: string,
+  keepCurrentActiveOrganization = true,
+) {
+  const suffix = crypto.randomUUID().slice(0, 8);
+
+  return auth.api.createOrganization({
+    body: {
+      keepCurrentActiveOrganization,
+      name: `${namePrefix} Organization`,
+      slug: `${namePrefix}-${suffix}`,
+    },
+    headers,
+  });
+}
+
+async function getMembershipResolution(headers: Headers) {
+  const response = await app.request('http://example.com/api/auth/membership-resolution', {
+    headers,
+  });
+
+  expect(response.status).toBe(200);
+
+  return (await response.json()) as MembershipResolutionResponse;
 }
 
 describe('Hello Hono worker', () => {
@@ -125,10 +153,239 @@ describe('Hello Hono worker', () => {
       headers: invitedUserSessionHeaders,
     });
     const invitedUserSession = await auth.api.getSession({ headers: invitedUserSessionHeaders });
+    const membershipResolution = await getMembershipResolution(invitedUserSessionHeaders);
 
     expect(invitedUserOrganizations).toHaveLength(0);
     expect(invitedUserInvitations).toHaveLength(1);
     expect(invitedUserInvitations[0]?.organizationId).toBe(organizationId);
     expect(invitedUserSession?.session.activeOrganizationId).toBeNull();
+    expect(membershipResolution).toMatchObject({
+      activeOrganizationId: null,
+      canCreateOrganization: true,
+      organizations: [],
+      pendingInvites: [
+        {
+          organizationId,
+        },
+      ],
+      status: 'needs-organization-choice',
+    });
+  });
+
+  it('resolves and persists the fallback active organization when the current session is missing one', async () => {
+    const user = createCredentials('membership-fallback');
+
+    await signUpUser(user);
+
+    const sessionHeaders = await signInUser(user);
+    const defaultOrganization = (await auth.api.listOrganizations({ headers: sessionHeaders }))[0];
+    const secondOrganization = await createOrganization(sessionHeaders, 'second-membership');
+    const session = await auth.api.getSession({ headers: sessionHeaders });
+
+    expect(defaultOrganization?.id).toBeTruthy();
+    expect(secondOrganization?.id).toBeTruthy();
+    expect(session?.session.id).toBeTruthy();
+
+    if (!defaultOrganization?.id || !secondOrganization?.id || !session?.session.id) {
+      throw new Error('Expected memberships and an active session for the fallback test.');
+    }
+
+    await db
+      .update(sessions)
+      .set({ activeOrganizationId: null })
+      .where(eq(sessions.id, session.session.id));
+
+    const membershipResolution = await getMembershipResolution(sessionHeaders);
+    const refreshedSession = await auth.api.getSession({ headers: sessionHeaders });
+
+    expect(membershipResolution).toMatchObject({
+      activeOrganizationId: defaultOrganization.id,
+      canCreateOrganization: true,
+      organizations: [{ id: defaultOrganization.id }, { id: secondOrganization.id }],
+      pendingInvites: [],
+      status: 'active-organization',
+    });
+    expect(refreshedSession?.session.activeOrganizationId).toBe(defaultOrganization.id);
+  });
+
+  it('keeps a valid active organization and still returns pending invites', async () => {
+    const user = createCredentials('membership-active');
+
+    await signUpUser(user);
+
+    const userSessionHeaders = await signInUser(user);
+    const defaultOrganization = (
+      await auth.api.listOrganizations({ headers: userSessionHeaders })
+    )[0];
+    const secondOrganization = await createOrganization(userSessionHeaders, 'active-membership');
+
+    expect(defaultOrganization?.id).toBeTruthy();
+    expect(secondOrganization?.id).toBeTruthy();
+
+    if (!defaultOrganization?.id || !secondOrganization?.id) {
+      throw new Error('Expected two organizations for the active membership test.');
+    }
+
+    await auth.api.setActiveOrganization({
+      body: {
+        organizationId: secondOrganization.id,
+      },
+      headers: userSessionHeaders,
+    });
+
+    const inviter = createCredentials('membership-inviter');
+
+    await signUpUser(inviter);
+
+    const inviterSessionHeaders = await signInUser(inviter);
+    const inviterOrganization = (
+      await auth.api.listOrganizations({ headers: inviterSessionHeaders })
+    )[0];
+
+    expect(inviterOrganization?.id).toBeTruthy();
+
+    if (!inviterOrganization?.id) {
+      throw new Error('Expected a default organization for the inviter.');
+    }
+
+    await auth.api.createInvitation({
+      body: {
+        email: user.email,
+        organizationId: inviterOrganization.id,
+        role: 'member',
+      },
+      headers: inviterSessionHeaders,
+    });
+
+    const membershipResolution = await getMembershipResolution(userSessionHeaders);
+    const session = await auth.api.getSession({ headers: userSessionHeaders });
+
+    expect(membershipResolution).toMatchObject({
+      activeOrganizationId: secondOrganization.id,
+      canCreateOrganization: true,
+      organizations: [{ id: secondOrganization.id }, { id: defaultOrganization.id }],
+      pendingInvites: [
+        {
+          organizationId: inviterOrganization.id,
+        },
+      ],
+      status: 'active-organization',
+    });
+    expect(session?.session.activeOrganizationId).toBe(secondOrganization.id);
+  });
+
+  it('ignores expired invites when resolving membership status', async () => {
+    const owner = createCredentials('expired-invite-owner');
+
+    await signUpUser(owner);
+
+    const ownerSessionHeaders = await signInUser(owner);
+    const ownerOrganization = (
+      await auth.api.listOrganizations({ headers: ownerSessionHeaders })
+    )[0];
+
+    expect(ownerOrganization?.id).toBeTruthy();
+
+    if (!ownerOrganization?.id) {
+      throw new Error('Expected a default organization for the expired invite owner.');
+    }
+
+    const invitedUser = createCredentials('expired-invite-user');
+
+    const invitation = await auth.api.createInvitation({
+      body: {
+        email: invitedUser.email,
+        organizationId: ownerOrganization.id,
+        role: 'member',
+      },
+      headers: ownerSessionHeaders,
+    });
+
+    await signUpUser(invitedUser);
+
+    await db
+      .update(invitations)
+      .set({ expiresAt: new Date(Date.now() - 60_000) })
+      .where(eq(invitations.id, invitation.id));
+
+    const invitedUserSessionHeaders = await signInUser(invitedUser);
+    const membershipResolution = await getMembershipResolution(invitedUserSessionHeaders);
+    const session = await auth.api.getSession({ headers: invitedUserSessionHeaders });
+
+    expect(membershipResolution).toMatchObject({
+      activeOrganizationId: null,
+      canCreateOrganization: true,
+      organizations: [],
+      pendingInvites: [],
+      status: 'needs-organization-creation',
+    });
+    expect(session?.session.activeOrganizationId).toBeNull();
+  });
+
+  it('activates the invited organization immediately after invite acceptance', async () => {
+    const owner = createCredentials('accept-owner');
+
+    await signUpUser(owner);
+
+    const ownerSessionHeaders = await signInUser(owner);
+    const ownerOrganization = (
+      await auth.api.listOrganizations({ headers: ownerSessionHeaders })
+    )[0];
+
+    expect(ownerOrganization?.id).toBeTruthy();
+
+    if (!ownerOrganization?.id) {
+      throw new Error('Expected a default organization for the invite owner.');
+    }
+
+    const invitedUser = createCredentials('accept-user');
+
+    await signUpUser(invitedUser);
+
+    await auth.api.createInvitation({
+      body: {
+        email: invitedUser.email,
+        organizationId: ownerOrganization.id,
+        role: 'member',
+      },
+      headers: ownerSessionHeaders,
+    });
+
+    const invitedUserSessionHeaders = await signInUser(invitedUser);
+    const invitedUserDefaultOrganization = (
+      await auth.api.listOrganizations({
+        headers: invitedUserSessionHeaders,
+      })
+    )[0];
+    const userInvitations = await auth.api.listUserInvitations({
+      headers: invitedUserSessionHeaders,
+    });
+    const invitationId = userInvitations[0]?.id;
+
+    expect(invitedUserDefaultOrganization?.id).toBeTruthy();
+    expect(invitationId).toBeTruthy();
+
+    if (!invitedUserDefaultOrganization?.id || !invitationId) {
+      throw new Error('Expected a default organization and a pending invitation.');
+    }
+
+    await auth.api.acceptInvitation({
+      body: {
+        invitationId,
+      },
+      headers: invitedUserSessionHeaders,
+    });
+
+    const membershipResolution = await getMembershipResolution(invitedUserSessionHeaders);
+    const refreshedSession = await auth.api.getSession({ headers: invitedUserSessionHeaders });
+
+    expect(membershipResolution).toMatchObject({
+      activeOrganizationId: ownerOrganization.id,
+      canCreateOrganization: true,
+      organizations: [{ id: ownerOrganization.id }, { id: invitedUserDefaultOrganization.id }],
+      pendingInvites: [],
+      status: 'active-organization',
+    });
+    expect(refreshedSession?.session.activeOrganizationId).toBe(ownerOrganization.id);
   });
 });


### PR DESCRIPTION
## Summary
- add an authenticated `/api/auth/membership-resolution` endpoint that resolves memberships, pending invites, and the post-login status in one backend contract
- persist a deterministic fallback `activeOrganizationId` when the current session is missing or invalid, while preserving a valid active organization
- add backend tests covering fallback resolution, pending and expired invite states, and immediate session activation after invite acceptance

## Testing
- pnpm test --filter backend-hono
- pnpm check-types --filter backend-hono

Closes #5