### PR TITLE
Configure Control Approval Policy

### DIFF
--- a/apps/backend-hono/drizzle/migrations/0005_control_approval_policy.sql
+++ b/apps/backend-hono/drizzle/migrations/0005_control_approval_policy.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `organizations` ADD `control_approval_policy_enabled` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `organizations` ADD `control_approval_required_count` integer DEFAULT 1 NOT NULL;

--- a/apps/backend-hono/src/db/schema.ts
+++ b/apps/backend-hono/src/db/schema.ts
@@ -26,6 +26,10 @@ export const organizations = sqliteTable(
     slug: text('slug').notNull().unique(),
     logo: text('logo'),
     metadata: text('metadata'),
+    controlApprovalPolicyEnabled: integer('control_approval_policy_enabled', { mode: 'boolean' })
+      .default(false)
+      .notNull(),
+    controlApprovalRequiredCount: integer('control_approval_required_count').default(1).notNull(),
     createdAt: integer('created_at', { mode: 'timestamp_ms' })
       .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
       .notNull(),

--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -4,6 +4,13 @@ import { auth } from './lib/auth';
 import { env } from 'cloudflare:workers';
 import { resolveInvitationEntryState, resolveMembershipResolution } from './lib/auth-organization';
 import {
+  canManageControlApprovalPolicy,
+  ControlApprovalPolicyInputError,
+  getControlApprovalPolicy,
+  normalizeControlApprovalPolicyUpdateBody,
+  updateControlApprovalPolicy,
+} from './lib/control-approval-policy';
+import {
   canPublishControls,
   ControlPublishInputError,
   createDraftControl,
@@ -99,6 +106,68 @@ app.get('/api/organizations/:organizationSlug/members', async (c) => {
   }
 
   return c.json({ members: await listOrganizationMembers(membership.organizationId) });
+});
+
+app.get('/api/organizations/:organizationSlug/control-approval-policy', async (c) => {
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(
+    c.req.param('organizationSlug'),
+    session.user.id,
+  );
+
+  if (!membership) {
+    return c.json({ error: 'Organization not found' }, 404);
+  }
+
+  return c.json({ policy: await getControlApprovalPolicy(membership.organizationId) });
+});
+
+app.patch('/api/organizations/:organizationSlug/control-approval-policy', async (c) => {
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(
+    c.req.param('organizationSlug'),
+    session.user.id,
+  );
+
+  if (!membership) {
+    return c.json({ error: 'Organization not found' }, 404);
+  }
+
+  if (!canManageControlApprovalPolicy(membership.role)) {
+    return c.json(
+      { error: 'Only Organization owners and admins can edit Control Approval Policy.' },
+      403,
+    );
+  }
+
+  try {
+    const policy = await updateControlApprovalPolicy(
+      membership,
+      normalizeControlApprovalPolicyUpdateBody(await c.req.json().catch(() => null)),
+    );
+
+    return c.json({ policy });
+  } catch (caughtError) {
+    if (caughtError instanceof ControlApprovalPolicyInputError) {
+      return c.json({ error: caughtError.message }, 400);
+    }
+
+    throw caughtError;
+  }
 });
 
 app.get('/api/organizations/:organizationSlug/projects', async (c) => {

--- a/apps/backend-hono/src/lib/control-approval-policy.ts
+++ b/apps/backend-hono/src/lib/control-approval-policy.ts
@@ -1,0 +1,120 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import { db } from '../db/client';
+import { members, organizations } from '../db/schema';
+import type { OrganizationMembership } from './projects';
+
+const editableOrganizationRoles = new Set(['owner', 'admin']);
+
+export type ControlApprovalPolicyResponse = {
+  enabled: boolean;
+  maxRequiredApprovals: number;
+  requiredApprovals: number;
+};
+
+type ControlApprovalPolicyUpdateInput = {
+  enabled: boolean;
+  requiredApprovals: number;
+};
+
+export class ControlApprovalPolicyInputError extends Error {}
+
+export function canManageControlApprovalPolicy(role: string): boolean {
+  return editableOrganizationRoles.has(role);
+}
+
+export function normalizeControlApprovalPolicyUpdateBody(
+  body: unknown,
+): ControlApprovalPolicyUpdateInput {
+  if (!body || typeof body !== 'object') {
+    throw new ControlApprovalPolicyInputError('Control Approval Policy settings are required.');
+  }
+
+  const record = body as Record<string, unknown>;
+
+  if (typeof record.enabled !== 'boolean') {
+    throw new ControlApprovalPolicyInputError('Control Approval Policy enabled state is required.');
+  }
+
+  const requiredApprovals = record.enabled ? (record.requiredApprovals ?? 1) : 1;
+
+  if (!Number.isInteger(requiredApprovals) || typeof requiredApprovals !== 'number') {
+    throw new ControlApprovalPolicyInputError('Required approval count must be a whole number.');
+  }
+
+  if (requiredApprovals < 1) {
+    throw new ControlApprovalPolicyInputError('Required approval count must be at least 1.');
+  }
+
+  return {
+    enabled: record.enabled,
+    requiredApprovals,
+  };
+}
+
+export async function getControlApprovalPolicy(
+  organizationId: string,
+): Promise<ControlApprovalPolicyResponse> {
+  const organization = await db
+    .select({
+      enabled: organizations.controlApprovalPolicyEnabled,
+      requiredApprovals: organizations.controlApprovalRequiredCount,
+    })
+    .from(organizations)
+    .where(eq(organizations.id, organizationId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!organization) {
+    throw new ControlApprovalPolicyInputError('Organization not found.');
+  }
+
+  return {
+    enabled: organization.enabled,
+    maxRequiredApprovals: await getMaxRequiredApprovals(organizationId),
+    requiredApprovals: organization.requiredApprovals,
+  };
+}
+
+export async function updateControlApprovalPolicy(
+  membership: OrganizationMembership,
+  input: ControlApprovalPolicyUpdateInput,
+): Promise<ControlApprovalPolicyResponse> {
+  const maxRequiredApprovals = await getMaxRequiredApprovals(membership.organizationId);
+
+  if (input.enabled && maxRequiredApprovals < 1) {
+    throw new ControlApprovalPolicyInputError(
+      'Control Approval Policy needs at least two Organization owners/admins before it can be enabled.',
+    );
+  }
+
+  if (input.enabled && input.requiredApprovals > maxRequiredApprovals) {
+    throw new ControlApprovalPolicyInputError(
+      'Required approval count cannot exceed eligible approvers other than the author.',
+    );
+  }
+
+  await db
+    .update(organizations)
+    .set({
+      controlApprovalPolicyEnabled: input.enabled,
+      controlApprovalRequiredCount: input.requiredApprovals,
+    })
+    .where(eq(organizations.id, membership.organizationId));
+
+  return {
+    enabled: input.enabled,
+    maxRequiredApprovals,
+    requiredApprovals: input.requiredApprovals,
+  };
+}
+
+async function getMaxRequiredApprovals(organizationId: string): Promise<number> {
+  const eligibleApprovers = await db
+    .select({ id: members.id })
+    .from(members)
+    .where(
+      and(eq(members.organizationId, organizationId), inArray(members.role, ['owner', 'admin'])),
+    );
+
+  return Math.max(eligibleApprovers.length - 1, 0);
+}

--- a/apps/backend-hono/test/control-approval-policy.spec.ts
+++ b/apps/backend-hono/test/control-approval-policy.spec.ts
@@ -1,0 +1,298 @@
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import app from '../src/index';
+import { db } from '../src/db/client';
+import { organizations, users } from '../src/db/schema';
+import { auth } from '../src/lib/auth';
+
+const authHeaders = {
+  origin: 'http://localhost:5173',
+  host: 'localhost:8787',
+};
+const verificationCallbackURL = 'http://localhost:8787/sign-in';
+const mailpitSendUrl = 'http://127.0.0.1:8025/api/v1/send';
+
+function createCredentials(prefix: string) {
+  const token = crypto.randomUUID();
+
+  return {
+    name: `${prefix} user`,
+    email: `${prefix}-${token}@example.com`,
+    password: `Password-${token}`,
+  };
+}
+
+async function signUpUser(credentials: ReturnType<typeof createCredentials>) {
+  await auth.api.signUpEmail({
+    body: {
+      ...credentials,
+      callbackURL: verificationCallbackURL,
+    },
+    headers: authHeaders,
+  });
+
+  await db.update(users).set({ emailVerified: true }).where(eq(users.email, credentials.email));
+}
+
+async function signInUser(credentials: ReturnType<typeof createCredentials>) {
+  const result = await auth.api.signInEmail({
+    body: {
+      email: credentials.email,
+      password: credentials.password,
+    },
+    headers: authHeaders,
+    returnHeaders: true,
+  });
+
+  const sessionCookie = result.headers.get('set-cookie');
+
+  expect(sessionCookie).toBeTruthy();
+
+  if (!sessionCookie) {
+    throw new Error('Expected Better Auth to return a session cookie.');
+  }
+
+  const cookie = sessionCookie.split(';', 1)[0] ?? sessionCookie;
+
+  return new Headers({
+    ...authHeaders,
+    cookie,
+  });
+}
+
+async function createSignedInOwner(prefix: string) {
+  const credentials = createCredentials(prefix);
+
+  await signUpUser(credentials);
+
+  const headers = await signInUser(credentials);
+  const organization = (await auth.api.listOrganizations({ headers }))[0];
+
+  expect(organization?.id).toBeTruthy();
+
+  if (!organization?.id) {
+    throw new Error('Expected a default organization.');
+  }
+
+  return { headers, organization };
+}
+
+async function createSignedInMember(input: {
+  ownerHeaders: Headers;
+  organizationId: string;
+  prefix: string;
+  role: 'admin' | 'member';
+}) {
+  const credentials = createCredentials(input.prefix);
+
+  await signUpUser(credentials);
+
+  const invitation = await auth.api.createInvitation({
+    body: {
+      email: credentials.email,
+      organizationId: input.organizationId,
+      role: input.role,
+    },
+    headers: input.ownerHeaders,
+  });
+  const headers = await signInUser(credentials);
+
+  await auth.api.acceptInvitation({
+    body: { invitationId: invitation.id },
+    headers,
+  });
+
+  return { headers };
+}
+
+async function getPolicyRequest(organizationSlug: string, headers: Headers) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/control-approval-policy`,
+    { headers },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function updatePolicyRequest(
+  organizationSlug: string,
+  headers: Headers,
+  body: Record<string, unknown>,
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/control-approval-policy`,
+    {
+      body: JSON.stringify(body),
+      headers,
+      method: 'PATCH',
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+beforeEach(() => {
+  const originalFetch = globalThis.fetch;
+
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+    if (url === mailpitSendUrl) {
+      return new Response(null, { status: 200 });
+    }
+
+    return originalFetch(input, init);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Control Approval Policy', () => {
+  it('lets Organization owners enable policy with a default required approval count', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner('policy-owner');
+
+    await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'policy-admin',
+      role: 'admin',
+    });
+
+    await expect(getPolicyRequest(organization.slug, ownerHeaders)).resolves.toMatchObject({
+      body: {
+        policy: {
+          enabled: false,
+          maxRequiredApprovals: 1,
+          requiredApprovals: 1,
+        },
+      },
+      status: 200,
+    });
+
+    const updateResponse = await updatePolicyRequest(organization.slug, ownerHeaders, {
+      enabled: true,
+    });
+
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.body.policy).toMatchObject({
+      enabled: true,
+      maxRequiredApprovals: 1,
+      requiredApprovals: 1,
+    });
+
+    await expect(
+      db
+        .select({
+          enabled: organizations.controlApprovalPolicyEnabled,
+          requiredCount: organizations.controlApprovalRequiredCount,
+        })
+        .from(organizations)
+        .where(eq(organizations.id, organization.id))
+        .limit(1)
+        .then((rows) => rows[0]),
+    ).resolves.toMatchObject({ enabled: true, requiredCount: 1 });
+  });
+
+  it('lets Organization admins configure required approval count within eligible approver limits', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner('policy-admin-owner');
+    const firstAdmin = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'policy-first-admin',
+      role: 'admin',
+    });
+
+    await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'policy-second-admin',
+      role: 'admin',
+    });
+
+    await expect(
+      updatePolicyRequest(organization.slug, firstAdmin.headers, {
+        enabled: true,
+        requiredApprovals: 2,
+      }),
+    ).resolves.toMatchObject({
+      body: {
+        policy: {
+          enabled: true,
+          maxRequiredApprovals: 2,
+          requiredApprovals: 2,
+        },
+      },
+      status: 200,
+    });
+  });
+
+  it('prevents members and impossible approval counts from changing policy', async () => {
+    const { headers: ownerHeaders, organization } =
+      await createSignedInOwner('policy-invalid-owner');
+    const member = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'policy-member',
+      role: 'member',
+    });
+
+    await expect(
+      updatePolicyRequest(organization.slug, member.headers, {
+        enabled: true,
+        requiredApprovals: 1,
+      }),
+    ).resolves.toMatchObject({ status: 403 });
+
+    await expect(
+      updatePolicyRequest(organization.slug, ownerHeaders, {
+        enabled: true,
+        requiredApprovals: 1,
+      }),
+    ).resolves.toMatchObject({
+      body: {
+        error:
+          'Control Approval Policy needs at least two Organization owners/admins before it can be enabled.',
+      },
+      status: 400,
+    });
+
+    await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'policy-invalid-admin',
+      role: 'admin',
+    });
+
+    await expect(
+      updatePolicyRequest(organization.slug, ownerHeaders, {
+        enabled: true,
+        requiredApprovals: 2,
+      }),
+    ).resolves.toMatchObject({
+      body: {
+        error: 'Required approval count cannot exceed eligible approvers other than the author.',
+      },
+      status: 400,
+    });
+
+    await expect(
+      updatePolicyRequest(organization.slug, ownerHeaders, {
+        enabled: true,
+        requiredApprovals: 0,
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Required approval count must be at least 1.' },
+      status: 400,
+    });
+  });
+});

--- a/apps/web/src/components/pages/settings.tsx
+++ b/apps/web/src/components/pages/settings.tsx
@@ -3,7 +3,10 @@ import type { FormEvent } from 'react';
 import { AlertCircle, CheckCircle2, Copy } from 'lucide-react';
 import {
   createOrganizationInvitation,
+  getControlApprovalPolicy,
   getMembershipResolution,
+  updateControlApprovalPolicy,
+  type ControlApprovalPolicy,
   type MembershipResolutionResponse,
 } from '../../features/auth/auth-api';
 import { humanizeAuthError } from '../../features/auth/auth-errors';
@@ -28,6 +31,13 @@ export function SettingsPage() {
   const [isSubmittingInvite, setIsSubmittingInvite] = useState(false);
   const [copied, setCopied] = useState(false);
 
+  const [policy, setPolicy] = useState<ControlApprovalPolicy | null>(null);
+  const [policyEnabled, setPolicyEnabled] = useState(false);
+  const [requiredApprovals, setRequiredApprovals] = useState('1');
+  const [policyError, setPolicyError] = useState<string | null>(null);
+  const [policyStatus, setPolicyStatus] = useState<string | null>(null);
+  const [isSubmittingPolicy, setIsSubmittingPolicy] = useState(false);
+
   useEffect(() => {
     let cancelled = false;
     async function loadResolution() {
@@ -48,6 +58,43 @@ export function SettingsPage() {
 
   const activeOrg =
     resolution?.organizations.find((org) => org.id === resolution.activeOrganizationId) ?? null;
+  const canManagePolicy = activeOrg?.role === 'owner' || activeOrg?.role === 'admin';
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadPolicy() {
+      if (!activeOrg) {
+        setPolicy(null);
+        return;
+      }
+
+      try {
+        const response = await getControlApprovalPolicy(activeOrg.slug);
+        if (cancelled) return;
+
+        setPolicy(response.policy);
+        setPolicyEnabled(response.policy.enabled);
+        setRequiredApprovals(String(response.policy.requiredApprovals));
+      } catch (caughtError) {
+        if (cancelled) return;
+
+        const rawMessage =
+          caughtError instanceof Error
+            ? caughtError.message
+            : 'Unable to load Control Approval Policy.';
+        setPolicyError(
+          humanizeAuthError(null, rawMessage, 'Unable to load Control Approval Policy.'),
+        );
+      }
+    }
+
+    void loadPolicy();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeOrg]);
 
   const handleInviteSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -83,6 +130,52 @@ export function SettingsPage() {
     }
   };
 
+  const handlePolicySubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!activeOrg || !policy) return;
+
+    setPolicyError(null);
+    setPolicyStatus(null);
+
+    const nextRequiredApprovals = policyEnabled ? Number(requiredApprovals) : 1;
+
+    if (!Number.isInteger(nextRequiredApprovals) || nextRequiredApprovals < 1) {
+      setPolicyError('Required approval count must be at least 1.');
+      return;
+    }
+
+    if (policyEnabled && nextRequiredApprovals > policy.maxRequiredApprovals) {
+      setPolicyError(
+        'Required approval count cannot exceed eligible approvers other than the author.',
+      );
+      return;
+    }
+
+    setIsSubmittingPolicy(true);
+
+    try {
+      const response = await updateControlApprovalPolicy(activeOrg.slug, {
+        enabled: policyEnabled,
+        requiredApprovals: nextRequiredApprovals,
+      });
+
+      setPolicy(response.policy);
+      setPolicyEnabled(response.policy.enabled);
+      setRequiredApprovals(String(response.policy.requiredApprovals));
+      setPolicyStatus('Control Approval Policy saved.');
+    } catch (caughtError) {
+      const rawMessage =
+        caughtError instanceof Error
+          ? caughtError.message
+          : 'Unable to save Control Approval Policy.';
+      setPolicyError(
+        humanizeAuthError(null, rawMessage, 'Unable to save Control Approval Policy.'),
+      );
+    } finally {
+      setIsSubmittingPolicy(false);
+    }
+  };
+
   return (
     <div className="mx-auto w-full max-w-2xl space-y-10">
       <header className="space-y-1">
@@ -91,6 +184,93 @@ export function SettingsPage() {
           Manage your organization and the people who have access to it.
         </p>
       </header>
+
+      <Separator />
+
+      <section className="space-y-6">
+        <div className="space-y-1">
+          <h2 className="text-lg font-medium">Control Approval Policy</h2>
+          <p className="text-sm text-muted-foreground">
+            Require approval before Organization owners and admins publish Controls or Control
+            updates.
+          </p>
+        </div>
+
+        {!canManagePolicy && activeOrg ? (
+          <Alert>
+            <AlertCircle />
+            <AlertTitle>Read-only policy</AlertTitle>
+            <AlertDescription>
+              Only Organization owners and admins can edit Control Approval Policy.
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        <form className="space-y-5" onSubmit={handlePolicySubmit}>
+          <div className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              <Label htmlFor="control-approval-enabled">Require approval to publish Controls</Label>
+              <p className="text-sm text-muted-foreground">
+                When enabled, publish actions need approval from eligible Organization owners/admins
+                other than the author.
+              </p>
+            </div>
+            <input
+              id="control-approval-enabled"
+              type="checkbox"
+              className="size-5"
+              checked={policyEnabled}
+              onChange={(event) => {
+                setPolicyEnabled(event.target.checked);
+                if (event.target.checked && requiredApprovals === '') setRequiredApprovals('1');
+              }}
+              disabled={!activeOrg || !canManagePolicy || !policy || isSubmittingPolicy}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="required-approvals">Required approval count</Label>
+            <Input
+              id="required-approvals"
+              type="number"
+              min={1}
+              max={policy?.maxRequiredApprovals || 1}
+              value={requiredApprovals}
+              onChange={(event) => setRequiredApprovals(event.target.value)}
+              disabled={!activeOrg || !canManagePolicy || !policyEnabled || isSubmittingPolicy}
+            />
+            <p className="text-sm text-muted-foreground">
+              {policy
+                ? `Maximum currently allowed: ${policy.maxRequiredApprovals}. Add more Organization owners/admins before requiring more approvals.`
+                : 'Loading approval limits...'}
+            </p>
+          </div>
+
+          {policyError ? (
+            <Alert variant="destructive">
+              <AlertCircle />
+              <AlertTitle>Couldn’t save policy</AlertTitle>
+              <AlertDescription>{policyError}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          {policyStatus ? (
+            <Alert>
+              <CheckCircle2 />
+              <AlertTitle>{policyStatus}</AlertTitle>
+            </Alert>
+          ) : null}
+
+          <div>
+            <Button
+              type="submit"
+              disabled={!activeOrg || !canManagePolicy || !policy || isSubmittingPolicy}
+            >
+              {isSubmittingPolicy ? 'Saving...' : 'Save policy'}
+            </Button>
+          </div>
+        </form>
+      </section>
 
       <Separator />
 

--- a/apps/web/src/features/auth/auth-api.ts
+++ b/apps/web/src/features/auth/auth-api.ts
@@ -101,6 +101,12 @@ export type OrganizationMemberListItem = {
   role: string;
 };
 
+export type ControlApprovalPolicy = {
+  enabled: boolean;
+  maxRequiredApprovals: number;
+  requiredApprovals: number;
+};
+
 type ApiErrorBody = {
   error?:
     | {
@@ -212,6 +218,28 @@ export function listOrganizationMembers(organizationSlug: string) {
     `/api/organizations/${organizationSlug}/members`,
     {
       method: 'GET',
+    },
+  );
+}
+
+export function getControlApprovalPolicy(organizationSlug: string) {
+  return request<{ policy: ControlApprovalPolicy }>(
+    `/api/organizations/${organizationSlug}/control-approval-policy`,
+    {
+      method: 'GET',
+    },
+  );
+}
+
+export function updateControlApprovalPolicy(
+  organizationSlug: string,
+  input: { enabled: boolean; requiredApprovals: number },
+) {
+  return request<{ policy: ControlApprovalPolicy }>(
+    `/api/organizations/${organizationSlug}/control-approval-policy`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify(input),
     },
   );
 }


### PR DESCRIPTION
## Summary
- Add Organization-scoped Control Approval Policy storage and API endpoints.
- Add settings UI for owners/admins to enable approval and configure required approval count.
- Validate impossible approval counts in API and UI, with backend coverage.

## Checks
- pnpm format:check
- pnpm lint
- pnpm check-types
- pnpm test
- pnpm build

Closes #25