### PR TITLE
feat(controls): add Control Library search and filters

### DIFF
--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -11,6 +11,8 @@ import {
   getControlDetail,
   listControls,
   listDraftControls,
+  normalizeControlListFilters,
+  normalizeDraftControlListFilters,
   normalizeDraftControlCreateBody,
   normalizeDraftControlPublishBody,
   publishDraftControl,
@@ -142,7 +144,12 @@ app.get('/api/organizations/:organizationSlug/controls/drafts', async (c) => {
     return c.json({ error: 'Organization not found' }, 404);
   }
 
-  return c.json({ draftControls: await listDraftControls(membership) });
+  return c.json({
+    draftControls: await listDraftControls(
+      membership,
+      normalizeDraftControlListFilters(c.req.query()),
+    ),
+  });
 });
 
 app.get('/api/organizations/:organizationSlug/controls', async (c) => {
@@ -163,7 +170,12 @@ app.get('/api/organizations/:organizationSlug/controls', async (c) => {
     return c.json({ error: 'Organization not found' }, 404);
   }
 
-  return c.json({ controls: await listControls(membership.organizationId) });
+  return c.json({
+    controls: await listControls(
+      membership.organizationId,
+      normalizeControlListFilters(c.req.query()),
+    ),
+  });
 });
 
 app.get('/api/organizations/:organizationSlug/controls/:controlId', async (c) => {

--- a/apps/backend-hono/src/lib/controls.ts
+++ b/apps/backend-hono/src/lib/controls.ts
@@ -34,7 +34,20 @@ export type ControlListItem = {
   createdAt: string;
   currentVersion: ControlVersionResponse;
   id: string;
+  status: 'active';
   title: string;
+};
+
+export type ControlListFilters = {
+  acceptedEvidenceType: string;
+  releaseImpact: ReleaseImpact | '';
+  search: string;
+  standardsFramework: string;
+  status: 'active' | 'archived';
+};
+
+export type DraftControlListFilters = {
+  search: string;
 };
 
 type CreateDraftControlInput = {
@@ -70,7 +83,14 @@ export function canPublishControls(role: string): boolean {
   return publishControlRoles.has(role);
 }
 
-export async function listControls(organizationId: string): Promise<ControlListItem[]> {
+export async function listControls(
+  organizationId: string,
+  filters: ControlListFilters = defaultControlListFilters,
+): Promise<ControlListItem[]> {
+  if (filters.status === 'archived') {
+    return [];
+  }
+
   const rows = await db
     .select({
       acceptedEvidenceTypes: controlVersions.acceptedEvidenceTypes,
@@ -92,7 +112,9 @@ export async function listControls(organizationId: string): Promise<ControlListI
     .where(eq(controls.organizationId, organizationId))
     .orderBy(asc(controlVersions.controlCode), asc(controlVersions.title));
 
-  return rows.map((row) => toControlListItem(row));
+  return rows
+    .map((row) => toControlListItem(row))
+    .filter((control) => matchesControlFilters(control, filters));
 }
 
 export async function getControlDetail(
@@ -126,6 +148,7 @@ export async function getControlDetail(
 
 export async function listDraftControls(
   membership: OrganizationMembership,
+  filters: DraftControlListFilters = defaultDraftControlListFilters,
 ): Promise<DraftControlListItem[]> {
   const rows = await db
     .select({
@@ -150,15 +173,17 @@ export async function listDraftControls(
     )
     .orderBy(asc(draftControls.createdAt), asc(draftControls.controlCode));
 
-  return rows.map(({ authorEmail, authorId, authorName, createdAt, ...draft }) => ({
-    ...draft,
-    author: {
-      email: authorEmail,
-      id: authorId,
-      name: authorName,
-    },
-    createdAt: createdAt.toISOString(),
-  }));
+  return rows
+    .map(({ authorEmail, authorId, authorName, createdAt, ...draft }) => ({
+      ...draft,
+      author: {
+        email: authorEmail,
+        id: authorId,
+        name: authorName,
+      },
+      createdAt: createdAt.toISOString(),
+    }))
+    .filter((draftControl) => matchesDraftControlFilters(draftControl, filters));
 }
 
 export async function createDraftControl(
@@ -298,6 +323,27 @@ export function normalizeDraftControlPublishBody(body: unknown): PublishDraftCon
   };
 }
 
+export function normalizeControlListFilters(
+  query: Record<string, string | string[] | undefined>,
+): ControlListFilters {
+  const releaseImpact = firstQueryValue(query.releaseImpact);
+  const status = firstQueryValue(query.status);
+
+  return {
+    acceptedEvidenceType: firstQueryValue(query.acceptedEvidenceType).trim(),
+    releaseImpact: releaseImpacts.has(releaseImpact) ? (releaseImpact as ReleaseImpact) : '',
+    search: firstQueryValue(query.q).trim(),
+    standardsFramework: firstQueryValue(query.standardsFramework).trim(),
+    status: status === 'archived' ? 'archived' : 'active',
+  };
+}
+
+export function normalizeDraftControlListFilters(
+  query: Record<string, string | string[] | undefined>,
+): DraftControlListFilters {
+  return { search: firstQueryValue(query.q).trim() };
+}
+
 function validateDraftControlInput(input: CreateDraftControlInput) {
   if (!input.controlCode.trim()) {
     throw new DraftControlInputError('Control Code is required.');
@@ -334,6 +380,77 @@ function toStringArray(value: unknown): string[] {
   return Array.isArray(value)
     ? value.filter((entry): entry is string => typeof entry === 'string' && Boolean(entry.trim()))
     : [];
+}
+
+function firstQueryValue(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? (value[0] ?? '') : (value ?? '');
+}
+
+const defaultControlListFilters: ControlListFilters = {
+  acceptedEvidenceType: '',
+  releaseImpact: '',
+  search: '',
+  standardsFramework: '',
+  status: 'active',
+};
+
+const defaultDraftControlListFilters: DraftControlListFilters = { search: '' };
+
+function matchesControlFilters(control: ControlListItem, filters: ControlListFilters): boolean {
+  const version = control.currentVersion;
+  const search = filters.search.toLowerCase();
+
+  if (
+    search &&
+    ![
+      version.controlCode,
+      version.title,
+      version.businessMeaning,
+      ...version.externalStandardsMappings.flatMap((mapping) => [
+        mapping.framework,
+        mapping.reference,
+      ]),
+    ].some((value) => value.toLowerCase().includes(search))
+  ) {
+    return false;
+  }
+
+  if (filters.releaseImpact && version.releaseImpact !== filters.releaseImpact) {
+    return false;
+  }
+
+  if (
+    filters.acceptedEvidenceType &&
+    !version.acceptedEvidenceTypes.some(
+      (value) => value.toLowerCase() === filters.acceptedEvidenceType.toLowerCase(),
+    )
+  ) {
+    return false;
+  }
+
+  if (
+    filters.standardsFramework &&
+    !version.externalStandardsMappings.some(
+      (mapping) => mapping.framework.toLowerCase() === filters.standardsFramework.toLowerCase(),
+    )
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function matchesDraftControlFilters(
+  draftControl: DraftControlListItem,
+  filters: DraftControlListFilters,
+): boolean {
+  const search = filters.search.toLowerCase();
+
+  return search
+    ? [draftControl.controlCode, draftControl.title].some((value) =>
+        value.toLowerCase().includes(search),
+      )
+    : true;
 }
 
 function toExternalStandardsMappings(value: unknown): ExternalStandardsMapping[] {
@@ -394,6 +511,7 @@ function toControlListItem(row: {
       versionNumber: row.versionNumber,
     },
     id: row.controlId,
+    status: 'active',
     title: row.title,
   };
 }

--- a/apps/backend-hono/test/draft-controls.spec.ts
+++ b/apps/backend-hono/test/draft-controls.spec.ts
@@ -126,9 +126,27 @@ async function createDraftControlRequest(
   };
 }
 
-async function listDraftControlsRequest(organizationSlug: string, headers: Headers) {
+function toQueryString(params: Record<string, string | undefined>) {
+  const query = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value) {
+      query.set(key, value);
+    }
+  }
+
+  const value = query.toString();
+
+  return value ? `?${value}` : '';
+}
+
+async function listDraftControlsRequest(
+  organizationSlug: string,
+  headers: Headers,
+  query: Record<string, string | undefined> = {},
+) {
   const response = await app.request(
-    `http://example.com/api/organizations/${organizationSlug}/controls/drafts`,
+    `http://example.com/api/organizations/${organizationSlug}/controls/drafts${toQueryString(query)}`,
     { headers },
   );
 
@@ -167,9 +185,13 @@ async function publishDraftControlRequest(
   };
 }
 
-async function listControlsRequest(organizationSlug: string, headers: Headers) {
+async function listControlsRequest(
+  organizationSlug: string,
+  headers: Headers,
+  query: Record<string, string | undefined> = {},
+) {
   const response = await app.request(
-    `http://example.com/api/organizations/${organizationSlug}/controls`,
+    `http://example.com/api/organizations/${organizationSlug}/controls${toQueryString(query)}`,
     {
       headers,
     },
@@ -427,6 +449,119 @@ describe('Draft Controls', () => {
       getControlRequest(organization.slug, control.id, member.headers),
     ).resolves.toMatchObject({
       body: { control: { controlCode: 'DATA-002', currentVersion: { releaseImpact: 'blocking' } } },
+      status: 200,
+    });
+  });
+
+  it('searches and filters active Controls by current Control fields', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner('control-search');
+    const member = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'control-search-member',
+      role: 'member',
+    });
+
+    const firstDraftResponse = await createDraftControlRequest(organization.slug, ownerHeaders, {
+      controlCode: 'AUTH-008',
+      title: 'Require phishing-resistant MFA',
+    });
+    const secondDraftResponse = await createDraftControlRequest(organization.slug, ownerHeaders, {
+      controlCode: 'DATA-003',
+      title: 'Retain audit logs',
+    });
+    const firstDraft = firstDraftResponse.body.draftControl as { id: string };
+    const secondDraft = secondDraftResponse.body.draftControl as { id: string };
+
+    await publishDraftControlRequest(organization.slug, firstDraft.id, ownerHeaders, {
+      ...completePublishBody,
+      externalStandardsMappings: [
+        { description: 'Logical access controls', framework: 'SOC 2', reference: 'CC6.1' },
+      ],
+    });
+    await publishDraftControlRequest(organization.slug, secondDraft.id, ownerHeaders, {
+      acceptedEvidenceTypes: ['scanner result'],
+      applicabilityConditions: 'Applies to audit log pipelines.',
+      businessMeaning: 'Release teams must preserve audit events for investigation.',
+      externalStandardsMappings: [{ framework: 'ISO 27001', reference: 'A.8.15' }],
+      releaseImpact: 'advisory',
+      verificationMethod: 'Review scanner retention output.',
+    });
+
+    await expect(
+      listControlsRequest(organization.slug, member.headers, { q: 'CC6.1' }),
+    ).resolves.toMatchObject({
+      body: { controls: [{ controlCode: 'AUTH-008' }] },
+      status: 200,
+    });
+    await expect(
+      listControlsRequest(organization.slug, member.headers, { q: 'investigation' }),
+    ).resolves.toMatchObject({
+      body: { controls: [{ controlCode: 'DATA-003' }] },
+      status: 200,
+    });
+    await expect(
+      listControlsRequest(organization.slug, member.headers, { releaseImpact: 'advisory' }),
+    ).resolves.toMatchObject({
+      body: { controls: [{ controlCode: 'DATA-003' }] },
+      status: 200,
+    });
+    await expect(
+      listControlsRequest(organization.slug, member.headers, {
+        acceptedEvidenceType: 'scanner result',
+      }),
+    ).resolves.toMatchObject({
+      body: { controls: [{ controlCode: 'DATA-003' }] },
+      status: 200,
+    });
+    await expect(
+      listControlsRequest(organization.slug, member.headers, { standardsFramework: 'SOC 2' }),
+    ).resolves.toMatchObject({
+      body: { controls: [{ controlCode: 'AUTH-008' }] },
+      status: 200,
+    });
+    await expect(
+      listControlsRequest(organization.slug, member.headers, { status: 'archived' }),
+    ).resolves.toMatchObject({
+      body: { controls: [] },
+      status: 200,
+    });
+  });
+
+  it('searches Draft Controls without weakening draft visibility rules', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner('draft-search-owner');
+    const firstMember = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'draft-search-first-member',
+      role: 'member',
+    });
+    const secondMember = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'draft-search-second-member',
+      role: 'member',
+    });
+
+    await createDraftControlRequest(organization.slug, firstMember.headers, {
+      controlCode: 'AUTH-009',
+      title: 'Review session timeout',
+    });
+    await createDraftControlRequest(organization.slug, secondMember.headers, {
+      controlCode: 'DATA-004',
+      title: 'Classify analytics exports',
+    });
+
+    await expect(
+      listDraftControlsRequest(organization.slug, firstMember.headers, { q: 'DATA' }),
+    ).resolves.toMatchObject({
+      body: { draftControls: [] },
+      status: 200,
+    });
+    await expect(
+      listDraftControlsRequest(organization.slug, ownerHeaders, { q: 'DATA' }),
+    ).resolves.toMatchObject({
+      body: { draftControls: [{ controlCode: 'DATA-004' }] },
       status: 200,
     });
   });

--- a/apps/web/src/components/pages/controls.tsx
+++ b/apps/web/src/components/pages/controls.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import { AlertCircle, CheckCircle2, Plus } from 'lucide-react';
-import { useParams } from 'react-router';
+import { useParams, useSearchParams } from 'react-router';
 import {
   createDraftControl,
   getMembershipResolution,
@@ -29,8 +29,13 @@ function canPublishControls(role: string | null): boolean {
   return role === 'owner' || role === 'admin';
 }
 
+function toStatusFilter(value: string | null) {
+  return value === 'active' || value === 'draft' || value === 'archived' ? value : 'all';
+}
+
 export function ControlsPage() {
   const { organizationSlug } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [controls, setControls] = useState<ControlListItem[]>([]);
   const [draftControls, setDraftControls] = useState<DraftControlListItem[]>([]);
   const [currentRole, setCurrentRole] = useState<string | null>(null);
@@ -41,6 +46,19 @@ export function ControlsPage() {
   const [status, setStatus] = useState<string | null>(null);
   const [controlCode, setControlCode] = useState('');
   const [title, setTitle] = useState('');
+  const search = searchParams.get('q') ?? '';
+  const statusFilter = toStatusFilter(searchParams.get('status'));
+  const releaseImpact = searchParams.get('releaseImpact') ?? '';
+  const acceptedEvidenceType = searchParams.get('acceptedEvidenceType') ?? '';
+  const standardsFramework = searchParams.get('standardsFramework') ?? '';
+  const canListDrafts =
+    (statusFilter === 'all' || statusFilter === 'draft') &&
+    !releaseImpact &&
+    !acceptedEvidenceType &&
+    !standardsFramework;
+  const hasActiveControlFilters = Boolean(
+    search || releaseImpact || acceptedEvidenceType || standardsFramework,
+  );
 
   useEffect(() => {
     const refresh = async () => {
@@ -50,8 +68,18 @@ export function ControlsPage() {
       setError(null);
       try {
         const [controlResponse, draftResponse, resolution] = await Promise.all([
-          listControls(organizationSlug),
-          listDraftControls(organizationSlug),
+          statusFilter === 'draft'
+            ? Promise.resolve({ controls: [] })
+            : listControls(organizationSlug, {
+                acceptedEvidenceType,
+                releaseImpact,
+                search,
+                standardsFramework,
+                status: statusFilter === 'archived' ? 'archived' : 'active',
+              }),
+          canListDrafts
+            ? listDraftControls(organizationSlug, search)
+            : Promise.resolve({ draftControls: [] }),
           getMembershipResolution(),
         ]);
         const organization = resolution.organizations.find((org) => org.slug === organizationSlug);
@@ -69,7 +97,35 @@ export function ControlsPage() {
     };
 
     void refresh();
-  }, [organizationSlug]);
+  }, [
+    acceptedEvidenceType,
+    canListDrafts,
+    organizationSlug,
+    releaseImpact,
+    search,
+    standardsFramework,
+    statusFilter,
+  ]);
+
+  const handleFilterControls = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const formData = new FormData(event.currentTarget);
+    const nextParams = new URLSearchParams();
+    const nextSearch = String(formData.get('q') ?? '').trim();
+    const nextStatus = String(formData.get('status') ?? 'all');
+    const nextReleaseImpact = String(formData.get('releaseImpact') ?? '');
+    const nextAcceptedEvidenceType = String(formData.get('acceptedEvidenceType') ?? '').trim();
+    const nextStandardsFramework = String(formData.get('standardsFramework') ?? '').trim();
+
+    if (nextSearch) nextParams.set('q', nextSearch);
+    if (nextStatus !== 'all') nextParams.set('status', nextStatus);
+    if (nextReleaseImpact) nextParams.set('releaseImpact', nextReleaseImpact);
+    if (nextAcceptedEvidenceType) nextParams.set('acceptedEvidenceType', nextAcceptedEvidenceType);
+    if (nextStandardsFramework) nextParams.set('standardsFramework', nextStandardsFramework);
+
+    setSearchParams(nextParams);
+  };
 
   const handleCreateDraftControl = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -118,7 +174,9 @@ export function ControlsPage() {
         verificationMethod: String(formData.get('verificationMethod') ?? ''),
       });
 
-      setControls((currentControls) => [...currentControls, response.control]);
+      if ((statusFilter === 'all' || statusFilter === 'active') && !hasActiveControlFilters) {
+        setControls((currentControls) => [...currentControls, response.control]);
+      }
       setDraftControls((currentDrafts) =>
         currentDrafts.filter((currentDraft) => currentDraft.id !== draftControl.id),
       );
@@ -203,6 +261,73 @@ export function ControlsPage() {
             Published Controls are visible to every Organization member.
           </p>
         </div>
+        <form className="rounded-xl border bg-card p-4" onSubmit={handleFilterControls}>
+          <div className="grid gap-4 md:grid-cols-5">
+            <div className="space-y-2 md:col-span-2">
+              <Label htmlFor="control-search">Search Controls</Label>
+              <Input
+                id="control-search"
+                name="q"
+                defaultValue={search}
+                placeholder="Control Code, title, meaning, or standard"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="control-status-filter">Status</Label>
+              <select
+                id="control-status-filter"
+                name="status"
+                className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                defaultValue={statusFilter}
+              >
+                <option value="all">All current</option>
+                <option value="active">Active</option>
+                <option value="draft">Draft</option>
+                <option value="archived">Archived</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="release-impact-filter">Release Impact</Label>
+              <select
+                id="release-impact-filter"
+                name="releaseImpact"
+                className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                defaultValue={releaseImpact}
+              >
+                <option value="">Any</option>
+                <option value="blocking">blocking</option>
+                <option value="needs review">needs review</option>
+                <option value="advisory">advisory</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="evidence-type-filter">Accepted Evidence Type</Label>
+              <Input
+                id="evidence-type-filter"
+                name="acceptedEvidenceType"
+                defaultValue={acceptedEvidenceType}
+                placeholder="document"
+              />
+            </div>
+          </div>
+          <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-end">
+            <div className="flex-1 space-y-2">
+              <Label htmlFor="standards-framework-filter">Standards framework</Label>
+              <Input
+                id="standards-framework-filter"
+                name="standardsFramework"
+                defaultValue={standardsFramework}
+                placeholder="SOC 2"
+              />
+            </div>
+            <div className="flex gap-2">
+              <Button type="submit">Apply filters</Button>
+              <Button type="button" variant="outline" onClick={() => setSearchParams({})}>
+                Clear
+              </Button>
+            </div>
+          </div>
+        </form>
         {isLoading ? (
           <p className="text-sm text-muted-foreground">Loading Controls...</p>
         ) : controls.length === 0 ? (

--- a/apps/web/src/features/auth/auth-api.ts
+++ b/apps/web/src/features/auth/auth-api.ts
@@ -91,7 +91,16 @@ export type ControlListItem = {
     versionNumber: number;
   };
   id: string;
+  status: 'active';
   title: string;
+};
+
+export type ControlListFilters = {
+  acceptedEvidenceType?: string;
+  releaseImpact?: string;
+  search?: string;
+  standardsFramework?: string;
+  status?: 'active' | 'archived';
 };
 
 export type OrganizationMemberListItem = {
@@ -242,18 +251,42 @@ export function createProject(
   });
 }
 
-export function listDraftControls(organizationSlug: string) {
+function toQueryString(params: Record<string, string | undefined>) {
+  const query = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value) {
+      query.set(key, value);
+    }
+  }
+
+  const value = query.toString();
+
+  return value ? `?${value}` : '';
+}
+
+export function listDraftControls(organizationSlug: string, search = '') {
+  const query = toQueryString({ q: search });
+
   return request<{ draftControls: DraftControlListItem[] }>(
-    `/api/organizations/${organizationSlug}/controls/drafts`,
+    `/api/organizations/${organizationSlug}/controls/drafts${query}`,
     {
       method: 'GET',
     },
   );
 }
 
-export function listControls(organizationSlug: string) {
+export function listControls(organizationSlug: string, filters: ControlListFilters = {}) {
+  const query = toQueryString({
+    acceptedEvidenceType: filters.acceptedEvidenceType,
+    q: filters.search,
+    releaseImpact: filters.releaseImpact,
+    standardsFramework: filters.standardsFramework,
+    status: filters.status,
+  });
+
   return request<{ controls: ControlListItem[] }>(
-    `/api/organizations/${organizationSlug}/controls`,
+    `/api/organizations/${organizationSlug}/controls${query}`,
     {
       method: 'GET',
     },


### PR DESCRIPTION
## Summary
- Add Control Library query params for searching active Controls and filtering by status, Release Impact, Accepted Evidence Type, and standards framework.
- Add Control Library UI controls backed by URL query params for active, draft, and archived status views.
- Cover active Control filtering and Draft Control search visibility with backend tests.

Closes #29