### PR TITLE
Create and view Draft Controls

### DIFF
--- a/apps/backend-hono/drizzle/migrations/0003_draft_controls.sql
+++ b/apps/backend-hono/drizzle/migrations/0003_draft_controls.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `draft_controls` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`author_member_id` text NOT NULL,
+	`control_code` text NOT NULL,
+	`title` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`author_member_id`) REFERENCES `members`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `draft_control_organization_id_idx` ON `draft_controls` (`organization_id`);--> statement-breakpoint
+CREATE INDEX `draft_control_author_member_id_idx` ON `draft_controls` (`author_member_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `draft_control_organization_code_unique` ON `draft_controls` (`organization_id`,`control_code`);

--- a/apps/backend-hono/src/db/schema.ts
+++ b/apps/backend-hono/src/db/schema.ts
@@ -181,3 +181,33 @@ export const projects = sqliteTable(
     uniqueIndex('project_organization_slug_unique').on(table.organizationId, table.slug),
   ],
 );
+
+export const draftControls = sqliteTable(
+  'draft_controls',
+  {
+    id: text('id').primaryKey(),
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    authorMemberId: text('author_member_id')
+      .notNull()
+      .references(() => members.id, { onDelete: 'cascade' }),
+    controlCode: text('control_code').notNull(),
+    title: text('title').notNull(),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    index('draft_control_organization_id_idx').on(table.organizationId),
+    index('draft_control_author_member_id_idx').on(table.authorMemberId),
+    uniqueIndex('draft_control_organization_code_unique').on(
+      table.organizationId,
+      table.controlCode,
+    ),
+  ],
+);

--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -4,6 +4,12 @@ import { auth } from './lib/auth';
 import { env } from 'cloudflare:workers';
 import { resolveInvitationEntryState, resolveMembershipResolution } from './lib/auth-organization';
 import {
+  createDraftControl,
+  DraftControlInputError,
+  listDraftControls,
+  normalizeDraftControlCreateBody,
+} from './lib/controls';
+import {
   canManageProjects,
   createProject,
   getProjectDetailForMember,
@@ -110,6 +116,61 @@ app.get('/api/organizations/:organizationSlug/projects', async (c) => {
   const status = c.req.query('status') === 'archived' ? 'archived' : 'active';
 
   return c.json({ projects: await listProjects(membership.organizationId, status) });
+});
+
+app.get('/api/organizations/:organizationSlug/controls/drafts', async (c) => {
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(
+    c.req.param('organizationSlug'),
+    session.user.id,
+  );
+
+  if (!membership) {
+    return c.json({ error: 'Organization not found' }, 404);
+  }
+
+  return c.json({ draftControls: await listDraftControls(membership) });
+});
+
+app.post('/api/organizations/:organizationSlug/controls/drafts', async (c) => {
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(
+    c.req.param('organizationSlug'),
+    session.user.id,
+  );
+
+  if (!membership) {
+    return c.json({ error: 'Organization not found' }, 404);
+  }
+
+  try {
+    const draftControl = await createDraftControl(
+      membership,
+      normalizeDraftControlCreateBody(await c.req.json().catch(() => null)),
+    );
+
+    return c.json({ draftControl }, 201);
+  } catch (caughtError) {
+    if (caughtError instanceof DraftControlInputError) {
+      return c.json({ error: caughtError.message }, 400);
+    }
+
+    throw caughtError;
+  }
 });
 
 app.post('/api/organizations/:organizationSlug/projects', async (c) => {

--- a/apps/backend-hono/src/lib/controls.ts
+++ b/apps/backend-hono/src/lib/controls.ts
@@ -1,0 +1,120 @@
+import { and, asc, eq } from 'drizzle-orm';
+import { db } from '../db/client';
+import { draftControls, members, users } from '../db/schema';
+import type { OrganizationMembership } from './projects';
+
+export type DraftControlListItem = {
+  author: {
+    email: string;
+    id: string;
+    name: string;
+  };
+  controlCode: string;
+  createdAt: string;
+  id: string;
+  title: string;
+};
+
+type CreateDraftControlInput = {
+  controlCode: string;
+  title: string;
+};
+
+const draftReviewerRoles = new Set(['owner', 'admin']);
+
+export class DraftControlInputError extends Error {}
+
+export async function listDraftControls(
+  membership: OrganizationMembership,
+): Promise<DraftControlListItem[]> {
+  const rows = await db
+    .select({
+      authorEmail: users.email,
+      authorId: members.id,
+      authorName: users.name,
+      controlCode: draftControls.controlCode,
+      createdAt: draftControls.createdAt,
+      id: draftControls.id,
+      title: draftControls.title,
+    })
+    .from(draftControls)
+    .innerJoin(members, eq(draftControls.authorMemberId, members.id))
+    .innerJoin(users, eq(members.userId, users.id))
+    .where(
+      draftReviewerRoles.has(membership.role)
+        ? eq(draftControls.organizationId, membership.organizationId)
+        : and(
+            eq(draftControls.organizationId, membership.organizationId),
+            eq(draftControls.authorMemberId, membership.id),
+          ),
+    )
+    .orderBy(asc(draftControls.createdAt), asc(draftControls.controlCode));
+
+  return rows.map(({ authorEmail, authorId, authorName, createdAt, ...draft }) => ({
+    ...draft,
+    author: {
+      email: authorEmail,
+      id: authorId,
+      name: authorName,
+    },
+    createdAt: createdAt.toISOString(),
+  }));
+}
+
+export async function createDraftControl(
+  membership: OrganizationMembership,
+  input: CreateDraftControlInput,
+): Promise<DraftControlListItem> {
+  validateDraftControlInput(input);
+
+  const existingDraft = await db
+    .select({ id: draftControls.id })
+    .from(draftControls)
+    .where(
+      and(
+        eq(draftControls.organizationId, membership.organizationId),
+        eq(draftControls.controlCode, input.controlCode.trim()),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existingDraft) {
+    throw new DraftControlInputError('Control Code is already used in this Organization.');
+  }
+
+  const now = new Date();
+  const draft = {
+    authorMemberId: membership.id,
+    controlCode: input.controlCode.trim(),
+    createdAt: now,
+    id: crypto.randomUUID(),
+    organizationId: membership.organizationId,
+    title: input.title.trim(),
+    updatedAt: now,
+  };
+
+  await db.insert(draftControls).values(draft);
+
+  return (await listDraftControls(membership)).find(({ id }) => id === draft.id)!;
+}
+
+export function normalizeDraftControlCreateBody(body: unknown): CreateDraftControlInput {
+  const value = typeof body === 'object' && body !== null ? body : {};
+  const record = value as Record<string, unknown>;
+
+  return {
+    controlCode: typeof record.controlCode === 'string' ? record.controlCode : '',
+    title: typeof record.title === 'string' ? record.title : '',
+  };
+}
+
+function validateDraftControlInput(input: CreateDraftControlInput) {
+  if (!input.controlCode.trim()) {
+    throw new DraftControlInputError('Control Code is required.');
+  }
+
+  if (!input.title.trim()) {
+    throw new DraftControlInputError('Control title is required.');
+  }
+}

--- a/apps/backend-hono/test/draft-controls.spec.ts
+++ b/apps/backend-hono/test/draft-controls.spec.ts
@@ -1,0 +1,297 @@
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import app from '../src/index';
+import { db } from '../src/db/client';
+import { users } from '../src/db/schema';
+import { auth } from '../src/lib/auth';
+
+const authHeaders = {
+  origin: 'http://localhost:5173',
+  host: 'localhost:8787',
+};
+const verificationCallbackURL = 'http://localhost:8787/sign-in';
+const mailpitSendUrl = 'http://127.0.0.1:8025/api/v1/send';
+
+function createCredentials(prefix: string) {
+  const token = crypto.randomUUID();
+
+  return {
+    name: `${prefix} user`,
+    email: `${prefix}-${token}@example.com`,
+    password: `Password-${token}`,
+  };
+}
+
+async function signUpUser(credentials: ReturnType<typeof createCredentials>) {
+  await auth.api.signUpEmail({
+    body: {
+      ...credentials,
+      callbackURL: verificationCallbackURL,
+    },
+    headers: authHeaders,
+  });
+
+  await db.update(users).set({ emailVerified: true }).where(eq(users.email, credentials.email));
+}
+
+async function signInUser(credentials: ReturnType<typeof createCredentials>) {
+  const result = await auth.api.signInEmail({
+    body: {
+      email: credentials.email,
+      password: credentials.password,
+    },
+    headers: authHeaders,
+    returnHeaders: true,
+  });
+
+  const sessionCookie = result.headers.get('set-cookie');
+
+  expect(sessionCookie).toBeTruthy();
+
+  if (!sessionCookie) {
+    throw new Error('Expected Better Auth to return a session cookie.');
+  }
+
+  const cookie = sessionCookie.split(';', 1)[0] ?? sessionCookie;
+
+  return new Headers({
+    ...authHeaders,
+    cookie,
+  });
+}
+
+async function createSignedInOwner(prefix: string) {
+  const credentials = createCredentials(prefix);
+
+  await signUpUser(credentials);
+
+  const headers = await signInUser(credentials);
+  const organization = (await auth.api.listOrganizations({ headers }))[0];
+
+  expect(organization?.id).toBeTruthy();
+
+  if (!organization?.id) {
+    throw new Error('Expected a default organization.');
+  }
+
+  return { headers, organization };
+}
+
+async function createSignedInMember(input: {
+  ownerHeaders: Headers;
+  organizationId: string;
+  prefix: string;
+  role: 'admin' | 'member';
+}) {
+  const credentials = createCredentials(input.prefix);
+
+  await signUpUser(credentials);
+
+  const invitation = await auth.api.createInvitation({
+    body: {
+      email: credentials.email,
+      organizationId: input.organizationId,
+      role: input.role,
+    },
+    headers: input.ownerHeaders,
+  });
+  const headers = await signInUser(credentials);
+
+  await auth.api.acceptInvitation({
+    body: { invitationId: invitation.id },
+    headers,
+  });
+
+  return { credentials, headers };
+}
+
+async function createDraftControlRequest(
+  organizationSlug: string,
+  headers: Headers,
+  body: Record<string, unknown>,
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls/drafts`,
+    {
+      body: JSON.stringify(body),
+      headers,
+      method: 'POST',
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function listDraftControlsRequest(organizationSlug: string, headers: Headers) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls/drafts`,
+    { headers },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+beforeEach(() => {
+  const originalFetch = globalThis.fetch;
+
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+    if (url === mailpitSendUrl) {
+      return new Response(null, { status: 200 });
+    }
+
+    return originalFetch(input, init);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Draft Controls', () => {
+  it('lets Organization members create and list their own Draft Controls', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner('draft-owner');
+    const member = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'draft-member',
+      role: 'member',
+    });
+
+    const createResponse = await createDraftControlRequest(organization.slug, member.headers, {
+      controlCode: 'AUTH-001',
+      title: 'Require multi-factor authentication',
+    });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body.draftControl).toMatchObject({
+      author: { email: member.credentials.email },
+      controlCode: 'AUTH-001',
+      title: 'Require multi-factor authentication',
+    });
+
+    await expect(
+      listDraftControlsRequest(organization.slug, member.headers),
+    ).resolves.toMatchObject({
+      body: { draftControls: [{ controlCode: 'AUTH-001' }] },
+      status: 200,
+    });
+  });
+
+  it('enforces Draft Control visibility by author and Organization owner/admin role', async () => {
+    const { headers: ownerHeaders, organization } =
+      await createSignedInOwner('draft-visibility-owner');
+    const firstMember = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'draft-first-member',
+      role: 'member',
+    });
+    const secondMember = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'draft-second-member',
+      role: 'member',
+    });
+    const admin = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'draft-admin',
+      role: 'admin',
+    });
+
+    await createDraftControlRequest(organization.slug, firstMember.headers, {
+      controlCode: 'AUTH-002',
+      title: 'Review privileged access',
+    });
+    await createDraftControlRequest(organization.slug, secondMember.headers, {
+      controlCode: 'DATA-001',
+      title: 'Classify production data',
+    });
+
+    await expect(
+      listDraftControlsRequest(organization.slug, firstMember.headers),
+    ).resolves.toMatchObject({
+      body: { draftControls: [{ controlCode: 'AUTH-002' }] },
+      status: 200,
+    });
+    await expect(listDraftControlsRequest(organization.slug, ownerHeaders)).resolves.toMatchObject({
+      body: {
+        draftControls: [{ controlCode: 'AUTH-002' }, { controlCode: 'DATA-001' }],
+      },
+      status: 200,
+    });
+    await expect(listDraftControlsRequest(organization.slug, admin.headers)).resolves.toMatchObject(
+      {
+        body: {
+          draftControls: [{ controlCode: 'AUTH-002' }, { controlCode: 'DATA-001' }],
+        },
+        status: 200,
+      },
+    );
+  });
+
+  it('validates required Draft Control fields and Organization-local Control Code uniqueness', async () => {
+    const first = await createSignedInOwner('draft-first-org');
+    const second = await createSignedInOwner('draft-second-org');
+
+    const missingCodeResponse = await createDraftControlRequest(
+      first.organization.slug,
+      first.headers,
+      {
+        controlCode: '',
+        title: 'Missing code',
+      },
+    );
+
+    expect(missingCodeResponse.status).toBe(400);
+    expect(missingCodeResponse.body).toMatchObject({ error: 'Control Code is required.' });
+
+    const missingTitleResponse = await createDraftControlRequest(
+      first.organization.slug,
+      first.headers,
+      {
+        controlCode: 'AUTH-003',
+        title: '',
+      },
+    );
+
+    expect(missingTitleResponse.status).toBe(400);
+    expect(missingTitleResponse.body).toMatchObject({ error: 'Control title is required.' });
+
+    await createDraftControlRequest(first.organization.slug, first.headers, {
+      controlCode: 'AUTH-003',
+      title: 'First code use',
+    });
+
+    const duplicateResponse = await createDraftControlRequest(
+      first.organization.slug,
+      first.headers,
+      {
+        controlCode: 'AUTH-003',
+        title: 'Duplicate code use',
+      },
+    );
+
+    expect(duplicateResponse.status).toBe(400);
+    expect(duplicateResponse.body).toMatchObject({
+      error: 'Control Code is already used in this Organization.',
+    });
+
+    await expect(
+      createDraftControlRequest(second.organization.slug, second.headers, {
+        controlCode: 'AUTH-003',
+        title: 'Same code in another Organization',
+      }),
+    ).resolves.toMatchObject({ status: 201 });
+  });
+});

--- a/apps/web/src/components/pages/controls.tsx
+++ b/apps/web/src/components/pages/controls.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+import { AlertCircle, CheckCircle2, Plus } from 'lucide-react';
+import { useParams } from 'react-router';
+import {
+  createDraftControl,
+  listDraftControls,
+  type DraftControlListItem,
+} from '../../features/auth/auth-api';
+import { humanizeAuthError } from '../../features/auth/auth-errors';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleDateString(undefined, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+export function ControlsPage() {
+  const { organizationSlug } = useParams();
+  const [draftControls, setDraftControls] = useState<DraftControlListItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [controlCode, setControlCode] = useState('');
+  const [title, setTitle] = useState('');
+
+  useEffect(() => {
+    const refresh = async () => {
+      if (!organizationSlug) return;
+
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await listDraftControls(organizationSlug);
+        setDraftControls(response.draftControls);
+      } catch (caughtError) {
+        const rawMessage =
+          caughtError instanceof Error ? caughtError.message : 'Unable to load Draft Controls.';
+        setError(humanizeAuthError(null, rawMessage, 'Unable to load Draft Controls.'));
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void refresh();
+  }, [organizationSlug]);
+
+  const handleCreateDraftControl = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!organizationSlug) return;
+
+    setIsCreating(true);
+    setError(null);
+    setStatus(null);
+    try {
+      const response = await createDraftControl(organizationSlug, { controlCode, title });
+      setDraftControls((currentDrafts) => [...currentDrafts, response.draftControl]);
+      setControlCode('');
+      setTitle('');
+      setStatus('Draft Control saved.');
+    } catch (caughtError) {
+      const rawMessage =
+        caughtError instanceof Error ? caughtError.message : 'Unable to save Draft Control.';
+      setError(humanizeAuthError(null, rawMessage, 'Unable to save Draft Control.'));
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Controls</h1>
+        <p className="text-sm text-muted-foreground">
+          Save Draft Controls before they are ready for the Control Library.
+        </p>
+      </header>
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertCircle />
+          <AlertTitle>Something went wrong</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+      {status ? (
+        <Alert>
+          <CheckCircle2 />
+          <AlertTitle>Done</AlertTitle>
+          <AlertDescription>{status}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <section className="rounded-xl border bg-card p-5">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold">Create Draft Control</h2>
+          <p className="text-sm text-muted-foreground">
+            Only Control Code and title are required while a Control is still a draft.
+          </p>
+        </div>
+        <form
+          className="mt-5 grid gap-4 sm:grid-cols-[12rem_1fr_auto]"
+          onSubmit={handleCreateDraftControl}
+        >
+          <div className="space-y-2">
+            <Label htmlFor="control-code">Control Code</Label>
+            <Input
+              id="control-code"
+              value={controlCode}
+              onChange={(event) => setControlCode(event.target.value)}
+              placeholder="AUTH-001"
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="control-title">Title</Label>
+            <Input
+              id="control-title"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder="Require multi-factor authentication"
+              required
+            />
+          </div>
+          <Button className="self-end" type="submit" disabled={isCreating}>
+            <Plus />
+            {isCreating ? 'Saving...' : 'Save Draft'}
+          </Button>
+        </form>
+      </section>
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading Draft Controls...</p>
+      ) : draftControls.length === 0 ? (
+        <section className="rounded-xl border border-dashed p-8 text-center">
+          <h2 className="text-lg font-medium">No Draft Controls yet</h2>
+          <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
+            Draft Controls you can access will appear here after they are saved.
+          </p>
+        </section>
+      ) : (
+        <section className="grid gap-3">
+          {draftControls.map((draftControl) => (
+            <article key={draftControl.id} className="rounded-xl border bg-card p-5">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-1">
+                  <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                    {draftControl.controlCode}
+                  </p>
+                  <h2 className="text-base font-semibold">{draftControl.title}</h2>
+                  <p className="text-sm text-muted-foreground">
+                    Author: {draftControl.author.name} ({draftControl.author.email})
+                  </p>
+                </div>
+                <p className="shrink-0 text-xs text-muted-foreground">
+                  Saved {formatDate(draftControl.createdAt)}
+                </p>
+              </div>
+            </article>
+          ))}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/auth/auth-api.ts
+++ b/apps/web/src/features/auth/auth-api.ts
@@ -58,6 +58,18 @@ export type ProjectListItem = {
   slug: string;
 };
 
+export type DraftControlListItem = {
+  author: {
+    email: string;
+    id: string;
+    name: string;
+  };
+  controlCode: string;
+  createdAt: string;
+  id: string;
+  title: string;
+};
+
 export type OrganizationMemberListItem = {
   email: string;
   id: string;
@@ -204,4 +216,29 @@ export function createProject(
     method: 'POST',
     body: JSON.stringify(input),
   });
+}
+
+export function listDraftControls(organizationSlug: string) {
+  return request<{ draftControls: DraftControlListItem[] }>(
+    `/api/organizations/${organizationSlug}/controls/drafts`,
+    {
+      method: 'GET',
+    },
+  );
+}
+
+export function createDraftControl(
+  organizationSlug: string,
+  input: {
+    controlCode: string;
+    title: string;
+  },
+) {
+  return request<{ draftControl: DraftControlListItem }>(
+    `/api/organizations/${organizationSlug}/controls/drafts`,
+    {
+      method: 'POST',
+      body: JSON.stringify(input),
+    },
+  );
 }

--- a/apps/web/src/providers/router.tsx
+++ b/apps/web/src/providers/router.tsx
@@ -113,6 +113,13 @@ const router = createBrowserRouter([
                     },
                   },
                   {
+                    path: 'controls',
+                    lazy: async () => {
+                      const { ControlsPage } = await import('../components/pages/controls');
+                      return { Component: ControlsPage };
+                    },
+                  },
+                  {
                     path: 'p/:projectSlug',
                     lazy: async () => {
                       const { ProjectDetailPage } =
@@ -128,7 +135,7 @@ const router = createBrowserRouter([
                       return { Component: ProjectSettingsPage };
                     },
                   },
-                  ...['checklists', 'controls', 'exceptions', 'audit'].map((path) => ({
+                  ...['checklists', 'exceptions', 'audit'].map((path) => ({
                     path,
                     lazy: async () => {
                       const { StaticAppPage } = await import('../components/pages/static-app-page');


### PR DESCRIPTION
## Summary
- Add Draft Control persistence and API endpoints for creating and listing drafts by Organization.
- Enforce visibility so authors see their own drafts while Organization owners/admins see all drafts.
- Add a Controls page for saving and viewing Draft Controls.

Closes #21