### PR TITLE
Preserve static pages when switching organizations

### DIFF
--- a/apps/web/src/components/layouts/dashboard-sidebar.tsx
+++ b/apps/web/src/components/layouts/dashboard-sidebar.tsx
@@ -18,7 +18,10 @@ import {
   type MembershipResolutionResponse,
 } from '../../features/auth/auth-api';
 import { signOut, useSession } from '../../features/auth/auth-client';
-import { buildOrganizationPath } from '../../features/auth/auth-routing';
+import {
+  buildOrganizationPath,
+  buildOrganizationSwitchPath,
+} from '../../features/auth/auth-routing';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import {
   DropdownMenu,
@@ -100,7 +103,15 @@ export function DashboardSidebar() {
       setResolution(next);
       const activeOrg = next.organizations.find((org) => org.id === organizationId);
       if (activeOrg) {
-        navigate(buildOrganizationPath(activeOrg.slug));
+        navigate(
+          buildOrganizationSwitchPath({
+            currentOrganizationSlug:
+              resolution?.organizations.find((org) => org.id === resolution.activeOrganizationId)
+                ?.slug ?? null,
+            currentPathname: location.pathname,
+            nextOrganizationSlug: activeOrg.slug,
+          }),
+        );
       }
     } finally {
       setSwitchingOrgId(null);

--- a/apps/web/src/features/auth/auth-routing.test.ts
+++ b/apps/web/src/features/auth/auth-routing.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildEmailVerificationCallbackUrl,
   buildOrganizationPath,
+  buildOrganizationSwitchPath,
   buildPasswordResetCallbackUrl,
   getPostLoginView,
   getVerificationCallbackState,
@@ -57,6 +58,82 @@ describe('auth routing helpers', () => {
     expect(buildOrganizationPath('acme')).toBe('/acme');
     expect(buildOrganizationPath('acme', '/settings')).toBe('/acme/settings');
     expect(buildOrganizationPath('acme', 'projects')).toBe('/acme/projects');
+  });
+
+  it('preserves static organization-scoped paths when switching organizations', () => {
+    expect(
+      buildOrganizationSwitchPath({
+        currentOrganizationSlug: 'acme',
+        currentPathname: '/acme',
+        nextOrganizationSlug: 'globex',
+      }),
+    ).toBe('/globex');
+    expect(
+      buildOrganizationSwitchPath({
+        currentOrganizationSlug: 'acme',
+        currentPathname: '/acme/settings',
+        nextOrganizationSlug: 'globex',
+      }),
+    ).toBe('/globex/settings');
+    expect(
+      buildOrganizationSwitchPath({
+        currentOrganizationSlug: 'acme',
+        currentPathname: '/acme/projects',
+        nextOrganizationSlug: 'globex',
+      }),
+    ).toBe('/globex/projects');
+    expect(
+      buildOrganizationSwitchPath({
+        currentOrganizationSlug: 'acme',
+        currentPathname: '/acme/controls',
+        nextOrganizationSlug: 'globex',
+      }),
+    ).toBe('/globex/controls');
+    expect(
+      buildOrganizationSwitchPath({
+        currentOrganizationSlug: 'acme',
+        currentPathname: '/acme/checklists',
+        nextOrganizationSlug: 'globex',
+      }),
+    ).toBe('/globex/checklists');
+    expect(
+      buildOrganizationSwitchPath({
+        currentOrganizationSlug: 'acme',
+        currentPathname: '/acme/exceptions',
+        nextOrganizationSlug: 'globex',
+      }),
+    ).toBe('/globex/exceptions');
+    expect(
+      buildOrganizationSwitchPath({
+        currentOrganizationSlug: 'acme',
+        currentPathname: '/acme/audit',
+        nextOrganizationSlug: 'globex',
+      }),
+    ).toBe('/globex/audit');
+  });
+
+  it('redirects dynamic or non-organization paths to the selected organization home', () => {
+    expect(
+      buildOrganizationSwitchPath({
+        currentOrganizationSlug: 'acme',
+        currentPathname: '/acme/p/my-project',
+        nextOrganizationSlug: 'globex',
+      }),
+    ).toBe('/globex');
+    expect(
+      buildOrganizationSwitchPath({
+        currentOrganizationSlug: 'acme',
+        currentPathname: '/settings',
+        nextOrganizationSlug: 'globex',
+      }),
+    ).toBe('/globex');
+    expect(
+      buildOrganizationSwitchPath({
+        currentOrganizationSlug: null,
+        currentPathname: '/',
+        nextOrganizationSlug: 'globex',
+      }),
+    ).toBe('/globex');
   });
 
   it('builds callback urls for verification and password reset', () => {

--- a/apps/web/src/features/auth/auth-routing.ts
+++ b/apps/web/src/features/auth/auth-routing.ts
@@ -45,6 +45,45 @@ export function buildOrganizationPath(organizationSlug: string, path = '/'): str
   return `/${organizationSlug}${normalizedPath === '/' ? '' : normalizedPath}`;
 }
 
+const STATIC_ORGANIZATION_PATHS = new Set([
+  '/',
+  '/settings',
+  '/projects',
+  '/controls',
+  '/checklists',
+  '/exceptions',
+  '/audit',
+]);
+
+export function buildOrganizationSwitchPath(input: {
+  currentPathname: string;
+  currentOrganizationSlug: string | null;
+  nextOrganizationSlug: string;
+}): string {
+  const { currentPathname, currentOrganizationSlug, nextOrganizationSlug } = input;
+
+  if (!currentOrganizationSlug) {
+    return buildOrganizationPath(nextOrganizationSlug);
+  }
+
+  const organizationPathPrefix = `/${currentOrganizationSlug}`;
+
+  if (
+    currentPathname !== organizationPathPrefix &&
+    !currentPathname.startsWith(`${organizationPathPrefix}/`)
+  ) {
+    return buildOrganizationPath(nextOrganizationSlug);
+  }
+
+  const pathWithinOrganization = currentPathname.slice(organizationPathPrefix.length) || '/';
+
+  if (!STATIC_ORGANIZATION_PATHS.has(pathWithinOrganization)) {
+    return buildOrganizationPath(nextOrganizationSlug);
+  }
+
+  return buildOrganizationPath(nextOrganizationSlug, pathWithinOrganization);
+}
+
 export function buildEmailVerificationCallbackUrl(input: {
   email: string;
   origin: string;


### PR DESCRIPTION
## Summary
- Preserve known static organization-scoped routes when switching Organizations from the sidebar.
- Redirect dynamic or unknown Organization routes back to the newly selected Organization home.
- Add routing helper coverage for static preservation and dynamic fallback behavior.

## Checks
- pnpm format:check
- pnpm lint
- pnpm check-types
- pnpm test
- pnpm build

Closes #9