### PR TITLE
Add Project settings editing

### DIFF
--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -11,7 +11,9 @@ import {
   listActiveProjects,
   listOrganizationMembers,
   normalizeProjectCreateBody,
+  normalizeProjectUpdateBody,
   ProjectInputError,
+  updateProjectForMembership,
 } from './lib/projects';
 
 const app = new Hono();
@@ -165,6 +167,49 @@ app.get('/api/organizations/:organizationSlug/projects/:projectSlug', async (c) 
   }
 
   return c.json({ project });
+});
+
+app.patch('/api/organizations/:organizationSlug/projects/:projectSlug', async (c) => {
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(
+    c.req.param('organizationSlug'),
+    session.user.id,
+  );
+
+  if (!membership) {
+    return c.json({ error: 'Project unavailable' }, 404);
+  }
+
+  if (!canManageProjects(membership.role)) {
+    return c.json({ error: 'Only Organization owners and admins can edit Projects.' }, 403);
+  }
+
+  try {
+    const project = await updateProjectForMembership({
+      membership,
+      projectSlug: c.req.param('projectSlug'),
+      updates: normalizeProjectUpdateBody(await c.req.json().catch(() => null)),
+    });
+
+    if (!project) {
+      return c.json({ error: 'Project unavailable' }, 404);
+    }
+
+    return c.json({ project });
+  } catch (caughtError) {
+    if (caughtError instanceof ProjectInputError) {
+      return c.json({ error: caughtError.message }, 400);
+    }
+
+    throw caughtError;
+  }
 });
 
 app.on(['POST', 'GET'], '/api/auth/*', (c) => auth.handler(c.req.raw));

--- a/apps/backend-hono/src/lib/projects.ts
+++ b/apps/backend-hono/src/lib/projects.ts
@@ -52,6 +52,12 @@ type CreateProjectInput = {
   slug: string;
 };
 
+type UpdateProjectInput = {
+  description: string;
+  name: string;
+  projectOwnerMemberId: string | null;
+};
+
 const editableOrganizationRoles = new Set(['owner', 'admin']);
 const projectSlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
@@ -137,14 +143,18 @@ export async function getProjectDetailForMember(input: {
     return null;
   }
 
+  return getProjectDetailForMembership(membership, input.projectSlug);
+}
+
+export async function getProjectDetailForMembership(
+  membership: OrganizationMembership,
+  projectSlug: string,
+): Promise<ProjectDetailResponse | null> {
   const project = await db
     .select()
     .from(projects)
     .where(
-      and(
-        eq(projects.organizationId, membership.organizationId),
-        eq(projects.slug, input.projectSlug),
-      ),
+      and(eq(projects.organizationId, membership.organizationId), eq(projects.slug, projectSlug)),
     )
     .limit(1)
     .then((rows) => rows[0] ?? null);
@@ -233,6 +243,60 @@ export async function createProject(
   return (await listActiveProjects(organizationId)).find(({ id }) => id === project.id)!;
 }
 
+export async function updateProjectForMembership(input: {
+  membership: OrganizationMembership;
+  projectSlug: string;
+  updates: UpdateProjectInput;
+}): Promise<ProjectDetailResponse | null> {
+  validateProjectUpdateInput(input.updates);
+
+  const existingProject = await db
+    .select({ id: projects.id })
+    .from(projects)
+    .where(
+      and(
+        eq(projects.organizationId, input.membership.organizationId),
+        eq(projects.slug, input.projectSlug),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!existingProject) {
+    return null;
+  }
+
+  if (input.updates.projectOwnerMemberId) {
+    const ownerMembership = await db
+      .select({ id: members.id })
+      .from(members)
+      .where(
+        and(
+          eq(members.id, input.updates.projectOwnerMemberId),
+          eq(members.organizationId, input.membership.organizationId),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+
+    if (!ownerMembership) {
+      throw new ProjectInputError('Project Owner must be a member of this Organization.');
+    }
+  }
+
+  await db
+    .update(projects)
+    .set({
+      description: input.updates.description.trim(),
+      name: input.updates.name.trim(),
+      projectOwnerMemberId: input.updates.projectOwnerMemberId,
+      updatedAt: new Date(),
+    })
+    .where(eq(projects.id, existingProject.id));
+
+  return getProjectDetailForMembership(input.membership, input.projectSlug);
+}
+
 export function slugifyProjectName(value: string): string {
   const normalizedValue = Array.from(value.normalize('NFKD'))
     .filter((character) => character.charCodeAt(0) <= 0x7f)
@@ -251,13 +315,7 @@ function validateProjectInput(input: CreateProjectInput) {
   const name = input.name.trim();
   const description = input.description.trim();
 
-  if (!name) {
-    throw new ProjectInputError('Project name is required.');
-  }
-
-  if (!description) {
-    throw new ProjectInputError('Project description is required.');
-  }
+  validateProjectNameAndDescription(name, description);
 
   if (!input.slug || !projectSlugPattern.test(input.slug)) {
     throw new ProjectInputError(
@@ -267,6 +325,20 @@ function validateProjectInput(input: CreateProjectInput) {
 
   if (input.slug !== slugifyProjectName(input.slug)) {
     throw new ProjectInputError('Project slug must be normalized.');
+  }
+}
+
+function validateProjectUpdateInput(input: UpdateProjectInput) {
+  validateProjectNameAndDescription(input.name.trim(), input.description.trim());
+}
+
+function validateProjectNameAndDescription(name: string, description: string) {
+  if (!name) {
+    throw new ProjectInputError('Project name is required.');
+  }
+
+  if (!description) {
+    throw new ProjectInputError('Project description is required.');
   }
 }
 
@@ -282,5 +354,19 @@ export function normalizeProjectCreateBody(body: unknown): CreateProjectInput {
         ? record.projectOwnerMemberId
         : null,
     slug: typeof record.slug === 'string' ? slugifyProjectName(record.slug) : '',
+  };
+}
+
+export function normalizeProjectUpdateBody(body: unknown): UpdateProjectInput {
+  const value = typeof body === 'object' && body !== null ? body : {};
+  const record = value as Record<string, unknown>;
+
+  return {
+    description: typeof record.description === 'string' ? record.description : '',
+    name: typeof record.name === 'string' ? record.name : '',
+    projectOwnerMemberId:
+      typeof record.projectOwnerMemberId === 'string' && record.projectOwnerMemberId
+        ? record.projectOwnerMemberId
+        : null,
   };
 }

--- a/apps/backend-hono/test/project-detail.spec.ts
+++ b/apps/backend-hono/test/project-detail.spec.ts
@@ -142,9 +142,10 @@ async function createProject(input: {
   slug: string;
 }) {
   const now = new Date();
+  const id = crypto.randomUUID();
 
   await db.insert(projects).values({
-    id: crypto.randomUUID(),
+    id,
     organizationId: input.organizationId,
     name: 'Vendor Risk Review',
     description: 'Governance work for reviewing critical vendor risk.',
@@ -153,12 +154,35 @@ async function createProject(input: {
     createdAt: now,
     updatedAt: now,
   });
+
+  return id;
 }
 
 async function getProjectDetail(headers: Headers, organizationSlug: string, projectSlug: string) {
   const response = await app.request(
     `http://example.com/api/organizations/${organizationSlug}/projects/${projectSlug}`,
     { headers },
+  );
+
+  return {
+    body: (await response.json()) as { project?: ProjectDetailResponse; error?: string },
+    status: response.status,
+  };
+}
+
+async function updateProject(
+  headers: Headers,
+  organizationSlug: string,
+  projectSlug: string,
+  body: Record<string, unknown>,
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/projects/${projectSlug}`,
+    {
+      body: JSON.stringify(body),
+      headers,
+      method: 'PATCH',
+    },
   );
 
   return {
@@ -222,5 +246,121 @@ describe('Project detail API', () => {
     await expect(
       getProjectDetail(outsider.headers, outsider.organization.slug, 'internal-controls'),
     ).resolves.toMatchObject({ status: 404 });
+  });
+
+  it('lets Organization owners edit Project settings without changing the slug', async () => {
+    const owner = await createSignedInOwner('project-settings-owner');
+    const projectOwner = await addMemberToOrganization(
+      owner.organization.id,
+      'project-settings-accountable',
+    );
+
+    await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'vendor-risk',
+    });
+
+    const response = await updateProject(owner.headers, owner.organization.slug, 'vendor-risk', {
+      description: 'Updated governance work for critical vendor risk.',
+      name: 'Critical Vendor Risk',
+      projectOwnerMemberId: projectOwner.memberId,
+      slug: 'ignored-new-slug',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.project).toMatchObject({
+      description: 'Updated governance work for critical vendor risk.',
+      name: 'Critical Vendor Risk',
+      projectOwner: {
+        email: projectOwner.credentials.email,
+        name: projectOwner.credentials.name,
+        role: 'member',
+      },
+      slug: 'vendor-risk',
+    });
+
+    const renamedProject = await getProjectDetail(
+      owner.headers,
+      owner.organization.slug,
+      'vendor-risk',
+    );
+
+    expect(renamedProject.status).toBe(200);
+    expect(renamedProject.body.project?.slug).toBe('vendor-risk');
+  });
+
+  it('prevents members from mutating Project settings', async () => {
+    const owner = await createSignedInOwner('project-settings-readonly-owner');
+    const member = await addMemberToOrganization(
+      owner.organization.id,
+      'project-settings-readonly',
+    );
+
+    await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: owner.member.id,
+      slug: 'vendor-risk',
+    });
+
+    const response = await updateProject(member.headers, owner.organization.slug, 'vendor-risk', {
+      description: 'Member mutation attempt.',
+      name: 'Member Mutation',
+      projectOwnerMemberId: null,
+    });
+
+    expect(response.status).toBe(403);
+
+    const project = await getProjectDetail(owner.headers, owner.organization.slug, 'vendor-risk');
+
+    expect(project.body.project).toMatchObject({
+      description: 'Governance work for reviewing critical vendor risk.',
+      name: 'Vendor Risk Review',
+    });
+  });
+
+  it('validates Project settings updates and Project Owner membership', async () => {
+    const owner = await createSignedInOwner('project-settings-validation-owner');
+    const outsider = await createSignedInOwner('project-settings-validation-outsider');
+
+    await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'vendor-risk',
+    });
+
+    const outsiderMembership = await db
+      .select({ id: members.id })
+      .from(members)
+      .where(eq(members.organizationId, outsider.organization.id))
+      .then((rows) => rows[0]);
+
+    expect(outsiderMembership?.id).toBeTruthy();
+
+    if (!outsiderMembership?.id) {
+      throw new Error('Expected outsider membership.');
+    }
+
+    await expect(
+      updateProject(owner.headers, owner.organization.slug, 'vendor-risk', {
+        description: '',
+        name: 'Missing Description',
+        projectOwnerMemberId: null,
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Project description is required.' },
+      status: 400,
+    });
+
+    await expect(
+      updateProject(owner.headers, owner.organization.slug, 'vendor-risk', {
+        description: 'Wrong owner membership.',
+        name: 'Wrong Owner',
+        projectOwnerMemberId: outsiderMembership.id,
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Project Owner must be a member of this Organization.' },
+      status: 400,
+    });
   });
 });

--- a/apps/web/src/components/pages/project-detail.tsx
+++ b/apps/web/src/components/pages/project-detail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router';
 import { AlertCircle, CalendarDays, FolderKanban, UserRound } from 'lucide-react';
 import { getProjectDetail, type ProjectDetail } from '@/features/projects/project-api';
-import { buildProjectsPath } from '@/features/projects/project-routing';
+import { buildProjectSettingsPath, buildProjectsPath } from '@/features/projects/project-routing';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -79,6 +79,9 @@ export function ProjectDetailPage() {
   }
 
   const { project } = state;
+  const settingsPath = organizationSlug
+    ? buildProjectSettingsPath(organizationSlug, project.slug)
+    : projectsPath;
 
   return (
     <div className="mx-auto w-full max-w-5xl space-y-6">
@@ -95,9 +98,14 @@ export function ProjectDetailPage() {
             </p>
           </div>
         </div>
-        <Button asChild variant="outline">
-          <Link to={projectsPath}>All Projects</Link>
-        </Button>
+        <div className="flex gap-2">
+          <Button asChild variant="outline">
+            <Link to={projectsPath}>All Projects</Link>
+          </Button>
+          <Button asChild>
+            <Link to={settingsPath}>Project settings</Link>
+          </Button>
+        </div>
       </header>
 
       <div className="grid gap-4 md:grid-cols-2">

--- a/apps/web/src/components/pages/project-settings.tsx
+++ b/apps/web/src/components/pages/project-settings.tsx
@@ -1,0 +1,270 @@
+import { useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+import { Link, useParams } from 'react-router';
+import { AlertCircle, CheckCircle2, LockKeyhole } from 'lucide-react';
+import {
+  getProjectDetail,
+  updateProjectSettings,
+  type ProjectDetail,
+} from '@/features/projects/project-api';
+import { buildProjectPath, buildProjectsPath } from '@/features/projects/project-routing';
+import {
+  getMembershipResolution,
+  listOrganizationMembers,
+  type OrganizationMemberListItem,
+} from '@/features/auth/auth-api';
+import { humanizeAuthError } from '@/features/auth/auth-errors';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Skeleton } from '@/components/ui/skeleton';
+
+type ProjectSettingsState =
+  | { status: 'loading' }
+  | { status: 'available'; project: ProjectDetail }
+  | { status: 'unavailable' }
+  | { status: 'error'; message: string };
+
+function canManageProjects(role: string | null): boolean {
+  return role === 'owner' || role === 'admin';
+}
+
+export function ProjectSettingsPage() {
+  const { organizationSlug = '', projectSlug = '' } = useParams();
+  const [state, setState] = useState<ProjectSettingsState>({ status: 'loading' });
+  const [members, setMembers] = useState<OrganizationMemberListItem[]>([]);
+  const [currentRole, setCurrentRole] = useState<string | null>(null);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [projectOwnerMemberId, setProjectOwnerMemberId] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const projectsPath = organizationSlug ? buildProjectsPath(organizationSlug) : '/';
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadSettings() {
+      if (!organizationSlug || !projectSlug) {
+        setState({ status: 'unavailable' });
+        return;
+      }
+
+      setState({ status: 'loading' });
+      setSaveError(null);
+      setStatus(null);
+
+      try {
+        const [projectResult, memberResponse, resolution] = await Promise.all([
+          getProjectDetail({ organizationSlug, projectSlug }),
+          listOrganizationMembers(organizationSlug),
+          getMembershipResolution(),
+        ]);
+
+        if (cancelled) return;
+
+        if (projectResult.status === 'unavailable') {
+          setState({ status: 'unavailable' });
+          return;
+        }
+
+        const organization = resolution.organizations.find((org) => org.slug === organizationSlug);
+
+        setMembers(memberResponse.members);
+        setCurrentRole(organization?.role ?? null);
+        setName(projectResult.project.name);
+        setDescription(projectResult.project.description);
+        setProjectOwnerMemberId(projectResult.project.projectOwner?.id ?? '');
+        setState({ status: 'available', project: projectResult.project });
+      } catch (caughtError) {
+        if (cancelled) return;
+        const rawMessage =
+          caughtError instanceof Error ? caughtError.message : 'Unable to load Project settings.';
+        setState({
+          status: 'error',
+          message: humanizeAuthError(null, rawMessage, 'Unable to load Project settings.'),
+        });
+      }
+    }
+
+    void loadSettings();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [organizationSlug, projectSlug]);
+
+  const handleSave = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!organizationSlug || !projectSlug || !canManageProjects(currentRole)) return;
+
+    setIsSaving(true);
+    setSaveError(null);
+    setStatus(null);
+
+    try {
+      const project = await updateProjectSettings({
+        description,
+        name,
+        organizationSlug,
+        projectOwnerMemberId: projectOwnerMemberId || null,
+        projectSlug,
+      });
+
+      setState({ status: 'available', project });
+      setName(project.name);
+      setDescription(project.description);
+      setProjectOwnerMemberId(project.projectOwner?.id ?? '');
+      setStatus('Project settings saved.');
+    } catch (caughtError) {
+      const rawMessage =
+        caughtError instanceof Error ? caughtError.message : 'Unable to save Project settings.';
+      setSaveError(humanizeAuthError(null, rawMessage, 'Unable to save Project settings.'));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (state.status === 'loading') {
+    return (
+      <div className="mx-auto w-full max-w-3xl space-y-6">
+        <Skeleton className="h-8 w-56" />
+        <Skeleton className="h-96 w-full" />
+      </div>
+    );
+  }
+
+  if (state.status === 'unavailable' || state.status === 'error') {
+    return (
+      <div className="mx-auto w-full max-w-3xl space-y-4">
+        <Alert variant={state.status === 'error' ? 'destructive' : 'default'}>
+          <AlertCircle className="size-4" />
+          <AlertTitle>Project settings unavailable</AlertTitle>
+          <AlertDescription>
+            {state.status === 'error'
+              ? state.message
+              : 'This Project could not be found, or you do not have access to it.'}
+          </AlertDescription>
+        </Alert>
+        <Button asChild variant="outline">
+          <Link to={projectsPath}>Back to Projects</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  const { project } = state;
+  const projectPath = organizationSlug
+    ? buildProjectPath(organizationSlug, project.slug)
+    : projectsPath;
+  const canEdit = canManageProjects(currentRole);
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-6">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight">Project settings</h1>
+          <p className="text-sm text-muted-foreground">
+            Edit Project details without changing its Organization-local slug.
+          </p>
+        </div>
+        <Button asChild variant="outline">
+          <Link to={projectPath}>Back to Project</Link>
+        </Button>
+      </header>
+
+      {!canEdit ? (
+        <Alert>
+          <LockKeyhole className="size-4" />
+          <AlertTitle>Read-only settings</AlertTitle>
+          <AlertDescription>
+            Members can view Project information, but only Organization owners and admins can edit
+            Project settings.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+      {saveError ? (
+        <Alert variant="destructive">
+          <AlertCircle className="size-4" />
+          <AlertTitle>Unable to save</AlertTitle>
+          <AlertDescription>{saveError}</AlertDescription>
+        </Alert>
+      ) : null}
+      {status ? (
+        <Alert>
+          <CheckCircle2 className="size-4" />
+          <AlertTitle>Done</AlertTitle>
+          <AlertDescription>{status}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Details</CardTitle>
+          <CardDescription>
+            Name, description, and Project Owner can change. The slug remains immutable.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleSave}>
+            <div className="space-y-2">
+              <Label htmlFor="project-name">Name</Label>
+              <Input
+                id="project-name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                disabled={!canEdit || isSaving}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="project-description">Description</Label>
+              <Input
+                id="project-description"
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                disabled={!canEdit || isSaving}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="project-owner">Project Owner</Label>
+              <select
+                id="project-owner"
+                value={projectOwnerMemberId}
+                onChange={(event) => setProjectOwnerMemberId(event.target.value)}
+                disabled={!canEdit || isSaving}
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+              >
+                <option value="">No Project Owner</option>
+                {members.map((member) => (
+                  <option key={member.id} value={member.id}>
+                    {member.name} ({member.email})
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="project-slug">Slug</Label>
+              <Input id="project-slug" value={project.slug} disabled />
+              <p className="text-xs text-muted-foreground">
+                Project URLs keep using this slug even if the name changes.
+              </p>
+            </div>
+            {canEdit ? (
+              <div className="flex justify-end">
+                <Button type="submit" disabled={isSaving}>
+                  {isSaving ? 'Saving...' : 'Save Project'}
+                </Button>
+              </div>
+            ) : null}
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/features/projects/project-api.ts
+++ b/apps/web/src/features/projects/project-api.ts
@@ -43,3 +43,39 @@ export async function getProjectDetail(input: {
   const body = (await response.json()) as { project: ProjectDetail };
   return { status: 'available', project: body.project };
 }
+
+export async function updateProjectSettings(input: {
+  description: string;
+  name: string;
+  organizationSlug: string;
+  projectOwnerMemberId: string | null;
+  projectSlug: string;
+}): Promise<ProjectDetail> {
+  const response = await fetch(
+    `${AUTH_BASE_URL}/api/organizations/${input.organizationSlug}/projects/${input.projectSlug}`,
+    {
+      body: JSON.stringify({
+        description: input.description,
+        name: input.name,
+        projectOwnerMemberId: input.projectOwnerMemberId,
+      }),
+      credentials: 'include',
+      headers: { 'content-type': 'application/json' },
+      method: 'PATCH',
+    },
+  );
+  const body = (await response.json().catch(() => null)) as {
+    error?: string;
+    project?: ProjectDetail;
+  } | null;
+
+  if (!response.ok) {
+    throw new Error(body?.error ?? 'Unable to update Project.');
+  }
+
+  if (!body?.project) {
+    throw new Error('Unable to update Project.');
+  }
+
+  return body.project;
+}

--- a/apps/web/src/features/projects/project-routing.test.ts
+++ b/apps/web/src/features/projects/project-routing.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { buildProjectPath, buildProjectsPath } from './project-routing';
+import { buildProjectPath, buildProjectSettingsPath, buildProjectsPath } from './project-routing';
 
 describe('project routing helpers', () => {
   it('builds organization-local Project routes', () => {
     expect(buildProjectPath('acme', 'risk-register')).toBe('/acme/p/risk-register');
+    expect(buildProjectSettingsPath('acme', 'risk-register')).toBe(
+      '/acme/p/risk-register/settings',
+    );
     expect(buildProjectsPath('acme')).toBe('/acme/projects');
   });
 });

--- a/apps/web/src/features/projects/project-routing.ts
+++ b/apps/web/src/features/projects/project-routing.ts
@@ -4,6 +4,10 @@ export function buildProjectPath(organizationSlug: string, projectSlug: string):
   return buildOrganizationPath(organizationSlug, `/p/${projectSlug}`);
 }
 
+export function buildProjectSettingsPath(organizationSlug: string, projectSlug: string): string {
+  return buildOrganizationPath(organizationSlug, `/p/${projectSlug}/settings`);
+}
+
 export function buildProjectsPath(organizationSlug: string): string {
   return buildOrganizationPath(organizationSlug, '/projects');
 }

--- a/apps/web/src/providers/router.tsx
+++ b/apps/web/src/providers/router.tsx
@@ -120,6 +120,14 @@ const router = createBrowserRouter([
                       return { Component: ProjectDetailPage };
                     },
                   },
+                  {
+                    path: 'p/:projectSlug/settings',
+                    lazy: async () => {
+                      const { ProjectSettingsPage } =
+                        await import('../components/pages/project-settings');
+                      return { Component: ProjectSettingsPage };
+                    },
+                  },
                   ...['checklists', 'controls', 'exceptions', 'audit'].map((path) => ({
                     path,
                     lazy: async () => {


### PR DESCRIPTION
## Summary
- Add Project settings at `/:organizationSlug/p/:projectSlug/settings` with owner/admin editing and member read-only access.
- Add `PATCH /api/organizations/:organizationSlug/projects/:projectSlug` for name, description, and Project Owner updates while keeping slugs immutable.
- Cover update authorization, validation, Project Owner membership, slug immutability, and route helpers with tests.

## Checks
- `pnpm test`
- `pnpm check-types`
- `pnpm lint`
- `pnpm format:check`
- `pnpm --filter backend-hono cf-typegen`
- `pnpm --filter web build`
- `pnpm --filter backend-hono build`

Closes #12