### PR TITLE
Publish Draft Controls without approval

### DIFF
--- a/apps/backend-hono/drizzle/migrations/0004_active_controls.sql
+++ b/apps/backend-hono/drizzle/migrations/0004_active_controls.sql
@@ -1,0 +1,30 @@
+CREATE TABLE `controls` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`current_version_id` text,
+	`current_control_code` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `control_organization_id_idx` ON `controls` (`organization_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `control_organization_code_unique` ON `controls` (`organization_id`,`current_control_code`);--> statement-breakpoint
+CREATE TABLE `control_versions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`control_id` text NOT NULL,
+	`version_number` integer NOT NULL,
+	`control_code` text NOT NULL,
+	`title` text NOT NULL,
+	`business_meaning` text NOT NULL,
+	`verification_method` text NOT NULL,
+	`accepted_evidence_types` text NOT NULL,
+	`applicability_conditions` text NOT NULL,
+	`release_impact` text NOT NULL,
+	`external_standards_mappings` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`control_id`) REFERENCES `controls`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `control_version_control_id_idx` ON `control_versions` (`control_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `control_version_number_unique` ON `control_versions` (`control_id`,`version_number`);

--- a/apps/backend-hono/src/db/schema.ts
+++ b/apps/backend-hono/src/db/schema.ts
@@ -211,3 +211,55 @@ export const draftControls = sqliteTable(
     ),
   ],
 );
+
+export const controls = sqliteTable(
+  'controls',
+  {
+    id: text('id').primaryKey(),
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    currentVersionId: text('current_version_id'),
+    currentControlCode: text('current_control_code').notNull(),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    index('control_organization_id_idx').on(table.organizationId),
+    uniqueIndex('control_organization_code_unique').on(
+      table.organizationId,
+      table.currentControlCode,
+    ),
+  ],
+);
+
+export const controlVersions = sqliteTable(
+  'control_versions',
+  {
+    id: text('id').primaryKey(),
+    controlId: text('control_id')
+      .notNull()
+      .references(() => controls.id, { onDelete: 'cascade' }),
+    versionNumber: integer('version_number').notNull(),
+    controlCode: text('control_code').notNull(),
+    title: text('title').notNull(),
+    businessMeaning: text('business_meaning').notNull(),
+    verificationMethod: text('verification_method').notNull(),
+    acceptedEvidenceTypes: text('accepted_evidence_types').notNull(),
+    applicabilityConditions: text('applicability_conditions').notNull(),
+    releaseImpact: text('release_impact').notNull(),
+    externalStandardsMappings: text('external_standards_mappings').notNull(),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+  },
+  (table) => [
+    index('control_version_control_id_idx').on(table.controlId),
+    uniqueIndex('control_version_number_unique').on(table.controlId, table.versionNumber),
+  ],
+);

--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -4,10 +4,16 @@ import { auth } from './lib/auth';
 import { env } from 'cloudflare:workers';
 import { resolveInvitationEntryState, resolveMembershipResolution } from './lib/auth-organization';
 import {
+  canPublishControls,
+  ControlPublishInputError,
   createDraftControl,
   DraftControlInputError,
+  getControlDetail,
+  listControls,
   listDraftControls,
   normalizeDraftControlCreateBody,
+  normalizeDraftControlPublishBody,
+  publishDraftControl,
 } from './lib/controls';
 import {
   canManageProjects,
@@ -139,6 +145,54 @@ app.get('/api/organizations/:organizationSlug/controls/drafts', async (c) => {
   return c.json({ draftControls: await listDraftControls(membership) });
 });
 
+app.get('/api/organizations/:organizationSlug/controls', async (c) => {
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(
+    c.req.param('organizationSlug'),
+    session.user.id,
+  );
+
+  if (!membership) {
+    return c.json({ error: 'Organization not found' }, 404);
+  }
+
+  return c.json({ controls: await listControls(membership.organizationId) });
+});
+
+app.get('/api/organizations/:organizationSlug/controls/:controlId', async (c) => {
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(
+    c.req.param('organizationSlug'),
+    session.user.id,
+  );
+
+  if (!membership) {
+    return c.json({ error: 'Control unavailable' }, 404);
+  }
+
+  const control = await getControlDetail(membership, c.req.param('controlId'));
+
+  if (!control) {
+    return c.json({ error: 'Control unavailable' }, 404);
+  }
+
+  return c.json({ control });
+});
+
 app.post('/api/organizations/:organizationSlug/controls/drafts', async (c) => {
   const session = await auth.api.getSession({
     headers: c.req.raw.headers,
@@ -172,6 +226,52 @@ app.post('/api/organizations/:organizationSlug/controls/drafts', async (c) => {
     throw caughtError;
   }
 });
+
+app.post(
+  '/api/organizations/:organizationSlug/controls/drafts/:draftControlId/publish',
+  async (c) => {
+    const session = await auth.api.getSession({
+      headers: c.req.raw.headers,
+    });
+
+    if (!session) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    const membership = await getOrganizationMembership(
+      c.req.param('organizationSlug'),
+      session.user.id,
+    );
+
+    if (!membership) {
+      return c.json({ error: 'Draft Control unavailable' }, 404);
+    }
+
+    if (!canPublishControls(membership.role)) {
+      return c.json({ error: 'Only Organization owners and admins can publish Controls.' }, 403);
+    }
+
+    try {
+      const control = await publishDraftControl(
+        membership,
+        c.req.param('draftControlId'),
+        normalizeDraftControlPublishBody(await c.req.json().catch(() => null)),
+      );
+
+      if (!control) {
+        return c.json({ error: 'Draft Control unavailable' }, 404);
+      }
+
+      return c.json({ control }, 201);
+    } catch (caughtError) {
+      if (caughtError instanceof ControlPublishInputError) {
+        return c.json({ error: caughtError.message }, 400);
+      }
+
+      throw caughtError;
+    }
+  },
+);
 
 app.post('/api/organizations/:organizationSlug/projects', async (c) => {
   const session = await auth.api.getSession({

--- a/apps/backend-hono/src/lib/controls.ts
+++ b/apps/backend-hono/src/lib/controls.ts
@@ -1,6 +1,6 @@
 import { and, asc, eq } from 'drizzle-orm';
 import { db } from '../db/client';
-import { draftControls, members, users } from '../db/schema';
+import { controls, controlVersions, draftControls, members, users } from '../db/schema';
 import type { OrganizationMembership } from './projects';
 
 export type DraftControlListItem = {
@@ -15,14 +15,114 @@ export type DraftControlListItem = {
   title: string;
 };
 
+export type ControlVersionResponse = {
+  acceptedEvidenceTypes: string[];
+  applicabilityConditions: string;
+  businessMeaning: string;
+  controlCode: string;
+  createdAt: string;
+  externalStandardsMappings: ExternalStandardsMapping[];
+  id: string;
+  releaseImpact: ReleaseImpact;
+  title: string;
+  verificationMethod: string;
+  versionNumber: number;
+};
+
+export type ControlListItem = {
+  controlCode: string;
+  createdAt: string;
+  currentVersion: ControlVersionResponse;
+  id: string;
+  title: string;
+};
+
 type CreateDraftControlInput = {
   controlCode: string;
   title: string;
 };
 
+type ExternalStandardsMapping = {
+  description?: string;
+  framework: string;
+  reference: string;
+};
+
+type ReleaseImpact = 'advisory' | 'blocking' | 'needs review';
+
+type PublishDraftControlInput = {
+  acceptedEvidenceTypes: string[];
+  applicabilityConditions: string;
+  businessMeaning: string;
+  externalStandardsMappings: ExternalStandardsMapping[];
+  releaseImpact: ReleaseImpact | '';
+  verificationMethod: string;
+};
+
 const draftReviewerRoles = new Set(['owner', 'admin']);
+const publishControlRoles = new Set(['owner', 'admin']);
+const releaseImpacts = new Set(['advisory', 'blocking', 'needs review']);
 
 export class DraftControlInputError extends Error {}
+export class ControlPublishInputError extends Error {}
+
+export function canPublishControls(role: string): boolean {
+  return publishControlRoles.has(role);
+}
+
+export async function listControls(organizationId: string): Promise<ControlListItem[]> {
+  const rows = await db
+    .select({
+      acceptedEvidenceTypes: controlVersions.acceptedEvidenceTypes,
+      applicabilityConditions: controlVersions.applicabilityConditions,
+      businessMeaning: controlVersions.businessMeaning,
+      controlCode: controlVersions.controlCode,
+      controlCreatedAt: controls.createdAt,
+      controlId: controls.id,
+      externalStandardsMappings: controlVersions.externalStandardsMappings,
+      releaseImpact: controlVersions.releaseImpact,
+      title: controlVersions.title,
+      verificationMethod: controlVersions.verificationMethod,
+      versionCreatedAt: controlVersions.createdAt,
+      versionId: controlVersions.id,
+      versionNumber: controlVersions.versionNumber,
+    })
+    .from(controls)
+    .innerJoin(controlVersions, eq(controls.currentVersionId, controlVersions.id))
+    .where(eq(controls.organizationId, organizationId))
+    .orderBy(asc(controlVersions.controlCode), asc(controlVersions.title));
+
+  return rows.map((row) => toControlListItem(row));
+}
+
+export async function getControlDetail(
+  membership: OrganizationMembership,
+  controlId: string,
+): Promise<ControlListItem | null> {
+  const row = await db
+    .select({
+      acceptedEvidenceTypes: controlVersions.acceptedEvidenceTypes,
+      applicabilityConditions: controlVersions.applicabilityConditions,
+      businessMeaning: controlVersions.businessMeaning,
+      controlCode: controlVersions.controlCode,
+      controlCreatedAt: controls.createdAt,
+      controlId: controls.id,
+      externalStandardsMappings: controlVersions.externalStandardsMappings,
+      releaseImpact: controlVersions.releaseImpact,
+      title: controlVersions.title,
+      verificationMethod: controlVersions.verificationMethod,
+      versionCreatedAt: controlVersions.createdAt,
+      versionId: controlVersions.id,
+      versionNumber: controlVersions.versionNumber,
+    })
+    .from(controls)
+    .innerJoin(controlVersions, eq(controls.currentVersionId, controlVersions.id))
+    .where(and(eq(controls.organizationId, membership.organizationId), eq(controls.id, controlId)))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  return row ? toControlListItem(row) : null;
+}
 
 export async function listDraftControls(
   membership: OrganizationMembership,
@@ -99,6 +199,76 @@ export async function createDraftControl(
   return (await listDraftControls(membership)).find(({ id }) => id === draft.id)!;
 }
 
+export async function publishDraftControl(
+  membership: OrganizationMembership,
+  draftControlId: string,
+  input: PublishDraftControlInput,
+): Promise<ControlListItem | null> {
+  validatePublishInput(input);
+
+  const draftControl = await db
+    .select()
+    .from(draftControls)
+    .where(
+      and(
+        eq(draftControls.id, draftControlId),
+        eq(draftControls.organizationId, membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!draftControl) {
+    return null;
+  }
+
+  const existingControl = await db
+    .select({ id: controls.id })
+    .from(controls)
+    .where(
+      and(
+        eq(controls.organizationId, membership.organizationId),
+        eq(controls.currentControlCode, draftControl.controlCode),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existingControl) {
+    throw new ControlPublishInputError('Control Code is already used in this Organization.');
+  }
+
+  const now = new Date();
+  const controlId = crypto.randomUUID();
+  const versionId = crypto.randomUUID();
+
+  await db.insert(controls).values({
+    createdAt: now,
+    currentControlCode: draftControl.controlCode,
+    currentVersionId: versionId,
+    id: controlId,
+    organizationId: membership.organizationId,
+    updatedAt: now,
+  });
+  await db.insert(controlVersions).values({
+    acceptedEvidenceTypes: JSON.stringify(input.acceptedEvidenceTypes.map((value) => value.trim())),
+    applicabilityConditions: input.applicabilityConditions.trim(),
+    businessMeaning: input.businessMeaning.trim(),
+    controlCode: draftControl.controlCode,
+    controlId,
+    createdAt: now,
+    externalStandardsMappings: JSON.stringify(input.externalStandardsMappings),
+    id: versionId,
+    releaseImpact: input.releaseImpact,
+    title: draftControl.title,
+    verificationMethod: input.verificationMethod.trim(),
+    versionNumber: 1,
+  });
+  await db.delete(draftControls).where(eq(draftControls.id, draftControl.id));
+
+  return getControlDetail(membership, controlId);
+}
+
 export function normalizeDraftControlCreateBody(body: unknown): CreateDraftControlInput {
   const value = typeof body === 'object' && body !== null ? body : {};
   const record = value as Record<string, unknown>;
@@ -106,6 +276,25 @@ export function normalizeDraftControlCreateBody(body: unknown): CreateDraftContr
   return {
     controlCode: typeof record.controlCode === 'string' ? record.controlCode : '',
     title: typeof record.title === 'string' ? record.title : '',
+  };
+}
+
+export function normalizeDraftControlPublishBody(body: unknown): PublishDraftControlInput {
+  const value = typeof body === 'object' && body !== null ? body : {};
+  const record = value as Record<string, unknown>;
+
+  return {
+    acceptedEvidenceTypes: toStringArray(record.acceptedEvidenceTypes),
+    applicabilityConditions:
+      typeof record.applicabilityConditions === 'string' ? record.applicabilityConditions : '',
+    businessMeaning: typeof record.businessMeaning === 'string' ? record.businessMeaning : '',
+    externalStandardsMappings: toExternalStandardsMappings(record.externalStandardsMappings),
+    releaseImpact:
+      typeof record.releaseImpact === 'string' && releaseImpacts.has(record.releaseImpact)
+        ? (record.releaseImpact as ReleaseImpact)
+        : '',
+    verificationMethod:
+      typeof record.verificationMethod === 'string' ? record.verificationMethod : '',
   };
 }
 
@@ -117,4 +306,94 @@ function validateDraftControlInput(input: CreateDraftControlInput) {
   if (!input.title.trim()) {
     throw new DraftControlInputError('Control title is required.');
   }
+}
+
+function validatePublishInput(input: PublishDraftControlInput) {
+  if (!input.businessMeaning.trim()) {
+    throw new ControlPublishInputError('Business meaning is required.');
+  }
+
+  if (!input.verificationMethod.trim()) {
+    throw new ControlPublishInputError('Verification method is required.');
+  }
+
+  if (input.acceptedEvidenceTypes.filter((value) => value.trim()).length === 0) {
+    throw new ControlPublishInputError('At least one Accepted Evidence Type is required.');
+  }
+
+  if (!input.applicabilityConditions.trim()) {
+    throw new ControlPublishInputError('Applicability conditions are required.');
+  }
+
+  if (!input.releaseImpact) {
+    throw new ControlPublishInputError('Release Impact is required.');
+  }
+}
+
+function toStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === 'string' && Boolean(entry.trim()))
+    : [];
+}
+
+function toExternalStandardsMappings(value: unknown): ExternalStandardsMapping[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((entry) => {
+    if (typeof entry !== 'object' || entry === null) {
+      return [];
+    }
+
+    const record = entry as Record<string, unknown>;
+    const framework = typeof record.framework === 'string' ? record.framework.trim() : '';
+    const reference = typeof record.reference === 'string' ? record.reference.trim() : '';
+
+    if (!framework || !reference) {
+      return [];
+    }
+
+    const description = typeof record.description === 'string' ? record.description.trim() : '';
+
+    return [description ? { description, framework, reference } : { framework, reference }];
+  });
+}
+
+function toControlListItem(row: {
+  acceptedEvidenceTypes: string;
+  applicabilityConditions: string;
+  businessMeaning: string;
+  controlCode: string;
+  controlCreatedAt: Date;
+  controlId: string;
+  externalStandardsMappings: string;
+  releaseImpact: string;
+  title: string;
+  verificationMethod: string;
+  versionCreatedAt: Date;
+  versionId: string;
+  versionNumber: number;
+}): ControlListItem {
+  return {
+    controlCode: row.controlCode,
+    createdAt: row.controlCreatedAt.toISOString(),
+    currentVersion: {
+      acceptedEvidenceTypes: JSON.parse(row.acceptedEvidenceTypes) as string[],
+      applicabilityConditions: row.applicabilityConditions,
+      businessMeaning: row.businessMeaning,
+      controlCode: row.controlCode,
+      createdAt: row.versionCreatedAt.toISOString(),
+      externalStandardsMappings: JSON.parse(
+        row.externalStandardsMappings,
+      ) as ExternalStandardsMapping[],
+      id: row.versionId,
+      releaseImpact: row.releaseImpact as ReleaseImpact,
+      title: row.title,
+      verificationMethod: row.verificationMethod,
+      versionNumber: row.versionNumber,
+    },
+    id: row.controlId,
+    title: row.title,
+  };
 }

--- a/apps/backend-hono/test/draft-controls.spec.ts
+++ b/apps/backend-hono/test/draft-controls.spec.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import app from '../src/index';
 import { db } from '../src/db/client';
-import { users } from '../src/db/schema';
+import { controlVersions, controls, users } from '../src/db/schema';
 import { auth } from '../src/lib/auth';
 
 const authHeaders = {
@@ -129,6 +129,61 @@ async function createDraftControlRequest(
 async function listDraftControlsRequest(organizationSlug: string, headers: Headers) {
   const response = await app.request(
     `http://example.com/api/organizations/${organizationSlug}/controls/drafts`,
+    { headers },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+const completePublishBody = {
+  acceptedEvidenceTypes: ['document', 'approval record'],
+  applicabilityConditions: 'Applies to internet-facing authentication surfaces.',
+  businessMeaning: 'Release teams must verify users have a second authentication factor.',
+  releaseImpact: 'blocking',
+  verificationMethod: 'Review identity provider MFA policy evidence.',
+};
+
+async function publishDraftControlRequest(
+  organizationSlug: string,
+  draftControlId: string,
+  headers: Headers,
+  body: Record<string, unknown> = completePublishBody,
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls/drafts/${draftControlId}/publish`,
+    {
+      body: JSON.stringify(body),
+      headers,
+      method: 'POST',
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function listControlsRequest(organizationSlug: string, headers: Headers) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls`,
+    {
+      headers,
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function getControlRequest(organizationSlug: string, controlId: string, headers: Headers) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls/${controlId}`,
     { headers },
   );
 
@@ -293,5 +348,149 @@ describe('Draft Controls', () => {
         title: 'Same code in another Organization',
       }),
     ).resolves.toMatchObject({ status: 201 });
+  });
+
+  it('lets Organization owners publish a complete Draft Control as active Control Version v1', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner('publish-owner');
+
+    const createResponse = await createDraftControlRequest(organization.slug, ownerHeaders, {
+      controlCode: 'AUTH-004',
+      title: 'Require phishing-resistant MFA',
+    });
+
+    expect(createResponse.status).toBe(201);
+
+    const draftControl = createResponse.body.draftControl as { id: string };
+    const publishResponse = await publishDraftControlRequest(
+      organization.slug,
+      draftControl.id,
+      ownerHeaders,
+    );
+
+    expect(publishResponse.status).toBe(201);
+    expect(publishResponse.body.control).toMatchObject({
+      controlCode: 'AUTH-004',
+      currentVersion: {
+        acceptedEvidenceTypes: ['document', 'approval record'],
+        releaseImpact: 'blocking',
+        title: 'Require phishing-resistant MFA',
+        versionNumber: 1,
+      },
+      title: 'Require phishing-resistant MFA',
+    });
+
+    const [controlRow] = await db
+      .select()
+      .from(controls)
+      .where(eq(controls.organizationId, organization.id));
+    expect(controlRow?.currentControlCode).toBe('AUTH-004');
+
+    const versions = await db
+      .select()
+      .from(controlVersions)
+      .where(eq(controlVersions.controlId, controlRow!.id));
+    expect(versions).toHaveLength(1);
+    expect(versions[0]).toMatchObject({ controlCode: 'AUTH-004', versionNumber: 1 });
+
+    await expect(listDraftControlsRequest(organization.slug, ownerHeaders)).resolves.toMatchObject({
+      body: { draftControls: [] },
+      status: 200,
+    });
+  });
+
+  it('makes published Controls visible in list and detail to all Organization members', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner('active-owner');
+    const member = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'active-member',
+      role: 'member',
+    });
+
+    const createResponse = await createDraftControlRequest(organization.slug, ownerHeaders, {
+      controlCode: 'DATA-002',
+      title: 'Classify customer data',
+    });
+    const draftControl = createResponse.body.draftControl as { id: string };
+    const publishResponse = await publishDraftControlRequest(
+      organization.slug,
+      draftControl.id,
+      ownerHeaders,
+    );
+    const control = publishResponse.body.control as { id: string };
+
+    await expect(listControlsRequest(organization.slug, member.headers)).resolves.toMatchObject({
+      body: { controls: [{ controlCode: 'DATA-002', currentVersion: { versionNumber: 1 } }] },
+      status: 200,
+    });
+    await expect(
+      getControlRequest(organization.slug, control.id, member.headers),
+    ).resolves.toMatchObject({
+      body: { control: { controlCode: 'DATA-002', currentVersion: { releaseImpact: 'blocking' } } },
+      status: 200,
+    });
+  });
+
+  it('limits Draft Control publishing to Organization owners and admins', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner('publish-role-owner');
+    const member = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'publish-role-member',
+      role: 'member',
+    });
+    const admin = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'publish-role-admin',
+      role: 'admin',
+    });
+
+    const firstDraftResponse = await createDraftControlRequest(organization.slug, member.headers, {
+      controlCode: 'AUTH-005',
+      title: 'Review privileged sessions',
+    });
+    const firstDraft = firstDraftResponse.body.draftControl as { id: string };
+
+    await expect(
+      publishDraftControlRequest(organization.slug, firstDraft.id, member.headers),
+    ).resolves.toMatchObject({
+      body: { error: 'Only Organization owners and admins can publish Controls.' },
+      status: 403,
+    });
+
+    const secondDraftResponse = await createDraftControlRequest(organization.slug, admin.headers, {
+      controlCode: 'AUTH-006',
+      title: 'Review production access',
+    });
+    const secondDraft = secondDraftResponse.body.draftControl as { id: string };
+
+    await expect(
+      publishDraftControlRequest(organization.slug, secondDraft.id, admin.headers),
+    ).resolves.toMatchObject({ status: 201 });
+  });
+
+  it('validates required Control publish fields', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner('publish-validation');
+    const createResponse = await createDraftControlRequest(organization.slug, ownerHeaders, {
+      controlCode: 'AUTH-007',
+      title: 'Validate publish fields',
+    });
+    const draftControl = createResponse.body.draftControl as { id: string };
+
+    const publishResponse = await publishDraftControlRequest(
+      organization.slug,
+      draftControl.id,
+      ownerHeaders,
+      {
+        ...completePublishBody,
+        acceptedEvidenceTypes: [],
+      },
+    );
+
+    expect(publishResponse.status).toBe(400);
+    expect(publishResponse.body).toMatchObject({
+      error: 'At least one Accepted Evidence Type is required.',
+    });
   });
 });

--- a/apps/web/src/components/pages/controls.tsx
+++ b/apps/web/src/components/pages/controls.tsx
@@ -4,7 +4,11 @@ import { AlertCircle, CheckCircle2, Plus } from 'lucide-react';
 import { useParams } from 'react-router';
 import {
   createDraftControl,
+  getMembershipResolution,
+  listControls,
   listDraftControls,
+  publishDraftControl,
+  type ControlListItem,
   type DraftControlListItem,
 } from '../../features/auth/auth-api';
 import { humanizeAuthError } from '../../features/auth/auth-errors';
@@ -21,11 +25,18 @@ function formatDate(value: string) {
   });
 }
 
+function canPublishControls(role: string | null): boolean {
+  return role === 'owner' || role === 'admin';
+}
+
 export function ControlsPage() {
   const { organizationSlug } = useParams();
+  const [controls, setControls] = useState<ControlListItem[]>([]);
   const [draftControls, setDraftControls] = useState<DraftControlListItem[]>([]);
+  const [currentRole, setCurrentRole] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isCreating, setIsCreating] = useState(false);
+  const [publishingDraftId, setPublishingDraftId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
   const [controlCode, setControlCode] = useState('');
@@ -38,8 +49,16 @@ export function ControlsPage() {
       setIsLoading(true);
       setError(null);
       try {
-        const response = await listDraftControls(organizationSlug);
-        setDraftControls(response.draftControls);
+        const [controlResponse, draftResponse, resolution] = await Promise.all([
+          listControls(organizationSlug),
+          listDraftControls(organizationSlug),
+          getMembershipResolution(),
+        ]);
+        const organization = resolution.organizations.find((org) => org.slug === organizationSlug);
+
+        setControls(controlResponse.controls);
+        setDraftControls(draftResponse.draftControls);
+        setCurrentRole(organization?.role ?? null);
       } catch (caughtError) {
         const rawMessage =
           caughtError instanceof Error ? caughtError.message : 'Unable to load Draft Controls.';
@@ -74,12 +93,53 @@ export function ControlsPage() {
     }
   };
 
+  const handlePublishDraftControl = async (
+    event: FormEvent<HTMLFormElement>,
+    draftControl: DraftControlListItem,
+  ) => {
+    event.preventDefault();
+    if (!organizationSlug) return;
+
+    const formData = new FormData(event.currentTarget);
+    const acceptedEvidenceTypes = String(formData.get('acceptedEvidenceTypes') ?? '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean);
+
+    setPublishingDraftId(draftControl.id);
+    setError(null);
+    setStatus(null);
+    try {
+      const response = await publishDraftControl(organizationSlug, draftControl.id, {
+        acceptedEvidenceTypes,
+        applicabilityConditions: String(formData.get('applicabilityConditions') ?? ''),
+        businessMeaning: String(formData.get('businessMeaning') ?? ''),
+        releaseImpact: String(formData.get('releaseImpact') ?? ''),
+        verificationMethod: String(formData.get('verificationMethod') ?? ''),
+      });
+
+      setControls((currentControls) => [...currentControls, response.control]);
+      setDraftControls((currentDrafts) =>
+        currentDrafts.filter((currentDraft) => currentDraft.id !== draftControl.id),
+      );
+      setStatus('Control published.');
+    } catch (caughtError) {
+      const rawMessage =
+        caughtError instanceof Error ? caughtError.message : 'Unable to publish Control.';
+      setError(humanizeAuthError(null, rawMessage, 'Unable to publish Control.'));
+    } finally {
+      setPublishingDraftId(null);
+    }
+  };
+
+  const canPublish = canPublishControls(currentRole);
+
   return (
     <div className="mx-auto w-full max-w-5xl space-y-6">
       <header className="space-y-1">
         <h1 className="text-2xl font-semibold tracking-tight">Controls</h1>
         <p className="text-sm text-muted-foreground">
-          Save Draft Controls before they are ready for the Control Library.
+          Publish complete Controls into the active Control Library.
         </p>
       </header>
 
@@ -136,6 +196,47 @@ export function ControlsPage() {
         </form>
       </section>
 
+      <section className="space-y-3">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold">Active Control Library</h2>
+          <p className="text-sm text-muted-foreground">
+            Published Controls are visible to every Organization member.
+          </p>
+        </div>
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading Controls...</p>
+        ) : controls.length === 0 ? (
+          <div className="rounded-xl border border-dashed p-8 text-center">
+            <h3 className="text-lg font-medium">No active Controls yet</h3>
+            <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
+              Published Controls will appear here after a Draft Control is completed.
+            </p>
+          </div>
+        ) : (
+          <div className="grid gap-3">
+            {controls.map((control) => (
+              <article key={control.id} className="rounded-xl border bg-card p-5">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="space-y-2">
+                    <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                      {control.controlCode} · v{control.currentVersion.versionNumber}
+                    </p>
+                    <h3 className="text-base font-semibold">{control.title}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Release Impact: {control.currentVersion.releaseImpact}
+                    </p>
+                    <p className="text-sm">{control.currentVersion.businessMeaning}</p>
+                  </div>
+                  <p className="shrink-0 text-xs text-muted-foreground">
+                    Published {formatDate(control.createdAt)}
+                  </p>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+
       {isLoading ? (
         <p className="text-sm text-muted-foreground">Loading Draft Controls...</p>
       ) : draftControls.length === 0 ? (
@@ -163,6 +264,77 @@ export function ControlsPage() {
                   Saved {formatDate(draftControl.createdAt)}
                 </p>
               </div>
+              {canPublish ? (
+                <form
+                  className="mt-5 grid gap-4"
+                  onSubmit={(event) => handlePublishDraftControl(event, draftControl)}
+                >
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label htmlFor={`${draftControl.id}-business-meaning`}>
+                        Business meaning
+                      </Label>
+                      <textarea
+                        id={`${draftControl.id}-business-meaning`}
+                        name="businessMeaning"
+                        className="min-h-24 w-full rounded-md border bg-background px-3 py-2 text-sm"
+                        required
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor={`${draftControl.id}-verification-method`}>
+                        Verification method
+                      </Label>
+                      <textarea
+                        id={`${draftControl.id}-verification-method`}
+                        name="verificationMethod"
+                        className="min-h-24 w-full rounded-md border bg-background px-3 py-2 text-sm"
+                        required
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor={`${draftControl.id}-accepted-evidence-types`}>
+                        Accepted Evidence Types
+                      </Label>
+                      <Input
+                        id={`${draftControl.id}-accepted-evidence-types`}
+                        name="acceptedEvidenceTypes"
+                        placeholder="document, approval record"
+                        required
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor={`${draftControl.id}-release-impact`}>Release Impact</Label>
+                      <select
+                        id={`${draftControl.id}-release-impact`}
+                        name="releaseImpact"
+                        className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                        required
+                        defaultValue="blocking"
+                      >
+                        <option value="blocking">blocking</option>
+                        <option value="needs review">needs review</option>
+                        <option value="advisory">advisory</option>
+                      </select>
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor={`${draftControl.id}-applicability-conditions`}>
+                      Applicability conditions
+                    </Label>
+                    <textarea
+                      id={`${draftControl.id}-applicability-conditions`}
+                      name="applicabilityConditions"
+                      className="min-h-20 w-full rounded-md border bg-background px-3 py-2 text-sm"
+                      required
+                    />
+                  </div>
+                  <Button type="submit" disabled={publishingDraftId === draftControl.id}>
+                    <CheckCircle2 />
+                    {publishingDraftId === draftControl.id ? 'Publishing...' : 'Publish Control'}
+                  </Button>
+                </form>
+              ) : null}
             </article>
           ))}
         </section>

--- a/apps/web/src/features/auth/auth-api.ts
+++ b/apps/web/src/features/auth/auth-api.ts
@@ -70,6 +70,30 @@ export type DraftControlListItem = {
   title: string;
 };
 
+export type ControlListItem = {
+  controlCode: string;
+  createdAt: string;
+  currentVersion: {
+    acceptedEvidenceTypes: string[];
+    applicabilityConditions: string;
+    businessMeaning: string;
+    controlCode: string;
+    createdAt: string;
+    externalStandardsMappings: Array<{
+      description?: string;
+      framework: string;
+      reference: string;
+    }>;
+    id: string;
+    releaseImpact: 'advisory' | 'blocking' | 'needs review';
+    title: string;
+    verificationMethod: string;
+    versionNumber: number;
+  };
+  id: string;
+  title: string;
+};
+
 export type OrganizationMemberListItem = {
   email: string;
   id: string;
@@ -227,6 +251,15 @@ export function listDraftControls(organizationSlug: string) {
   );
 }
 
+export function listControls(organizationSlug: string) {
+  return request<{ controls: ControlListItem[] }>(
+    `/api/organizations/${organizationSlug}/controls`,
+    {
+      method: 'GET',
+    },
+  );
+}
+
 export function createDraftControl(
   organizationSlug: string,
   input: {
@@ -236,6 +269,26 @@ export function createDraftControl(
 ) {
   return request<{ draftControl: DraftControlListItem }>(
     `/api/organizations/${organizationSlug}/controls/drafts`,
+    {
+      method: 'POST',
+      body: JSON.stringify(input),
+    },
+  );
+}
+
+export function publishDraftControl(
+  organizationSlug: string,
+  draftControlId: string,
+  input: {
+    acceptedEvidenceTypes: string[];
+    applicabilityConditions: string;
+    businessMeaning: string;
+    releaseImpact: string;
+    verificationMethod: string;
+  },
+) {
+  return request<{ control: ControlListItem }>(
+    `/api/organizations/${organizationSlug}/controls/drafts/${draftControlId}/publish`,
     {
       method: 'POST',
       body: JSON.stringify(input),


### PR DESCRIPTION
## Summary
- Add active Control and Control Version storage for publishing complete Draft Controls as v1.
- Add publish/list/detail APIs with Organization owner/admin publish authorization and member visibility for active Controls.
- Update the Control Library UI to show active Controls and let owners/admins complete and publish Draft Controls.

## Checks
- pnpm format:check
- pnpm lint
- pnpm check-types
- pnpm test
- pnpm build

Closes #22