### PR TITLE
Add Project creation and listing

### DIFF
--- a/apps/backend-hono/drizzle/migrations/0002_projects.sql
+++ b/apps/backend-hono/drizzle/migrations/0002_projects.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `projects` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`name` text NOT NULL,
+	`description` text NOT NULL,
+	`slug` text NOT NULL,
+	`project_owner_member_id` text,
+	`archived_at` integer,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`project_owner_member_id`) REFERENCES `members`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `project_organization_id_idx` ON `projects` (`organization_id`);--> statement-breakpoint
+CREATE INDEX `project_owner_member_id_idx` ON `projects` (`project_owner_member_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `project_organization_slug_unique` ON `projects` (`organization_id`,`slug`);

--- a/apps/backend-hono/drizzle/migrations/meta/_journal.json
+++ b/apps/backend-hono/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776583468335,
       "tag": "0001_swift_war_machine",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1776583468336,
+      "tag": "0002_projects",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend-hono/src/db/schema.ts
+++ b/apps/backend-hono/src/db/schema.ts
@@ -152,3 +152,32 @@ export const invitations = sqliteTable(
     index('invitation_inviter_id_idx').on(table.inviterId),
   ],
 );
+
+export const projects = sqliteTable(
+  'projects',
+  {
+    id: text('id').primaryKey(),
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    description: text('description').notNull(),
+    slug: text('slug').notNull(),
+    projectOwnerMemberId: text('project_owner_member_id').references(() => members.id, {
+      onDelete: 'set null',
+    }),
+    archivedAt: integer('archived_at', { mode: 'timestamp_ms' }),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    index('project_organization_id_idx').on(table.organizationId),
+    index('project_owner_member_id_idx').on(table.projectOwnerMemberId),
+    uniqueIndex('project_organization_slug_unique').on(table.organizationId, table.slug),
+  ],
+);

--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -3,6 +3,15 @@ import { cors } from 'hono/cors';
 import { auth } from './lib/auth';
 import { env } from 'cloudflare:workers';
 import { resolveInvitationEntryState, resolveMembershipResolution } from './lib/auth-organization';
+import {
+  canManageProjects,
+  createProject,
+  getOrganizationMembership,
+  listActiveProjects,
+  listOrganizationMembers,
+  normalizeProjectCreateBody,
+  ProjectInputError,
+} from './lib/projects';
 
 const app = new Hono();
 
@@ -53,6 +62,86 @@ app.get('/api/auth/invitations/:invitationId', async (c) => {
   );
 
   return c.json(invitation, invitation.status === 'invalid' ? 404 : 200);
+});
+
+app.get('/api/organizations/:organizationSlug/members', async (c) => {
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(
+    c.req.param('organizationSlug'),
+    session.user.id,
+  );
+
+  if (!membership) {
+    return c.json({ error: 'Organization not found' }, 404);
+  }
+
+  return c.json({ members: await listOrganizationMembers(membership.organizationId) });
+});
+
+app.get('/api/organizations/:organizationSlug/projects', async (c) => {
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(
+    c.req.param('organizationSlug'),
+    session.user.id,
+  );
+
+  if (!membership) {
+    return c.json({ error: 'Organization not found' }, 404);
+  }
+
+  return c.json({ projects: await listActiveProjects(membership.organizationId) });
+});
+
+app.post('/api/organizations/:organizationSlug/projects', async (c) => {
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(
+    c.req.param('organizationSlug'),
+    session.user.id,
+  );
+
+  if (!membership) {
+    return c.json({ error: 'Organization not found' }, 404);
+  }
+
+  if (!canManageProjects(membership.role)) {
+    return c.json({ error: 'Only Organization owners and admins can create Projects.' }, 403);
+  }
+
+  try {
+    const project = await createProject(
+      membership.organizationId,
+      normalizeProjectCreateBody(await c.req.json().catch(() => null)),
+    );
+
+    return c.json({ project }, 201);
+  } catch (caughtError) {
+    if (caughtError instanceof ProjectInputError) {
+      return c.json({ error: caughtError.message }, 400);
+    }
+
+    throw caughtError;
+  }
 });
 
 app.on(['POST', 'GET'], '/api/auth/*', (c) => auth.handler(c.req.raw));

--- a/apps/backend-hono/src/lib/projects.ts
+++ b/apps/backend-hono/src/lib/projects.ts
@@ -1,0 +1,213 @@
+import { and, asc, eq, isNull } from 'drizzle-orm';
+import { db } from '../db/client';
+import { members, organizations, projects, users } from '../db/schema';
+
+export type ProjectListItem = {
+  createdAt: string;
+  description: string;
+  id: string;
+  name: string;
+  projectOwner: {
+    email: string;
+    id: string;
+    name: string;
+  } | null;
+  slug: string;
+};
+
+export type OrganizationMemberListItem = {
+  email: string;
+  id: string;
+  name: string;
+  role: string;
+};
+
+export type OrganizationMembership = {
+  id: string;
+  organizationId: string;
+  organizationName: string;
+  organizationSlug: string;
+  role: string;
+};
+
+type CreateProjectInput = {
+  description: string;
+  name: string;
+  projectOwnerMemberId: string | null;
+  slug: string;
+};
+
+const editableOrganizationRoles = new Set(['owner', 'admin']);
+const projectSlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export async function getOrganizationMembership(
+  organizationSlug: string,
+  userId: string,
+): Promise<OrganizationMembership | null> {
+  return db
+    .select({
+      id: members.id,
+      organizationId: organizations.id,
+      organizationName: organizations.name,
+      organizationSlug: organizations.slug,
+      role: members.role,
+    })
+    .from(members)
+    .innerJoin(organizations, eq(members.organizationId, organizations.id))
+    .where(and(eq(organizations.slug, organizationSlug), eq(members.userId, userId)))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+}
+
+export function canManageProjects(role: string): boolean {
+  return editableOrganizationRoles.has(role);
+}
+
+export async function listOrganizationMembers(
+  organizationId: string,
+): Promise<OrganizationMemberListItem[]> {
+  return db
+    .select({
+      email: users.email,
+      id: members.id,
+      name: users.name,
+      role: members.role,
+    })
+    .from(members)
+    .innerJoin(users, eq(members.userId, users.id))
+    .where(eq(members.organizationId, organizationId))
+    .orderBy(asc(users.name), asc(users.email));
+}
+
+export async function listActiveProjects(organizationId: string): Promise<ProjectListItem[]> {
+  const rows = await db
+    .select({
+      createdAt: projects.createdAt,
+      description: projects.description,
+      id: projects.id,
+      name: projects.name,
+      ownerEmail: users.email,
+      ownerId: members.id,
+      ownerName: users.name,
+      slug: projects.slug,
+    })
+    .from(projects)
+    .leftJoin(members, eq(projects.projectOwnerMemberId, members.id))
+    .leftJoin(users, eq(members.userId, users.id))
+    .where(and(eq(projects.organizationId, organizationId), isNull(projects.archivedAt)))
+    .orderBy(asc(projects.createdAt), asc(projects.name));
+
+  return rows.map(({ createdAt, ownerEmail, ownerId, ownerName, ...project }) => ({
+    ...project,
+    createdAt: createdAt.toISOString(),
+    projectOwner:
+      ownerId && ownerEmail && ownerName
+        ? {
+            email: ownerEmail,
+            id: ownerId,
+            name: ownerName,
+          }
+        : null,
+  }));
+}
+
+export async function createProject(
+  organizationId: string,
+  input: CreateProjectInput,
+): Promise<ProjectListItem> {
+  validateProjectInput(input);
+
+  const existingProject = await db
+    .select({ id: projects.id })
+    .from(projects)
+    .where(and(eq(projects.organizationId, organizationId), eq(projects.slug, input.slug)))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existingProject) {
+    throw new ProjectInputError('Project slug is already used in this Organization.');
+  }
+
+  if (input.projectOwnerMemberId) {
+    const ownerMembership = await db
+      .select({ id: members.id })
+      .from(members)
+      .where(
+        and(eq(members.id, input.projectOwnerMemberId), eq(members.organizationId, organizationId)),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+
+    if (!ownerMembership) {
+      throw new ProjectInputError('Project Owner must be a member of this Organization.');
+    }
+  }
+
+  const now = new Date();
+  const project = {
+    createdAt: now,
+    description: input.description.trim(),
+    id: crypto.randomUUID(),
+    name: input.name.trim(),
+    organizationId,
+    projectOwnerMemberId: input.projectOwnerMemberId,
+    slug: input.slug,
+    updatedAt: now,
+  };
+
+  await db.insert(projects).values(project);
+
+  return (await listActiveProjects(organizationId)).find(({ id }) => id === project.id)!;
+}
+
+export function slugifyProjectName(value: string): string {
+  const normalizedValue = Array.from(value.normalize('NFKD'))
+    .filter((character) => character.charCodeAt(0) <= 0x7f)
+    .join('');
+
+  return normalizedValue
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+}
+
+export class ProjectInputError extends Error {}
+
+function validateProjectInput(input: CreateProjectInput) {
+  const name = input.name.trim();
+  const description = input.description.trim();
+
+  if (!name) {
+    throw new ProjectInputError('Project name is required.');
+  }
+
+  if (!description) {
+    throw new ProjectInputError('Project description is required.');
+  }
+
+  if (!input.slug || !projectSlugPattern.test(input.slug)) {
+    throw new ProjectInputError(
+      'Project slug must contain lowercase letters, numbers, and hyphens.',
+    );
+  }
+
+  if (input.slug !== slugifyProjectName(input.slug)) {
+    throw new ProjectInputError('Project slug must be normalized.');
+  }
+}
+
+export function normalizeProjectCreateBody(body: unknown): CreateProjectInput {
+  const value = typeof body === 'object' && body !== null ? body : {};
+  const record = value as Record<string, unknown>;
+
+  return {
+    description: typeof record.description === 'string' ? record.description : '',
+    name: typeof record.name === 'string' ? record.name : '',
+    projectOwnerMemberId:
+      typeof record.projectOwnerMemberId === 'string' && record.projectOwnerMemberId
+        ? record.projectOwnerMemberId
+        : null,
+    slug: typeof record.slug === 'string' ? slugifyProjectName(record.slug) : '',
+  };
+}

--- a/apps/backend-hono/test/projects.spec.ts
+++ b/apps/backend-hono/test/projects.spec.ts
@@ -1,0 +1,314 @@
+import { and, eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import app from '../src/index';
+import { db } from '../src/db/client';
+import { members, projects, users } from '../src/db/schema';
+import { auth } from '../src/lib/auth';
+
+const authHeaders = {
+  origin: 'http://localhost:5173',
+  host: 'localhost:8787',
+};
+const verificationCallbackURL = 'http://localhost:8787/sign-in';
+const mailpitSendUrl = 'http://127.0.0.1:8025/api/v1/send';
+
+function createCredentials(prefix: string) {
+  const token = crypto.randomUUID();
+
+  return {
+    name: `${prefix} user`,
+    email: `${prefix}-${token}@example.com`,
+    password: `Password-${token}`,
+  };
+}
+
+async function signUpUser(credentials: ReturnType<typeof createCredentials>) {
+  await auth.api.signUpEmail({
+    body: {
+      ...credentials,
+      callbackURL: verificationCallbackURL,
+    },
+    headers: authHeaders,
+  });
+
+  await db.update(users).set({ emailVerified: true }).where(eq(users.email, credentials.email));
+}
+
+async function signInUser(credentials: ReturnType<typeof createCredentials>) {
+  const result = await auth.api.signInEmail({
+    body: {
+      email: credentials.email,
+      password: credentials.password,
+    },
+    headers: authHeaders,
+    returnHeaders: true,
+  });
+
+  const sessionCookie = result.headers.get('set-cookie');
+
+  expect(sessionCookie).toBeTruthy();
+
+  if (!sessionCookie) {
+    throw new Error('Expected Better Auth to return a session cookie.');
+  }
+
+  const cookie = sessionCookie.split(';', 1)[0] ?? sessionCookie;
+
+  return new Headers({
+    ...authHeaders,
+    cookie,
+  });
+}
+
+async function createSignedInOwner(prefix: string) {
+  const credentials = createCredentials(prefix);
+
+  await signUpUser(credentials);
+
+  const headers = await signInUser(credentials);
+  const organization = (await auth.api.listOrganizations({ headers }))[0];
+
+  expect(organization?.id).toBeTruthy();
+
+  if (!organization?.id) {
+    throw new Error('Expected a default organization.');
+  }
+
+  return { headers, organization };
+}
+
+async function createProjectRequest(
+  organizationSlug: string,
+  headers: Headers,
+  body: Record<string, unknown>,
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/projects`,
+    {
+      body: JSON.stringify(body),
+      headers,
+      method: 'POST',
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+beforeEach(() => {
+  const originalFetch = globalThis.fetch;
+
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+    if (url === mailpitSendUrl) {
+      return new Response(null, { status: 200 });
+    }
+
+    return originalFetch(input, init);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('organization projects', () => {
+  it('lets Organization owners create and list active Projects', async () => {
+    const { headers, organization } = await createSignedInOwner('project-owner');
+    const ownerMembership = await db
+      .select({ id: members.id })
+      .from(members)
+      .where(eq(members.organizationId, organization.id))
+      .limit(1)
+      .then((rows) => rows[0]);
+
+    expect(ownerMembership?.id).toBeTruthy();
+
+    if (!ownerMembership?.id) {
+      throw new Error('Expected an owner membership.');
+    }
+
+    const createResponse = await createProjectRequest(organization.slug, headers, {
+      description: 'SOC 2 readiness work for this Organization.',
+      name: 'SOC 2 Readiness',
+      projectOwnerMemberId: ownerMembership.id,
+      slug: 'soc-2-readiness',
+    });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body.project).toMatchObject({
+      description: 'SOC 2 readiness work for this Organization.',
+      name: 'SOC 2 Readiness',
+      projectOwner: { id: ownerMembership.id },
+      slug: 'soc-2-readiness',
+    });
+
+    const listResponse = await app.request(
+      `http://example.com/api/organizations/${organization.slug}/projects`,
+      { headers },
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(await listResponse.json()).toMatchObject({
+      projects: [
+        {
+          name: 'SOC 2 Readiness',
+          slug: 'soc-2-readiness',
+        },
+      ],
+    });
+  });
+
+  it('prevents members from creating Projects but allows them to list active Projects', async () => {
+    const { headers: ownerHeaders, organization } =
+      await createSignedInOwner('project-member-owner');
+    const member = createCredentials('project-member');
+
+    await signUpUser(member);
+
+    const invitation = await auth.api.createInvitation({
+      body: {
+        email: member.email,
+        organizationId: organization.id,
+        role: 'member',
+      },
+      headers: ownerHeaders,
+    });
+    const memberHeaders = await signInUser(member);
+
+    await auth.api.acceptInvitation({
+      body: { invitationId: invitation.id },
+      headers: memberHeaders,
+    });
+
+    await createProjectRequest(organization.slug, ownerHeaders, {
+      description: 'Vendor review work.',
+      name: 'Vendor Review',
+      slug: 'vendor-review',
+    });
+
+    const forbiddenCreateResponse = await createProjectRequest(organization.slug, memberHeaders, {
+      description: 'Member-created work.',
+      name: 'Member Project',
+      slug: 'member-project',
+    });
+    const listResponse = await app.request(
+      `http://example.com/api/organizations/${organization.slug}/projects`,
+      { headers: memberHeaders },
+    );
+
+    expect(forbiddenCreateResponse.status).toBe(403);
+    expect(listResponse.status).toBe(200);
+    expect(await listResponse.json()).toMatchObject({
+      projects: [{ slug: 'vendor-review' }],
+    });
+  });
+
+  it('validates required fields, Organization-local slug uniqueness, and Project Owner membership', async () => {
+    const first = await createSignedInOwner('project-first-org');
+    const second = await createSignedInOwner('project-second-org');
+    const secondOwnerMembership = await db
+      .select({ id: members.id })
+      .from(members)
+      .where(eq(members.organizationId, second.organization.id))
+      .limit(1)
+      .then((rows) => rows[0]);
+
+    expect(secondOwnerMembership?.id).toBeTruthy();
+
+    if (!secondOwnerMembership?.id) {
+      throw new Error('Expected a second owner membership.');
+    }
+
+    const missingDescriptionResponse = await createProjectRequest(
+      first.organization.slug,
+      first.headers,
+      {
+        description: '',
+        name: 'Missing Description',
+        slug: 'missing-description',
+      },
+    );
+
+    expect(missingDescriptionResponse.status).toBe(400);
+    expect(missingDescriptionResponse.body).toMatchObject({
+      error: 'Project description is required.',
+    });
+
+    const wrongOwnerResponse = await createProjectRequest(first.organization.slug, first.headers, {
+      description: 'Wrong owner membership.',
+      name: 'Wrong Owner',
+      projectOwnerMemberId: secondOwnerMembership.id,
+      slug: 'wrong-owner',
+    });
+
+    expect(wrongOwnerResponse.status).toBe(400);
+    expect(wrongOwnerResponse.body).toMatchObject({
+      error: 'Project Owner must be a member of this Organization.',
+    });
+
+    await createProjectRequest(first.organization.slug, first.headers, {
+      description: 'First instance.',
+      name: 'Shared Slug',
+      slug: 'shared-slug',
+    });
+    const duplicateResponse = await createProjectRequest(first.organization.slug, first.headers, {
+      description: 'Duplicate instance.',
+      name: 'Shared Slug Duplicate',
+      slug: 'shared-slug',
+    });
+
+    expect(duplicateResponse.status).toBe(400);
+    expect(duplicateResponse.body).toMatchObject({
+      error: 'Project slug is already used in this Organization.',
+    });
+
+    const otherOrganizationResponse = await createProjectRequest(
+      second.organization.slug,
+      second.headers,
+      {
+        description: 'Same slug in another Organization.',
+        name: 'Shared Slug',
+        slug: 'shared-slug',
+      },
+    );
+
+    expect(otherOrganizationResponse.status).toBe(201);
+
+    const archivedDuplicate = await db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(
+        and(eq(projects.organizationId, first.organization.id), eq(projects.slug, 'shared-slug')),
+      )
+      .then((rows) => rows[0]);
+
+    expect(archivedDuplicate?.id).toBeTruthy();
+
+    if (!archivedDuplicate?.id) {
+      throw new Error('Expected the first Project.');
+    }
+
+    await db
+      .update(projects)
+      .set({ archivedAt: new Date() })
+      .where(eq(projects.id, archivedDuplicate.id));
+
+    const archivedSlugResponse = await createProjectRequest(
+      first.organization.slug,
+      first.headers,
+      {
+        description: 'Archived slug reuse attempt.',
+        name: 'Archived Slug Reuse',
+        slug: 'shared-slug',
+      },
+    );
+
+    expect(archivedSlugResponse.status).toBe(400);
+  });
+});

--- a/apps/web/src/components/pages/project-detail.tsx
+++ b/apps/web/src/components/pages/project-detail.tsx
@@ -1,0 +1,24 @@
+import { Link, useParams } from 'react-router';
+import { buildOrganizationPath } from '../../features/auth/auth-routing';
+import { Button } from '@/components/ui/button';
+
+export function ProjectDetailPage() {
+  const { organizationSlug, projectSlug } = useParams();
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-4">
+      <header className="space-y-1">
+        <p className="text-sm text-muted-foreground">Project</p>
+        <h1 className="text-2xl font-semibold tracking-tight">{projectSlug}</h1>
+        <p className="text-sm text-muted-foreground">
+          The Project detail view will expand in the next Project slice.
+        </p>
+      </header>
+      {organizationSlug ? (
+        <Button asChild variant="outline">
+          <Link to={buildOrganizationPath(organizationSlug, '/projects')}>Back to Projects</Link>
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/pages/projects.tsx
+++ b/apps/web/src/components/pages/projects.tsx
@@ -1,0 +1,268 @@
+import { useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+import { AlertCircle, CheckCircle2, Plus } from 'lucide-react';
+import { Link, useNavigate, useParams } from 'react-router';
+import {
+  createProject,
+  getMembershipResolution,
+  listOrganizationMembers,
+  listProjects,
+  type OrganizationMemberListItem,
+  type ProjectListItem,
+} from '../../features/auth/auth-api';
+import { humanizeAuthError } from '../../features/auth/auth-errors';
+import { buildOrganizationPath, slugifyProjectName } from '../../features/auth/auth-routing';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleDateString(undefined, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function canCreateProjects(role: string | null): boolean {
+  return role === 'owner' || role === 'admin';
+}
+
+export function ProjectsPage() {
+  const { organizationSlug } = useParams();
+  const navigate = useNavigate();
+  const [projects, setProjects] = useState<ProjectListItem[]>([]);
+  const [members, setMembers] = useState<OrganizationMemberListItem[]>([]);
+  const [currentRole, setCurrentRole] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [slug, setSlug] = useState('');
+  const [projectOwnerMemberId, setProjectOwnerMemberId] = useState('');
+
+  useEffect(() => {
+    const refresh = async () => {
+      if (!organizationSlug) return;
+
+      setIsLoading(true);
+      setError(null);
+      try {
+        const [projectResponse, memberResponse, resolution] = await Promise.all([
+          listProjects(organizationSlug),
+          listOrganizationMembers(organizationSlug),
+          getMembershipResolution(),
+        ]);
+        const organization = resolution.organizations.find((org) => org.slug === organizationSlug);
+
+        setProjects(projectResponse.projects);
+        setMembers(memberResponse.members);
+        setCurrentRole(organization?.role ?? null);
+      } catch (caughtError) {
+        const rawMessage =
+          caughtError instanceof Error ? caughtError.message : 'Unable to load Projects.';
+        setError(humanizeAuthError(null, rawMessage, 'Unable to load Projects.'));
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void refresh();
+  }, [organizationSlug]);
+
+  const resetForm = () => {
+    setName('');
+    setDescription('');
+    setSlug('');
+    setProjectOwnerMemberId('');
+  };
+
+  const handleCreateProject = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!organizationSlug) return;
+
+    setIsCreating(true);
+    setError(null);
+    setStatus(null);
+    try {
+      const response = await createProject(organizationSlug, {
+        description,
+        name,
+        projectOwnerMemberId: projectOwnerMemberId || null,
+        slug,
+      });
+      resetForm();
+      setIsModalOpen(false);
+      setStatus('Project created.');
+      navigate(buildOrganizationPath(organizationSlug, `/p/${response.project.slug}`));
+    } catch (caughtError) {
+      const rawMessage =
+        caughtError instanceof Error ? caughtError.message : 'Unable to create Project.';
+      setError(humanizeAuthError(null, rawMessage, 'Unable to create Project.'));
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const canCreate = canCreateProjects(currentRole);
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-6">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight">Projects</h1>
+          <p className="text-sm text-muted-foreground">
+            Track active governance work for this Organization.
+          </p>
+        </div>
+        {canCreate ? (
+          <Button type="button" onClick={() => setIsModalOpen(true)}>
+            <Plus />
+            Create Project
+          </Button>
+        ) : null}
+      </header>
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertCircle />
+          <AlertTitle>Something went wrong</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+      {status ? (
+        <Alert>
+          <CheckCircle2 />
+          <AlertTitle>Done</AlertTitle>
+          <AlertDescription>{status}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading Projects...</p>
+      ) : projects.length === 0 ? (
+        <section className="rounded-xl border border-dashed p-8 text-center">
+          <h2 className="text-lg font-medium">No active Projects yet</h2>
+          <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
+            Create the first Project to start organizing governance work for this Organization.
+          </p>
+          {canCreate ? (
+            <Button className="mt-4" type="button" onClick={() => setIsModalOpen(true)}>
+              Create Project
+            </Button>
+          ) : null}
+        </section>
+      ) : (
+        <section className="grid gap-3">
+          {projects.map((project) => (
+            <Link
+              key={project.id}
+              to={
+                organizationSlug
+                  ? buildOrganizationPath(organizationSlug, `/p/${project.slug}`)
+                  : '#'
+              }
+              className="rounded-xl border bg-card p-5 transition-colors hover:bg-muted/40"
+            >
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-1">
+                  <h2 className="text-base font-semibold">{project.name}</h2>
+                  <p className="text-sm text-muted-foreground">{project.description}</p>
+                </div>
+                <p className="shrink-0 text-xs text-muted-foreground">
+                  Created {formatDate(project.createdAt)}
+                </p>
+              </div>
+              <p className="mt-3 text-xs text-muted-foreground">
+                Project Owner:{' '}
+                {project.projectOwner
+                  ? `${project.projectOwner.name} (${project.projectOwner.email})`
+                  : 'Not assigned'}
+              </p>
+            </Link>
+          ))}
+        </section>
+      )}
+
+      {isModalOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 p-4 backdrop-blur-sm">
+          <div className="w-full max-w-lg rounded-xl border bg-card p-6 shadow-lg">
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold">Create Project</h2>
+              <p className="text-sm text-muted-foreground">
+                Add a Project for this Organization. The slug can be edited before creation.
+              </p>
+            </div>
+            <form className="mt-6 space-y-4" onSubmit={handleCreateProject}>
+              <div className="space-y-2">
+                <Label htmlFor="project-name">Name</Label>
+                <Input
+                  id="project-name"
+                  value={name}
+                  onChange={(event) => {
+                    setName(event.target.value);
+                    setSlug(slugifyProjectName(event.target.value));
+                  }}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="project-slug">Slug</Label>
+                <Input
+                  id="project-slug"
+                  value={slug}
+                  onChange={(event) => setSlug(slugifyProjectName(event.target.value))}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="project-description">Description</Label>
+                <Input
+                  id="project-description"
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="project-owner">Project Owner</Label>
+                <select
+                  id="project-owner"
+                  value={projectOwnerMemberId}
+                  onChange={(event) => setProjectOwnerMemberId(event.target.value)}
+                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                >
+                  <option value="">No Project Owner</option>
+                  {members.map((member) => (
+                    <option key={member.id} value={member.id}>
+                      {member.name} ({member.email})
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setIsModalOpen(false);
+                    resetForm();
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={isCreating}>
+                  {isCreating ? 'Creating...' : 'Create Project'}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/auth/auth-api.ts
+++ b/apps/web/src/features/auth/auth-api.ts
@@ -44,6 +44,26 @@ export type InvitationEntryResponse = {
   };
 };
 
+export type ProjectListItem = {
+  createdAt: string;
+  description: string;
+  id: string;
+  name: string;
+  projectOwner: {
+    email: string;
+    id: string;
+    name: string;
+  } | null;
+  slug: string;
+};
+
+export type OrganizationMemberListItem = {
+  email: string;
+  id: string;
+  name: string;
+  role: string;
+};
+
 type ApiErrorBody = {
   error?:
     | {
@@ -147,5 +167,38 @@ export function acceptOrganizationInvitation(invitationId: string) {
   return request(`/api/auth/organization/accept-invitation`, {
     method: 'POST',
     body: JSON.stringify({ invitationId }),
+  });
+}
+
+export function listOrganizationMembers(organizationSlug: string) {
+  return request<{ members: OrganizationMemberListItem[] }>(
+    `/api/organizations/${organizationSlug}/members`,
+    {
+      method: 'GET',
+    },
+  );
+}
+
+export function listProjects(organizationSlug: string) {
+  return request<{ projects: ProjectListItem[] }>(
+    `/api/organizations/${organizationSlug}/projects`,
+    {
+      method: 'GET',
+    },
+  );
+}
+
+export function createProject(
+  organizationSlug: string,
+  input: {
+    description: string;
+    name: string;
+    projectOwnerMemberId?: string | null;
+    slug: string;
+  },
+) {
+  return request<{ project: ProjectListItem }>(`/api/organizations/${organizationSlug}/projects`, {
+    method: 'POST',
+    body: JSON.stringify(input),
   });
 }

--- a/apps/web/src/features/auth/auth-routing.test.ts
+++ b/apps/web/src/features/auth/auth-routing.test.ts
@@ -6,6 +6,7 @@ import {
   getPostLoginView,
   getVerificationCallbackState,
   slugifyOrganizationName,
+  slugifyProjectName,
 } from './auth-routing';
 
 describe('auth routing helpers', () => {
@@ -51,6 +52,12 @@ describe('auth routing helpers', () => {
     expect(slugifyOrganizationName('My Workspace')).toBe('my-workspace');
     expect(slugifyOrganizationName('Zolc Team ++')).toBe('zolc-team');
     expect(slugifyOrganizationName('')).toBe('');
+  });
+
+  it('slugifies Project names for editable Project creation slugs', () => {
+    expect(slugifyProjectName('SOC 2 Readiness')).toBe('soc-2-readiness');
+    expect(slugifyProjectName('Controls & Evidence')).toBe('controls-evidence');
+    expect(slugifyProjectName('')).toBe('');
   });
 
   it('builds organization-scoped app paths', () => {

--- a/apps/web/src/features/auth/auth-routing.ts
+++ b/apps/web/src/features/auth/auth-routing.ts
@@ -39,6 +39,18 @@ export function slugifyOrganizationName(value: string): string {
     .slice(0, 48);
 }
 
+export function slugifyProjectName(value: string): string {
+  const normalizedValue = Array.from(value.normalize('NFKD'))
+    .filter((character) => character.charCodeAt(0) <= 0x7f)
+    .join('');
+
+  return normalizedValue
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+}
+
 export function buildOrganizationPath(organizationSlug: string, path = '/'): string {
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
 

--- a/apps/web/src/providers/router.tsx
+++ b/apps/web/src/providers/router.tsx
@@ -105,7 +105,22 @@ const router = createBrowserRouter([
                       return { Component: SettingsPage };
                     },
                   },
-                  ...['projects', 'checklists', 'controls', 'exceptions', 'audit'].map((path) => ({
+                  {
+                    path: 'projects',
+                    lazy: async () => {
+                      const { ProjectsPage } = await import('../components/pages/projects');
+                      return { Component: ProjectsPage };
+                    },
+                  },
+                  {
+                    path: 'p/:projectSlug',
+                    lazy: async () => {
+                      const { ProjectDetailPage } =
+                        await import('../components/pages/project-detail');
+                      return { Component: ProjectDetailPage };
+                    },
+                  },
+                  ...['checklists', 'controls', 'exceptions', 'audit'].map((path) => ({
                     path,
                     lazy: async () => {
                       const { StaticAppPage } = await import('../components/pages/static-app-page');


### PR DESCRIPTION
## Summary
- Add persisted Projects with Organization-scoped slugs, optional Project Owner, active-list filtering, and owner/admin create authorization.
- Add Projects UI at `/:organizationSlug/projects` with a create modal, editable slug, Project Owner selection, active list, and redirect to the Project detail route.
- Cover Project API validation, authorization, member visibility, slug uniqueness including archived rows, and frontend slug routing helper behavior.

## Checks
- `pnpm lint`
- `pnpm format:check`
- `pnpm check-types`
- `pnpm test`
- `pnpm --filter backend-hono cf-typegen`
- `pnpm --filter web build`
- `pnpm --filter backend-hono build`

Closes #10