### PR TITLE
Add Project archive and restore flows

### DIFF
--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { cors } from 'hono/cors';
 import { auth } from './lib/auth';
 import { env } from 'cloudflare:workers';
@@ -8,11 +8,12 @@ import {
   createProject,
   getProjectDetailForMember,
   getOrganizationMembership,
-  listActiveProjects,
+  listProjects,
   listOrganizationMembers,
   normalizeProjectCreateBody,
   normalizeProjectUpdateBody,
   ProjectInputError,
+  setProjectArchivedForMembership,
   updateProjectForMembership,
 } from './lib/projects';
 
@@ -106,7 +107,9 @@ app.get('/api/organizations/:organizationSlug/projects', async (c) => {
     return c.json({ error: 'Organization not found' }, 404);
   }
 
-  return c.json({ projects: await listActiveProjects(membership.organizationId) });
+  const status = c.req.query('status') === 'archived' ? 'archived' : 'active';
+
+  return c.json({ projects: await listProjects(membership.organizationId, status) });
 });
 
 app.post('/api/organizations/:organizationSlug/projects', async (c) => {
@@ -211,6 +214,58 @@ app.patch('/api/organizations/:organizationSlug/projects/:projectSlug', async (c
     throw caughtError;
   }
 });
+
+app.patch('/api/organizations/:organizationSlug/projects/:projectSlug/archive', async (c) => {
+  return setProjectArchived(c, true);
+});
+
+app.patch('/api/organizations/:organizationSlug/projects/:projectSlug/restore', async (c) => {
+  return setProjectArchived(c, false);
+});
+
+async function setProjectArchived(c: Context, archived: boolean) {
+  const organizationSlug = c.req.param('organizationSlug');
+  const projectSlug = c.req.param('projectSlug');
+
+  if (!organizationSlug || !projectSlug) {
+    return c.json({ error: 'Project unavailable' }, 404);
+  }
+
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(organizationSlug, session.user.id);
+
+  if (!membership) {
+    return c.json({ error: 'Project unavailable' }, 404);
+  }
+
+  if (!canManageProjects(membership.role)) {
+    return c.json(
+      {
+        error: `Only Organization owners and admins can ${archived ? 'archive' : 'restore'} Projects.`,
+      },
+      403,
+    );
+  }
+
+  const project = await setProjectArchivedForMembership({
+    archived,
+    membership,
+    projectSlug,
+  });
+
+  if (!project) {
+    return c.json({ error: 'Project unavailable' }, 404);
+  }
+
+  return c.json({ project });
+}
 
 app.on(['POST', 'GET'], '/api/auth/*', (c) => auth.handler(c.req.raw));
 

--- a/apps/backend-hono/src/lib/projects.ts
+++ b/apps/backend-hono/src/lib/projects.ts
@@ -1,8 +1,9 @@
-import { and, asc, eq, isNull } from 'drizzle-orm';
+import { and, asc, eq, isNotNull, isNull } from 'drizzle-orm';
 import { db } from '../db/client';
 import { members, organizations, projects, users } from '../db/schema';
 
 export type ProjectListItem = {
+  archivedAt: string | null;
   createdAt: string;
   description: string;
   id: string;
@@ -14,6 +15,8 @@ export type ProjectListItem = {
   } | null;
   slug: string;
 };
+
+export type ProjectListStatus = 'active' | 'archived';
 
 export type ProjectDetailResponse = {
   id: string;
@@ -100,9 +103,13 @@ export async function listOrganizationMembers(
     .orderBy(asc(users.name), asc(users.email));
 }
 
-export async function listActiveProjects(organizationId: string): Promise<ProjectListItem[]> {
+export async function listProjects(
+  organizationId: string,
+  status: ProjectListStatus,
+): Promise<ProjectListItem[]> {
   const rows = await db
     .select({
+      archivedAt: projects.archivedAt,
       createdAt: projects.createdAt,
       description: projects.description,
       id: projects.id,
@@ -115,11 +122,17 @@ export async function listActiveProjects(organizationId: string): Promise<Projec
     .from(projects)
     .leftJoin(members, eq(projects.projectOwnerMemberId, members.id))
     .leftJoin(users, eq(members.userId, users.id))
-    .where(and(eq(projects.organizationId, organizationId), isNull(projects.archivedAt)))
+    .where(
+      and(
+        eq(projects.organizationId, organizationId),
+        status === 'archived' ? isNotNull(projects.archivedAt) : isNull(projects.archivedAt),
+      ),
+    )
     .orderBy(asc(projects.createdAt), asc(projects.name));
 
-  return rows.map(({ createdAt, ownerEmail, ownerId, ownerName, ...project }) => ({
+  return rows.map(({ archivedAt, createdAt, ownerEmail, ownerId, ownerName, ...project }) => ({
     ...project,
+    archivedAt: archivedAt?.toISOString() ?? null,
     createdAt: createdAt.toISOString(),
     projectOwner:
       ownerId && ownerEmail && ownerName
@@ -240,7 +253,39 @@ export async function createProject(
 
   await db.insert(projects).values(project);
 
-  return (await listActiveProjects(organizationId)).find(({ id }) => id === project.id)!;
+  return (await listProjects(organizationId, 'active')).find(({ id }) => id === project.id)!;
+}
+
+export async function setProjectArchivedForMembership(input: {
+  archived: boolean;
+  membership: OrganizationMembership;
+  projectSlug: string;
+}): Promise<ProjectDetailResponse | null> {
+  const existingProject = await db
+    .select({ id: projects.id })
+    .from(projects)
+    .where(
+      and(
+        eq(projects.organizationId, input.membership.organizationId),
+        eq(projects.slug, input.projectSlug),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!existingProject) {
+    return null;
+  }
+
+  await db
+    .update(projects)
+    .set({
+      archivedAt: input.archived ? new Date() : null,
+      updatedAt: new Date(),
+    })
+    .where(eq(projects.id, existingProject.id));
+
+  return getProjectDetailForMembership(input.membership, input.projectSlug);
 }
 
 export async function updateProjectForMembership(input: {

--- a/apps/backend-hono/test/project-detail.spec.ts
+++ b/apps/backend-hono/test/project-detail.spec.ts
@@ -227,6 +227,34 @@ describe('Project detail API', () => {
     expect(response.body.project?.archivedAt).toBeNull();
   });
 
+  it('keeps archived Project detail URLs reachable for Organization members', async () => {
+    const owner = await createSignedInOwner('project-detail-archived-owner');
+    const member = await addMemberToOrganization(
+      owner.organization.id,
+      'project-detail-archived-member',
+    );
+    const projectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'archived-project',
+    });
+    const archivedAt = new Date();
+
+    await db.update(projects).set({ archivedAt }).where(eq(projects.id, projectId));
+
+    const response = await getProjectDetail(
+      member.headers,
+      owner.organization.slug,
+      'archived-project',
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.project).toMatchObject({
+      archivedAt: archivedAt.toISOString(),
+      slug: 'archived-project',
+    });
+  });
+
   it('hides missing, inaccessible, and wrong-Organization Projects behind not found', async () => {
     const owner = await createSignedInOwner('project-detail-hidden-owner');
     const outsider = await createSignedInOwner('project-detail-outsider');

--- a/apps/backend-hono/test/projects.spec.ts
+++ b/apps/backend-hono/test/projects.spec.ts
@@ -98,6 +98,55 @@ async function createProjectRequest(
   };
 }
 
+async function archiveProjectRequest(
+  organizationSlug: string,
+  projectSlug: string,
+  headers: Headers,
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/projects/${projectSlug}/archive`,
+    { headers, method: 'PATCH' },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function restoreProjectRequest(
+  organizationSlug: string,
+  projectSlug: string,
+  headers: Headers,
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/projects/${projectSlug}/restore`,
+    { headers, method: 'PATCH' },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function listProjectsRequest(
+  organizationSlug: string,
+  headers: Headers,
+  status: 'active' | 'archived' = 'active',
+) {
+  const query = status === 'archived' ? '?status=archived' : '';
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/projects${query}`,
+    { headers },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
 beforeEach(() => {
   const originalFetch = globalThis.fetch;
 
@@ -310,5 +359,98 @@ describe('organization projects', () => {
     );
 
     expect(archivedSlugResponse.status).toBe(400);
+  });
+
+  it('lets Organization owners archive and restore Projects from active and archived lists', async () => {
+    const { headers, organization } = await createSignedInOwner('project-archive-owner');
+
+    await createProjectRequest(organization.slug, headers, {
+      description: 'Archive-ready governance work.',
+      name: 'Archive Ready',
+      slug: 'archive-ready',
+    });
+
+    const archiveResponse = await archiveProjectRequest(
+      organization.slug,
+      'archive-ready',
+      headers,
+    );
+
+    expect(archiveResponse.status).toBe(200);
+    expect(archiveResponse.body.project).toMatchObject({ slug: 'archive-ready' });
+    expect((archiveResponse.body.project as { archivedAt?: string }).archivedAt).toBeTruthy();
+
+    await expect(listProjectsRequest(organization.slug, headers)).resolves.toMatchObject({
+      body: { projects: [] },
+      status: 200,
+    });
+    await expect(
+      listProjectsRequest(organization.slug, headers, 'archived'),
+    ).resolves.toMatchObject({
+      body: { projects: [{ slug: 'archive-ready' }] },
+      status: 200,
+    });
+
+    const restoreResponse = await restoreProjectRequest(
+      organization.slug,
+      'archive-ready',
+      headers,
+    );
+
+    expect(restoreResponse.status).toBe(200);
+    expect(restoreResponse.body.project).toMatchObject({
+      archivedAt: null,
+      slug: 'archive-ready',
+    });
+    await expect(listProjectsRequest(organization.slug, headers)).resolves.toMatchObject({
+      body: { projects: [{ slug: 'archive-ready' }] },
+      status: 200,
+    });
+  });
+
+  it('prevents members from archiving and restoring Projects while allowing archived list access', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'project-archive-member-owner',
+    );
+    const member = createCredentials('project-archive-member');
+
+    await signUpUser(member);
+
+    const invitation = await auth.api.createInvitation({
+      body: {
+        email: member.email,
+        organizationId: organization.id,
+        role: 'member',
+      },
+      headers: ownerHeaders,
+    });
+    const memberHeaders = await signInUser(member);
+
+    await auth.api.acceptInvitation({
+      body: { invitationId: invitation.id },
+      headers: memberHeaders,
+    });
+
+    await createProjectRequest(organization.slug, ownerHeaders, {
+      description: 'Member-visible archived work.',
+      name: 'Member Visible',
+      slug: 'member-visible',
+    });
+
+    await expect(
+      archiveProjectRequest(organization.slug, 'member-visible', memberHeaders),
+    ).resolves.toMatchObject({ status: 403 });
+
+    await archiveProjectRequest(organization.slug, 'member-visible', ownerHeaders);
+
+    await expect(
+      listProjectsRequest(organization.slug, memberHeaders, 'archived'),
+    ).resolves.toMatchObject({
+      body: { projects: [{ slug: 'member-visible' }] },
+      status: 200,
+    });
+    await expect(
+      restoreProjectRequest(organization.slug, 'member-visible', memberHeaders),
+    ).resolves.toMatchObject({ status: 403 });
   });
 });

--- a/apps/web/src/components/pages/project-detail.tsx
+++ b/apps/web/src/components/pages/project-detail.tsx
@@ -1,7 +1,19 @@
 import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router';
-import { AlertCircle, CalendarDays, FolderKanban, UserRound } from 'lucide-react';
-import { getProjectDetail, type ProjectDetail } from '@/features/projects/project-api';
+import {
+  AlertCircle,
+  Archive,
+  CalendarDays,
+  FolderKanban,
+  RotateCcw,
+  UserRound,
+} from 'lucide-react';
+import { getMembershipResolution } from '@/features/auth/auth-api';
+import {
+  getProjectDetail,
+  restoreProject,
+  type ProjectDetail,
+} from '@/features/projects/project-api';
 import { buildProjectSettingsPath, buildProjectsPath } from '@/features/projects/project-routing';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -23,6 +35,8 @@ function formatDate(value: string): string {
 export function ProjectDetailPage() {
   const { organizationSlug = '', projectSlug = '' } = useParams();
   const [state, setState] = useState<ProjectDetailState>({ status: 'loading' });
+  const [currentRole, setCurrentRole] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
   const projectsPath = organizationSlug ? buildProjectsPath(organizationSlug) : '/';
 
   useEffect(() => {
@@ -35,10 +49,16 @@ export function ProjectDetailPage() {
       }
 
       setState({ status: 'loading' });
+      setActionError(null);
 
       try {
-        const result = await getProjectDetail({ organizationSlug, projectSlug });
+        const [result, resolution] = await Promise.all([
+          getProjectDetail({ organizationSlug, projectSlug }),
+          getMembershipResolution(),
+        ]);
+        const organization = resolution.organizations.find((org) => org.slug === organizationSlug);
         if (!cancelled) setState(result);
+        if (!cancelled) setCurrentRole(organization?.role ?? null);
       } catch {
         if (!cancelled) setState({ status: 'error' });
       }
@@ -82,9 +102,41 @@ export function ProjectDetailPage() {
   const settingsPath = organizationSlug
     ? buildProjectSettingsPath(organizationSlug, project.slug)
     : projectsPath;
+  const canManage = currentRole === 'owner' || currentRole === 'admin';
+
+  const handleRestore = async () => {
+    if (!organizationSlug || !projectSlug || !canManage) return;
+
+    setActionError(null);
+    try {
+      const restoredProject = await restoreProject({ organizationSlug, projectSlug });
+      setState({ status: 'available', project: restoredProject });
+    } catch (caughtError) {
+      setActionError(
+        caughtError instanceof Error ? caughtError.message : 'Unable to restore Project.',
+      );
+    }
+  };
 
   return (
     <div className="mx-auto w-full max-w-5xl space-y-6">
+      {project.archivedAt ? (
+        <Alert>
+          <Archive className="size-4" />
+          <AlertTitle>Archived Project</AlertTitle>
+          <AlertDescription>
+            This Project is hidden from active work. Its URL remains available for Organization
+            members.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+      {actionError ? (
+        <Alert variant="destructive">
+          <AlertCircle className="size-4" />
+          <AlertTitle>Unable to restore</AlertTitle>
+          <AlertDescription>{actionError}</AlertDescription>
+        </Alert>
+      ) : null}
       <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="space-y-2">
           <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
@@ -102,6 +154,12 @@ export function ProjectDetailPage() {
           <Button asChild variant="outline">
             <Link to={projectsPath}>All Projects</Link>
           </Button>
+          {project.archivedAt && canManage ? (
+            <Button type="button" variant="outline" onClick={() => void handleRestore()}>
+              <RotateCcw />
+              Restore
+            </Button>
+          ) : null}
           <Button asChild>
             <Link to={settingsPath}>Project settings</Link>
           </Button>

--- a/apps/web/src/components/pages/project-settings.tsx
+++ b/apps/web/src/components/pages/project-settings.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import { Link, useParams } from 'react-router';
-import { AlertCircle, CheckCircle2, LockKeyhole } from 'lucide-react';
+import { AlertCircle, Archive, CheckCircle2, LockKeyhole, RotateCcw } from 'lucide-react';
 import {
+  archiveProject,
   getProjectDetail,
+  restoreProject,
   updateProjectSettings,
   type ProjectDetail,
 } from '@/features/projects/project-api';
@@ -40,6 +42,7 @@ export function ProjectSettingsPage() {
   const [description, setDescription] = useState('');
   const [projectOwnerMemberId, setProjectOwnerMemberId] = useState('');
   const [isSaving, setIsSaving] = useState(false);
+  const [isArchiving, setIsArchiving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
   const projectsPath = organizationSlug ? buildProjectsPath(organizationSlug) : '/';
@@ -129,6 +132,37 @@ export function ProjectSettingsPage() {
     }
   };
 
+  const handleArchiveStateChange = async () => {
+    if (
+      !organizationSlug ||
+      !projectSlug ||
+      !canManageProjects(currentRole) ||
+      state.status !== 'available'
+    ) {
+      return;
+    }
+
+    setIsArchiving(true);
+    setSaveError(null);
+    setStatus(null);
+
+    try {
+      const project = state.project.archivedAt
+        ? await restoreProject({ organizationSlug, projectSlug })
+        : await archiveProject({ organizationSlug, projectSlug });
+
+      setState({ status: 'available', project });
+      setStatus(project.archivedAt ? 'Project archived.' : 'Project restored.');
+    } catch (caughtError) {
+      const action = state.project.archivedAt ? 'restore' : 'archive';
+      const rawMessage =
+        caughtError instanceof Error ? caughtError.message : `Unable to ${action} Project.`;
+      setSaveError(humanizeAuthError(null, rawMessage, `Unable to ${action} Project.`));
+    } finally {
+      setIsArchiving(false);
+    }
+  };
+
   if (state.status === 'loading') {
     return (
       <div className="mx-auto w-full max-w-3xl space-y-6">
@@ -176,6 +210,16 @@ export function ProjectSettingsPage() {
           <Link to={projectPath}>Back to Project</Link>
         </Button>
       </header>
+
+      {project.archivedAt ? (
+        <Alert>
+          <Archive className="size-4" />
+          <AlertTitle>Archived Project</AlertTitle>
+          <AlertDescription>
+            This Project is hidden from active work. Restore it to return it to active Projects.
+          </AlertDescription>
+        </Alert>
+      ) : null}
 
       {!canEdit ? (
         <Alert>
@@ -265,6 +309,36 @@ export function ProjectSettingsPage() {
           </form>
         </CardContent>
       </Card>
+
+      {canEdit ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>{project.archivedAt ? 'Restore Project' : 'Archive Project'}</CardTitle>
+            <CardDescription>
+              {project.archivedAt
+                ? 'Move this Project back to active work.'
+                : 'Hide this Project from active work without deleting its record or URL.'}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button
+              type="button"
+              variant={project.archivedAt ? 'default' : 'outline'}
+              disabled={isArchiving}
+              onClick={() => void handleArchiveStateChange()}
+            >
+              {project.archivedAt ? <RotateCcw /> : <Archive />}
+              {isArchiving
+                ? project.archivedAt
+                  ? 'Restoring...'
+                  : 'Archiving...'
+                : project.archivedAt
+                  ? 'Restore Project'
+                  : 'Archive Project'}
+            </Button>
+          </CardContent>
+        </Card>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/pages/projects.tsx
+++ b/apps/web/src/components/pages/projects.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
-import { AlertCircle, CheckCircle2, Plus } from 'lucide-react';
-import { Link, useNavigate, useParams } from 'react-router';
+import { AlertCircle, Archive, CheckCircle2, Plus, RotateCcw } from 'lucide-react';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router';
 import {
   createProject,
   getMembershipResolution,
@@ -12,6 +12,7 @@ import {
 } from '../../features/auth/auth-api';
 import { humanizeAuthError } from '../../features/auth/auth-errors';
 import { buildOrganizationPath, slugifyProjectName } from '../../features/auth/auth-routing';
+import { archiveProject, restoreProject } from '@/features/projects/project-api';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -29,9 +30,14 @@ function canCreateProjects(role: string | null): boolean {
   return role === 'owner' || role === 'admin';
 }
 
+function isArchivedView(value: string | null): boolean {
+  return value === 'archived';
+}
+
 export function ProjectsPage() {
   const { organizationSlug } = useParams();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [projects, setProjects] = useState<ProjectListItem[]>([]);
   const [members, setMembers] = useState<OrganizationMemberListItem[]>([]);
   const [currentRole, setCurrentRole] = useState<string | null>(null);
@@ -44,6 +50,7 @@ export function ProjectsPage() {
   const [description, setDescription] = useState('');
   const [slug, setSlug] = useState('');
   const [projectOwnerMemberId, setProjectOwnerMemberId] = useState('');
+  const archivedView = isArchivedView(searchParams.get('status'));
 
   useEffect(() => {
     const refresh = async () => {
@@ -53,7 +60,7 @@ export function ProjectsPage() {
       setError(null);
       try {
         const [projectResponse, memberResponse, resolution] = await Promise.all([
-          listProjects(organizationSlug),
+          listProjects(organizationSlug, archivedView ? 'archived' : 'active'),
           listOrganizationMembers(organizationSlug),
           getMembershipResolution(),
         ]);
@@ -72,7 +79,7 @@ export function ProjectsPage() {
     };
 
     void refresh();
-  }, [organizationSlug]);
+  }, [archivedView, organizationSlug]);
 
   const resetForm = () => {
     setName('');
@@ -108,7 +115,34 @@ export function ProjectsPage() {
     }
   };
 
+  const handleArchiveStateChange = async (project: ProjectListItem) => {
+    if (!organizationSlug) return;
+
+    setError(null);
+    setStatus(null);
+    try {
+      if (archivedView) {
+        await restoreProject({ organizationSlug, projectSlug: project.slug });
+        setProjects((currentProjects) => currentProjects.filter(({ id }) => id !== project.id));
+        setStatus('Project restored.');
+      } else {
+        await archiveProject({ organizationSlug, projectSlug: project.slug });
+        setProjects((currentProjects) => currentProjects.filter(({ id }) => id !== project.id));
+        setStatus('Project archived.');
+      }
+    } catch (caughtError) {
+      const action = archivedView ? 'restore' : 'archive';
+      const rawMessage =
+        caughtError instanceof Error ? caughtError.message : `Unable to ${action} Project.`;
+      setError(humanizeAuthError(null, rawMessage, `Unable to ${action} Project.`));
+    }
+  };
+
   const canCreate = canCreateProjects(currentRole);
+  const emptyTitle = archivedView ? 'No archived Projects' : 'No active Projects yet';
+  const emptyDescription = archivedView
+    ? 'Archived Projects will appear here after they are hidden from active work.'
+    : 'Create the first Project to start organizing governance work for this Organization.';
 
   return (
     <div className="mx-auto w-full max-w-5xl space-y-6">
@@ -116,15 +150,33 @@ export function ProjectsPage() {
         <div className="space-y-1">
           <h1 className="text-2xl font-semibold tracking-tight">Projects</h1>
           <p className="text-sm text-muted-foreground">
-            Track active governance work for this Organization.
+            {archivedView
+              ? 'Review Archived Projects hidden from active work.'
+              : 'Track active governance work for this Organization.'}
           </p>
         </div>
-        {canCreate ? (
-          <Button type="button" onClick={() => setIsModalOpen(true)}>
-            <Plus />
-            Create Project
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant={archivedView ? 'outline' : 'default'}
+            onClick={() => setSearchParams({})}
+          >
+            Active
           </Button>
-        ) : null}
+          <Button
+            type="button"
+            variant={archivedView ? 'default' : 'outline'}
+            onClick={() => setSearchParams({ status: 'archived' })}
+          >
+            Archived
+          </Button>
+          {canCreate && !archivedView ? (
+            <Button type="button" onClick={() => setIsModalOpen(true)}>
+              <Plus />
+              Create Project
+            </Button>
+          ) : null}
+        </div>
       </header>
 
       {error ? (
@@ -146,11 +198,9 @@ export function ProjectsPage() {
         <p className="text-sm text-muted-foreground">Loading Projects...</p>
       ) : projects.length === 0 ? (
         <section className="rounded-xl border border-dashed p-8 text-center">
-          <h2 className="text-lg font-medium">No active Projects yet</h2>
-          <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
-            Create the first Project to start organizing governance work for this Organization.
-          </p>
-          {canCreate ? (
+          <h2 className="text-lg font-medium">{emptyTitle}</h2>
+          <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">{emptyDescription}</p>
+          {canCreate && !archivedView ? (
             <Button className="mt-4" type="button" onClick={() => setIsModalOpen(true)}>
               Create Project
             </Button>
@@ -159,31 +209,47 @@ export function ProjectsPage() {
       ) : (
         <section className="grid gap-3">
           {projects.map((project) => (
-            <Link
-              key={project.id}
-              to={
-                organizationSlug
-                  ? buildOrganizationPath(organizationSlug, `/p/${project.slug}`)
-                  : '#'
-              }
-              className="rounded-xl border bg-card p-5 transition-colors hover:bg-muted/40"
-            >
+            <article key={project.id} className="rounded-xl border bg-card p-5">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                 <div className="space-y-1">
-                  <h2 className="text-base font-semibold">{project.name}</h2>
+                  <Link
+                    to={
+                      organizationSlug
+                        ? buildOrganizationPath(organizationSlug, `/p/${project.slug}`)
+                        : '#'
+                    }
+                    className="text-base font-semibold hover:underline"
+                  >
+                    {project.name}
+                  </Link>
                   <p className="text-sm text-muted-foreground">{project.description}</p>
                 </div>
                 <p className="shrink-0 text-xs text-muted-foreground">
-                  Created {formatDate(project.createdAt)}
+                  {archivedView && project.archivedAt
+                    ? `Archived ${formatDate(project.archivedAt)}`
+                    : `Created ${formatDate(project.createdAt)}`}
                 </p>
               </div>
-              <p className="mt-3 text-xs text-muted-foreground">
-                Project Owner:{' '}
-                {project.projectOwner
-                  ? `${project.projectOwner.name} (${project.projectOwner.email})`
-                  : 'Not assigned'}
-              </p>
-            </Link>
+              <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-xs text-muted-foreground">
+                  Project Owner:{' '}
+                  {project.projectOwner
+                    ? `${project.projectOwner.name} (${project.projectOwner.email})`
+                    : 'Not assigned'}
+                </p>
+                {canCreate ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void handleArchiveStateChange(project)}
+                  >
+                    {archivedView ? <RotateCcw /> : <Archive />}
+                    {archivedView ? 'Restore' : 'Archive'}
+                  </Button>
+                ) : null}
+              </div>
+            </article>
           ))}
         </section>
       )}

--- a/apps/web/src/features/auth/auth-api.ts
+++ b/apps/web/src/features/auth/auth-api.ts
@@ -45,6 +45,7 @@ export type InvitationEntryResponse = {
 };
 
 export type ProjectListItem = {
+  archivedAt: string | null;
   createdAt: string;
   description: string;
   id: string;
@@ -179,9 +180,11 @@ export function listOrganizationMembers(organizationSlug: string) {
   );
 }
 
-export function listProjects(organizationSlug: string) {
+export function listProjects(organizationSlug: string, status: 'active' | 'archived' = 'active') {
+  const query = status === 'archived' ? '?status=archived' : '';
+
   return request<{ projects: ProjectListItem[] }>(
-    `/api/organizations/${organizationSlug}/projects`,
+    `/api/organizations/${organizationSlug}/projects${query}`,
     {
       method: 'GET',
     },

--- a/apps/web/src/features/projects/project-api.ts
+++ b/apps/web/src/features/projects/project-api.ts
@@ -79,3 +79,45 @@ export async function updateProjectSettings(input: {
 
   return body.project;
 }
+
+export async function archiveProject(input: {
+  organizationSlug: string;
+  projectSlug: string;
+}): Promise<ProjectDetail> {
+  return setProjectArchived(input, 'archive');
+}
+
+export async function restoreProject(input: {
+  organizationSlug: string;
+  projectSlug: string;
+}): Promise<ProjectDetail> {
+  return setProjectArchived(input, 'restore');
+}
+
+async function setProjectArchived(
+  input: { organizationSlug: string; projectSlug: string },
+  action: 'archive' | 'restore',
+): Promise<ProjectDetail> {
+  const response = await fetch(
+    `${AUTH_BASE_URL}/api/organizations/${input.organizationSlug}/projects/${input.projectSlug}/${action}`,
+    {
+      credentials: 'include',
+      headers: { 'content-type': 'application/json' },
+      method: 'PATCH',
+    },
+  );
+  const body = (await response.json().catch(() => null)) as {
+    error?: string;
+    project?: ProjectDetail;
+  } | null;
+
+  if (!response.ok) {
+    throw new Error(body?.error ?? `Unable to ${action} Project.`);
+  }
+
+  if (!body?.project) {
+    throw new Error(`Unable to ${action} Project.`);
+  }
+
+  return body.project;
+}


### PR DESCRIPTION
## Summary
- Add API support for active/archived Project list filtering plus archive and restore mutations.
- Add archived Project banners and restore actions on Project detail/settings, with archive/restore controls in the Projects list.
- Cover archive/restore authorization, filtering, slug preservation, and archived detail access in backend tests.

## Checks
- pnpm test
- pnpm check-types
- pnpm lint
- pnpm format:check
- pnpm build

Closes #13