### PR TITLE
Reserve public organization slugs

### DIFF
--- a/apps/backend-hono/src/lib/auth-organization.ts
+++ b/apps/backend-hono/src/lib/auth-organization.ts
@@ -1,4 +1,5 @@
 import { and, asc, eq, gt, sql } from 'drizzle-orm';
+import { APIError } from 'better-auth/api';
 import { getOrgAdapter, type OrganizationOptions } from 'better-auth/plugins';
 import { db } from '../db/client';
 import {
@@ -90,6 +91,15 @@ type InvitationEntryViewer = {
 const defaultOrganizationNameSuffix = ' Organization';
 const fallbackOrganizationName = 'Workspace';
 const maxSlugSuffixAttempts = 100;
+const reservedOrganizationSlugs = new Set([
+  'api',
+  'forgot-password',
+  'invite',
+  'reset-password',
+  'sign-in',
+  'sign-up',
+  'verify-email',
+]);
 
 // Gatekeeper maps product concepts onto Better Auth's organization plugin:
 // - account => Better Auth user
@@ -103,6 +113,15 @@ const maxSlugSuffixAttempts = 100;
 // - new session: initialize the active organization from the user's memberships, if any exist
 export const gatekeeperOrganizationOptions: OrganizationOptions = {
   allowUserToCreateOrganization: true,
+  organizationHooks: {
+    beforeCreateOrganization: async ({ organization }) => {
+      if (organization.slug && isReservedOrganizationSlug(organization.slug)) {
+        throw new APIError('BAD_REQUEST', {
+          message: 'This organization slug is reserved for a public Gatekeeper route.',
+        });
+      }
+    },
+  },
 };
 
 export async function resolveSignUpOrganizationMode(
@@ -309,6 +328,10 @@ export function isEmailPasswordSignUp(context: { path?: string } | null): boolea
   return context?.path === '/sign-up/email';
 }
 
+export function isReservedOrganizationSlug(slug: string): boolean {
+  return reservedOrganizationSlugs.has(slug.toLowerCase());
+}
+
 async function getPendingInvitations(authContext: OrganizationAuthContext, email: string) {
   const pendingInvitations = await getOrgAdapter(
     authContext,
@@ -333,7 +356,10 @@ async function getUniqueDefaultOrganizationSlug(
 ): Promise<string> {
   const adapter = getOrgAdapter(authContext, gatekeeperOrganizationOptions);
   const emailLocalPart = user.email.split('@')[0] ?? '';
-  const baseSlug = slugify(user.name) || slugify(emailLocalPart) || 'workspace';
+  const candidateBaseSlug = slugify(user.name) || slugify(emailLocalPart) || 'workspace';
+  const baseSlug = isReservedOrganizationSlug(candidateBaseSlug)
+    ? `${candidateBaseSlug}-organization`
+    : candidateBaseSlug;
 
   for (let attempt = 0; attempt < maxSlugSuffixAttempts; attempt += 1) {
     const slug = attempt === 0 ? baseSlug : `${baseSlug}-${attempt + 1}`;

--- a/apps/backend-hono/test/organization-membership.spec.ts
+++ b/apps/backend-hono/test/organization-membership.spec.ts
@@ -181,6 +181,38 @@ describe('organization membership resolution', () => {
       expect(session?.session.activeOrganizationId).toBe(organizations[0]?.id);
     });
 
+    it('avoids reserved public route words for default organization slugs', async () => {
+      const user = {
+        ...createCredentials('reserved-default-org'),
+        name: 'Sign In',
+      };
+
+      await signUpUser(user);
+
+      const sessionHeaders = await signInUser(user);
+      const organizations = await auth.api.listOrganizations({ headers: sessionHeaders });
+
+      expect(organizations[0]?.slug).toBe('sign-in-organization');
+    });
+
+    it('rejects organization creation with public route slugs', async () => {
+      const user = createCredentials('reserved-create-org');
+
+      await signUpUser(user);
+
+      const sessionHeaders = await signInUser(user);
+
+      await expect(
+        auth.api.createOrganization({
+          body: {
+            name: 'Sign In',
+            slug: 'sign-in',
+          },
+          headers: sessionHeaders,
+        }),
+      ).rejects.toThrow('reserved for a public Gatekeeper route');
+    });
+
     it('skips default organization creation when the user already has a pending invite', async () => {
       const owner = createCredentials('owner');
 

--- a/apps/web/src/components/pages/home.tsx
+++ b/apps/web/src/components/pages/home.tsx
@@ -11,7 +11,9 @@ import {
 import { humanizeAuthError } from '../../features/auth/auth-errors';
 import {
   buildOrganizationPath,
+  generateOrganizationSlug,
   getPostLoginView,
+  isReservedOrganizationSlug,
   slugifyOrganizationName,
 } from '../../features/auth/auth-routing';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
@@ -66,6 +68,10 @@ export function HomePage() {
     event.preventDefault();
     if (!orgSlug) {
       setOrgError('Organization slug is required.');
+      return;
+    }
+    if (isReservedOrganizationSlug(orgSlug)) {
+      setOrgError('This organization slug is reserved for a public Gatekeeper route.');
       return;
     }
     setOrgError(null);
@@ -161,7 +167,7 @@ export function HomePage() {
           value={orgName}
           onChange={(event) => {
             setOrgName(event.target.value);
-            setOrgSlug(slugifyOrganizationName(event.target.value));
+            setOrgSlug(generateOrganizationSlug(event.target.value));
           }}
           required
         />

--- a/apps/web/src/features/auth/auth-routing.test.ts
+++ b/apps/web/src/features/auth/auth-routing.test.ts
@@ -3,8 +3,10 @@ import {
   buildEmailVerificationCallbackUrl,
   buildOrganizationPath,
   buildPasswordResetCallbackUrl,
+  generateOrganizationSlug,
   getPostLoginView,
   getVerificationCallbackState,
+  isReservedOrganizationSlug,
   slugifyOrganizationName,
 } from './auth-routing';
 
@@ -51,6 +53,17 @@ describe('auth routing helpers', () => {
     expect(slugifyOrganizationName('My Workspace')).toBe('my-workspace');
     expect(slugifyOrganizationName('Zolc Team ++')).toBe('zolc-team');
     expect(slugifyOrganizationName('')).toBe('');
+  });
+
+  it('identifies organization slugs reserved by public routes', () => {
+    expect(isReservedOrganizationSlug('sign-in')).toBe(true);
+    expect(isReservedOrganizationSlug('verify-email')).toBe(true);
+    expect(isReservedOrganizationSlug('my-workspace')).toBe(false);
+  });
+
+  it('avoids reserved route words when generating organization slugs', () => {
+    expect(generateOrganizationSlug('Sign In')).toBe('sign-in-organization');
+    expect(generateOrganizationSlug('My Workspace')).toBe('my-workspace');
   });
 
   it('builds organization-scoped app paths', () => {

--- a/apps/web/src/features/auth/auth-routing.ts
+++ b/apps/web/src/features/auth/auth-routing.ts
@@ -4,6 +4,16 @@ export type PostLoginView = 'app' | 'organization-choice' | 'organization-creati
 
 export type VerificationCallbackState = 'expired' | 'invalid' | 'success';
 
+const reservedOrganizationSlugs = new Set([
+  'api',
+  'forgot-password',
+  'invite',
+  'reset-password',
+  'sign-in',
+  'sign-up',
+  'verify-email',
+]);
+
 export function getPostLoginView(resolution: MembershipResolutionResponse): PostLoginView {
   switch (resolution.status) {
     case 'active-organization':
@@ -37,6 +47,16 @@ export function slugifyOrganizationName(value: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 48);
+}
+
+export function generateOrganizationSlug(value: string): string {
+  const slug = slugifyOrganizationName(value);
+
+  return isReservedOrganizationSlug(slug) ? `${slug}-organization` : slug;
+}
+
+export function isReservedOrganizationSlug(slug: string): boolean {
+  return reservedOrganizationSlugs.has(slug.toLowerCase());
 }
 
 export function buildOrganizationPath(organizationSlug: string, path = '/'): string {


### PR DESCRIPTION
## Summary
- Reject organization slugs that collide with public routes like sign-in, invite, verify-email, and reset-password.
- Avoid reserved words when generating default organization slugs.
- Add backend and frontend tests for reserved slug behavior.

## Checks
- pnpm format:check
- pnpm lint
- pnpm check-types
- pnpm test
- pnpm build

Closes #8