### PR TITLE
Archive and restore published Controls

### DIFF
--- a/apps/backend-hono/drizzle/migrations/0005_archived_controls.sql
+++ b/apps/backend-hono/drizzle/migrations/0005_archived_controls.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `controls` ADD `archived_at` integer;--> statement-breakpoint
+ALTER TABLE `controls` ADD `archived_by_member_id` text REFERENCES `members`(`id`) ON UPDATE no action ON DELETE set null;--> statement-breakpoint
+ALTER TABLE `controls` ADD `archive_reason` text;--> statement-breakpoint
+CREATE INDEX `control_archived_by_member_id_idx` ON `controls` (`archived_by_member_id`);

--- a/apps/backend-hono/src/db/schema.ts
+++ b/apps/backend-hono/src/db/schema.ts
@@ -221,6 +221,11 @@ export const controls = sqliteTable(
       .references(() => organizations.id, { onDelete: 'cascade' }),
     currentVersionId: text('current_version_id'),
     currentControlCode: text('current_control_code').notNull(),
+    archivedAt: integer('archived_at', { mode: 'timestamp_ms' }),
+    archivedByMemberId: text('archived_by_member_id').references(() => members.id, {
+      onDelete: 'set null',
+    }),
+    archiveReason: text('archive_reason'),
     createdAt: integer('created_at', { mode: 'timestamp_ms' })
       .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
       .notNull(),
@@ -231,6 +236,7 @@ export const controls = sqliteTable(
   },
   (table) => [
     index('control_organization_id_idx').on(table.organizationId),
+    index('control_archived_by_member_id_idx').on(table.archivedByMemberId),
     uniqueIndex('control_organization_code_unique').on(
       table.organizationId,
       table.currentControlCode,

--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -4,16 +4,20 @@ import { auth } from './lib/auth';
 import { env } from 'cloudflare:workers';
 import { resolveInvitationEntryState, resolveMembershipResolution } from './lib/auth-organization';
 import {
+  canArchiveControls,
   canPublishControls,
+  cancelDraftControl,
   ControlPublishInputError,
   createDraftControl,
   DraftControlInputError,
   getControlDetail,
   listControls,
   listDraftControls,
+  normalizeControlArchiveBody,
   normalizeDraftControlCreateBody,
   normalizeDraftControlPublishBody,
   publishDraftControl,
+  setControlArchivedForMembership,
 } from './lib/controls';
 import {
   canManageProjects,
@@ -163,7 +167,16 @@ app.get('/api/organizations/:organizationSlug/controls', async (c) => {
     return c.json({ error: 'Organization not found' }, 404);
   }
 
-  return c.json({ controls: await listControls(membership.organizationId) });
+  const status = c.req.query('status') === 'archived' ? 'archived' : 'active';
+
+  if (status === 'archived' && !canArchiveControls(membership.role)) {
+    return c.json(
+      { error: 'Only Organization owners and admins can view archived Controls.' },
+      403,
+    );
+  }
+
+  return c.json({ controls: await listControls(membership.organizationId, status) });
 });
 
 app.get('/api/organizations/:organizationSlug/controls/:controlId', async (c) => {
@@ -272,6 +285,41 @@ app.post(
     }
   },
 );
+
+app.delete('/api/organizations/:organizationSlug/controls/drafts/:draftControlId', async (c) => {
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(
+    c.req.param('organizationSlug'),
+    session.user.id,
+  );
+
+  if (!membership) {
+    return c.json({ error: 'Draft Control unavailable' }, 404);
+  }
+
+  const canceled = await cancelDraftControl(membership, c.req.param('draftControlId'));
+
+  if (!canceled) {
+    return c.json({ error: 'Draft Control unavailable' }, 404);
+  }
+
+  return c.json({ canceled: true });
+});
+
+app.patch('/api/organizations/:organizationSlug/controls/:controlId/archive', async (c) => {
+  return setControlArchived(c, true);
+});
+
+app.patch('/api/organizations/:organizationSlug/controls/:controlId/restore', async (c) => {
+  return setControlArchived(c, false);
+});
 
 app.post('/api/organizations/:organizationSlug/projects', async (c) => {
   const session = await auth.api.getSession({
@@ -426,6 +474,54 @@ async function setProjectArchived(c: Context, archived: boolean) {
   }
 
   return c.json({ project });
+}
+
+async function setControlArchived(c: Context, archived: boolean) {
+  const organizationSlug = c.req.param('organizationSlug');
+  const controlId = c.req.param('controlId');
+
+  if (!organizationSlug || !controlId) {
+    return c.json({ error: 'Control unavailable' }, 404);
+  }
+
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(organizationSlug, session.user.id);
+
+  if (!membership) {
+    return c.json({ error: 'Control unavailable' }, 404);
+  }
+
+  if (!canArchiveControls(membership.role)) {
+    return c.json(
+      {
+        error: `Only Organization owners and admins can ${archived ? 'archive' : 'restore'} Controls.`,
+      },
+      403,
+    );
+  }
+
+  const archiveReason = archived
+    ? normalizeControlArchiveBody(await c.req.json().catch(() => null)).reason
+    : undefined;
+  const control = await setControlArchivedForMembership({
+    archived,
+    controlId,
+    membership,
+    reason: archiveReason,
+  });
+
+  if (!control) {
+    return c.json({ error: 'Control unavailable' }, 404);
+  }
+
+  return c.json({ control });
 }
 
 app.on(['POST', 'GET'], '/api/auth/*', (c) => auth.handler(c.req.raw));

--- a/apps/backend-hono/src/lib/controls.ts
+++ b/apps/backend-hono/src/lib/controls.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq } from 'drizzle-orm';
+import { and, asc, eq, isNotNull, isNull } from 'drizzle-orm';
 import { db } from '../db/client';
 import { controls, controlVersions, draftControls, members, users } from '../db/schema';
 import type { OrganizationMembership } from './projects';
@@ -30,6 +30,8 @@ export type ControlVersionResponse = {
 };
 
 export type ControlListItem = {
+  archivedAt: string | null;
+  archiveReason: string | null;
   controlCode: string;
   createdAt: string;
   currentVersion: ControlVersionResponse;
@@ -59,8 +61,13 @@ type PublishDraftControlInput = {
   verificationMethod: string;
 };
 
+type ArchiveControlInput = {
+  reason: string;
+};
+
 const draftReviewerRoles = new Set(['owner', 'admin']);
 const publishControlRoles = new Set(['owner', 'admin']);
+const archiveControlRoles = new Set(['owner', 'admin']);
 const releaseImpacts = new Set(['advisory', 'blocking', 'needs review']);
 
 export class DraftControlInputError extends Error {}
@@ -70,10 +77,19 @@ export function canPublishControls(role: string): boolean {
   return publishControlRoles.has(role);
 }
 
-export async function listControls(organizationId: string): Promise<ControlListItem[]> {
+export function canArchiveControls(role: string): boolean {
+  return archiveControlRoles.has(role);
+}
+
+export async function listControls(
+  organizationId: string,
+  status: 'active' | 'archived' = 'active',
+): Promise<ControlListItem[]> {
   const rows = await db
     .select({
       acceptedEvidenceTypes: controlVersions.acceptedEvidenceTypes,
+      archivedAt: controls.archivedAt,
+      archiveReason: controls.archiveReason,
       applicabilityConditions: controlVersions.applicabilityConditions,
       businessMeaning: controlVersions.businessMeaning,
       controlCode: controlVersions.controlCode,
@@ -89,7 +105,12 @@ export async function listControls(organizationId: string): Promise<ControlListI
     })
     .from(controls)
     .innerJoin(controlVersions, eq(controls.currentVersionId, controlVersions.id))
-    .where(eq(controls.organizationId, organizationId))
+    .where(
+      and(
+        eq(controls.organizationId, organizationId),
+        status === 'archived' ? isNotNull(controls.archivedAt) : isNull(controls.archivedAt),
+      ),
+    )
     .orderBy(asc(controlVersions.controlCode), asc(controlVersions.title));
 
   return rows.map((row) => toControlListItem(row));
@@ -102,6 +123,8 @@ export async function getControlDetail(
   const row = await db
     .select({
       acceptedEvidenceTypes: controlVersions.acceptedEvidenceTypes,
+      archivedAt: controls.archivedAt,
+      archiveReason: controls.archiveReason,
       applicabilityConditions: controlVersions.applicabilityConditions,
       businessMeaning: controlVersions.businessMeaning,
       controlCode: controlVersions.controlCode,
@@ -121,7 +144,11 @@ export async function getControlDetail(
     .limit(1)
     .then((rows) => rows[0] ?? null);
 
-  return row ? toControlListItem(row) : null;
+  if (!row || (row.archivedAt && !archiveControlRoles.has(membership.role))) {
+    return null;
+  }
+
+  return toControlListItem(row);
 }
 
 export async function listDraftControls(
@@ -167,13 +194,14 @@ export async function createDraftControl(
 ): Promise<DraftControlListItem> {
   validateDraftControlInput(input);
 
+  const trimmedControlCode = input.controlCode.trim();
   const existingDraft = await db
     .select({ id: draftControls.id })
     .from(draftControls)
     .where(
       and(
         eq(draftControls.organizationId, membership.organizationId),
-        eq(draftControls.controlCode, input.controlCode.trim()),
+        eq(draftControls.controlCode, trimmedControlCode),
       ),
     )
     .limit(1)
@@ -183,10 +211,26 @@ export async function createDraftControl(
     throw new DraftControlInputError('Control Code is already used in this Organization.');
   }
 
+  const existingControl = await db
+    .select({ id: controls.id })
+    .from(controls)
+    .where(
+      and(
+        eq(controls.organizationId, membership.organizationId),
+        eq(controls.currentControlCode, trimmedControlCode),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existingControl) {
+    throw new DraftControlInputError('Control Code is already used in this Organization.');
+  }
+
   const now = new Date();
   const draft = {
     authorMemberId: membership.id,
-    controlCode: input.controlCode.trim(),
+    controlCode: trimmedControlCode,
     createdAt: now,
     id: crypto.randomUUID(),
     organizationId: membership.organizationId,
@@ -197,6 +241,35 @@ export async function createDraftControl(
   await db.insert(draftControls).values(draft);
 
   return (await listDraftControls(membership)).find(({ id }) => id === draft.id)!;
+}
+
+export async function cancelDraftControl(
+  membership: OrganizationMembership,
+  draftControlId: string,
+): Promise<boolean> {
+  const draftControl = await db
+    .select({ authorMemberId: draftControls.authorMemberId, id: draftControls.id })
+    .from(draftControls)
+    .where(
+      and(
+        eq(draftControls.id, draftControlId),
+        eq(draftControls.organizationId, membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!draftControl) {
+    return false;
+  }
+
+  if (draftControl.authorMemberId !== membership.id && !draftReviewerRoles.has(membership.role)) {
+    return false;
+  }
+
+  await db.delete(draftControls).where(eq(draftControls.id, draftControl.id));
+
+  return true;
 }
 
 export async function publishDraftControl(
@@ -269,6 +342,50 @@ export async function publishDraftControl(
   return getControlDetail(membership, controlId);
 }
 
+export async function setControlArchivedForMembership(input: {
+  archived: boolean;
+  controlId: string;
+  membership: OrganizationMembership;
+  reason?: string;
+}): Promise<ControlListItem | null> {
+  const control = await db
+    .select({ id: controls.id })
+    .from(controls)
+    .where(
+      and(
+        eq(controls.id, input.controlId),
+        eq(controls.organizationId, input.membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!control) {
+    return null;
+  }
+
+  await db
+    .update(controls)
+    .set(
+      input.archived
+        ? {
+            archivedAt: new Date(),
+            archivedByMemberId: input.membership.id,
+            archiveReason: input.reason?.trim() || null,
+            updatedAt: new Date(),
+          }
+        : {
+            archivedAt: null,
+            archivedByMemberId: null,
+            archiveReason: null,
+            updatedAt: new Date(),
+          },
+    )
+    .where(eq(controls.id, control.id));
+
+  return getControlDetail(input.membership, input.controlId);
+}
+
 export function normalizeDraftControlCreateBody(body: unknown): CreateDraftControlInput {
   const value = typeof body === 'object' && body !== null ? body : {};
   const record = value as Record<string, unknown>;
@@ -295,6 +412,15 @@ export function normalizeDraftControlPublishBody(body: unknown): PublishDraftCon
         : '',
     verificationMethod:
       typeof record.verificationMethod === 'string' ? record.verificationMethod : '',
+  };
+}
+
+export function normalizeControlArchiveBody(body: unknown): ArchiveControlInput {
+  const value = typeof body === 'object' && body !== null ? body : {};
+  const record = value as Record<string, unknown>;
+
+  return {
+    reason: typeof record.reason === 'string' ? record.reason : '',
   };
 }
 
@@ -362,6 +488,8 @@ function toExternalStandardsMappings(value: unknown): ExternalStandardsMapping[]
 
 function toControlListItem(row: {
   acceptedEvidenceTypes: string;
+  archivedAt: Date | null;
+  archiveReason: string | null;
   applicabilityConditions: string;
   businessMeaning: string;
   controlCode: string;
@@ -376,6 +504,8 @@ function toControlListItem(row: {
   versionNumber: number;
 }): ControlListItem {
   return {
+    archivedAt: row.archivedAt?.toISOString() ?? null,
+    archiveReason: row.archiveReason,
     controlCode: row.controlCode,
     createdAt: row.controlCreatedAt.toISOString(),
     currentVersion: {

--- a/apps/backend-hono/test/draft-controls.spec.ts
+++ b/apps/backend-hono/test/draft-controls.spec.ts
@@ -167,11 +167,75 @@ async function publishDraftControlRequest(
   };
 }
 
-async function listControlsRequest(organizationSlug: string, headers: Headers) {
+async function listControlsRequest(
+  organizationSlug: string,
+  headers: Headers,
+  status: 'active' | 'archived' = 'active',
+) {
+  const query = status === 'archived' ? '?status=archived' : '';
   const response = await app.request(
-    `http://example.com/api/organizations/${organizationSlug}/controls`,
+    `http://example.com/api/organizations/${organizationSlug}/controls${query}`,
     {
       headers,
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function archiveControlRequest(
+  organizationSlug: string,
+  controlId: string,
+  headers: Headers,
+  body: Record<string, unknown> = {},
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls/${controlId}/archive`,
+    {
+      body: JSON.stringify(body),
+      headers,
+      method: 'PATCH',
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function restoreControlRequest(
+  organizationSlug: string,
+  controlId: string,
+  headers: Headers,
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls/${controlId}/restore`,
+    {
+      headers,
+      method: 'PATCH',
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function cancelDraftControlRequest(
+  organizationSlug: string,
+  draftControlId: string,
+  headers: Headers,
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls/drafts/${draftControlId}`,
+    {
+      headers,
+      method: 'DELETE',
     },
   );
 
@@ -492,5 +556,163 @@ describe('Draft Controls', () => {
     expect(publishResponse.body).toMatchObject({
       error: 'At least one Accepted Evidence Type is required.',
     });
+  });
+
+  it('lets Organization owners archive and restore published Controls with an optional reason', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner('archive-owner');
+
+    const createResponse = await createDraftControlRequest(organization.slug, ownerHeaders, {
+      controlCode: 'AUTH-008',
+      title: 'Archive published Control',
+    });
+    const draftControl = createResponse.body.draftControl as { id: string };
+    const publishResponse = await publishDraftControlRequest(
+      organization.slug,
+      draftControl.id,
+      ownerHeaders,
+    );
+    const control = publishResponse.body.control as { id: string };
+
+    const archiveResponse = await archiveControlRequest(
+      organization.slug,
+      control.id,
+      ownerHeaders,
+      {
+        reason: 'Replaced by a stricter Control.',
+      },
+    );
+
+    expect(archiveResponse.status).toBe(200);
+    expect(archiveResponse.body.control).toMatchObject({
+      archiveReason: 'Replaced by a stricter Control.',
+      controlCode: 'AUTH-008',
+    });
+    expect((archiveResponse.body.control as { archivedAt?: string }).archivedAt).toBeTruthy();
+
+    await expect(listControlsRequest(organization.slug, ownerHeaders)).resolves.toMatchObject({
+      body: { controls: [] },
+      status: 200,
+    });
+    await expect(
+      listControlsRequest(organization.slug, ownerHeaders, 'archived'),
+    ).resolves.toMatchObject({
+      body: { controls: [{ controlCode: 'AUTH-008' }] },
+      status: 200,
+    });
+
+    const restoreResponse = await restoreControlRequest(
+      organization.slug,
+      control.id,
+      ownerHeaders,
+    );
+
+    expect(restoreResponse.status).toBe(200);
+    expect(restoreResponse.body.control).toMatchObject({
+      archivedAt: null,
+      archiveReason: null,
+      controlCode: 'AUTH-008',
+    });
+    await expect(listControlsRequest(organization.slug, ownerHeaders)).resolves.toMatchObject({
+      body: { controls: [{ controlCode: 'AUTH-008' }] },
+      status: 200,
+    });
+  });
+
+  it('restricts archived Control access and archive actions to Organization owners and admins', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner('archive-role-owner');
+    const member = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'archive-role-member',
+      role: 'member',
+    });
+    const admin = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'archive-role-admin',
+      role: 'admin',
+    });
+
+    const createResponse = await createDraftControlRequest(organization.slug, ownerHeaders, {
+      controlCode: 'AUTH-009',
+      title: 'Restrict archived Control',
+    });
+    const draftControl = createResponse.body.draftControl as { id: string };
+    const publishResponse = await publishDraftControlRequest(
+      organization.slug,
+      draftControl.id,
+      ownerHeaders,
+    );
+    const control = publishResponse.body.control as { id: string };
+
+    await expect(
+      archiveControlRequest(organization.slug, control.id, member.headers),
+    ).resolves.toMatchObject({ status: 403 });
+
+    await archiveControlRequest(organization.slug, control.id, admin.headers);
+
+    await expect(
+      listControlsRequest(organization.slug, member.headers, 'archived'),
+    ).resolves.toMatchObject({
+      body: { error: 'Only Organization owners and admins can view archived Controls.' },
+      status: 403,
+    });
+    await expect(
+      getControlRequest(organization.slug, control.id, member.headers),
+    ).resolves.toMatchObject({
+      body: { error: 'Control unavailable' },
+      status: 404,
+    });
+    await expect(
+      restoreControlRequest(organization.slug, control.id, member.headers),
+    ).resolves.toMatchObject({ status: 403 });
+  });
+
+  it('keeps archived published Control Codes reserved while canceled Draft Control codes can be reused', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner('code-reuse-owner');
+
+    const publishedDraftResponse = await createDraftControlRequest(
+      organization.slug,
+      ownerHeaders,
+      {
+        controlCode: 'AUTH-010',
+        title: 'Reserve archived code',
+      },
+    );
+    const publishedDraft = publishedDraftResponse.body.draftControl as { id: string };
+    const publishResponse = await publishDraftControlRequest(
+      organization.slug,
+      publishedDraft.id,
+      ownerHeaders,
+    );
+    const control = publishResponse.body.control as { id: string };
+
+    await archiveControlRequest(organization.slug, control.id, ownerHeaders);
+
+    const reservedCodeResponse = await createDraftControlRequest(organization.slug, ownerHeaders, {
+      controlCode: 'AUTH-010',
+      title: 'Reuse archived published code',
+    });
+
+    expect(reservedCodeResponse.status).toBe(400);
+    expect(reservedCodeResponse.body).toMatchObject({
+      error: 'Control Code is already used in this Organization.',
+    });
+
+    const canceledDraftResponse = await createDraftControlRequest(organization.slug, ownerHeaders, {
+      controlCode: 'AUTH-011',
+      title: 'Reusable canceled draft',
+    });
+    const canceledDraft = canceledDraftResponse.body.draftControl as { id: string };
+
+    await expect(
+      cancelDraftControlRequest(organization.slug, canceledDraft.id, ownerHeaders),
+    ).resolves.toMatchObject({ body: { canceled: true }, status: 200 });
+    await expect(
+      createDraftControlRequest(organization.slug, ownerHeaders, {
+        controlCode: 'AUTH-011',
+        title: 'Reused canceled draft code',
+      }),
+    ).resolves.toMatchObject({ status: 201 });
   });
 });

--- a/apps/web/src/components/pages/controls.tsx
+++ b/apps/web/src/components/pages/controls.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
-import { AlertCircle, CheckCircle2, Plus } from 'lucide-react';
-import { useParams } from 'react-router';
+import { AlertCircle, Archive, CheckCircle2, Plus, RotateCcw, Trash2 } from 'lucide-react';
+import { useParams, useSearchParams } from 'react-router';
 import {
+  archiveControl,
+  cancelDraftControl,
   createDraftControl,
   getMembershipResolution,
   listControls,
   listDraftControls,
   publishDraftControl,
+  restoreControl,
   type ControlListItem,
   type DraftControlListItem,
 } from '../../features/auth/auth-api';
@@ -29,8 +32,13 @@ function canPublishControls(role: string | null): boolean {
   return role === 'owner' || role === 'admin';
 }
 
+function isArchivedView(value: string | null): boolean {
+  return value === 'archived';
+}
+
 export function ControlsPage() {
   const { organizationSlug } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [controls, setControls] = useState<ControlListItem[]>([]);
   const [draftControls, setDraftControls] = useState<DraftControlListItem[]>([]);
   const [currentRole, setCurrentRole] = useState<string | null>(null);
@@ -41,6 +49,9 @@ export function ControlsPage() {
   const [status, setStatus] = useState<string | null>(null);
   const [controlCode, setControlCode] = useState('');
   const [title, setTitle] = useState('');
+  const [archiveControlId, setArchiveControlId] = useState<string | null>(null);
+  const [archiveReason, setArchiveReason] = useState('');
+  const archivedView = isArchivedView(searchParams.get('status'));
 
   useEffect(() => {
     const refresh = async () => {
@@ -50,7 +61,7 @@ export function ControlsPage() {
       setError(null);
       try {
         const [controlResponse, draftResponse, resolution] = await Promise.all([
-          listControls(organizationSlug),
+          listControls(organizationSlug, archivedView ? 'archived' : 'active'),
           listDraftControls(organizationSlug),
           getMembershipResolution(),
         ]);
@@ -69,7 +80,7 @@ export function ControlsPage() {
     };
 
     void refresh();
-  }, [organizationSlug]);
+  }, [archivedView, organizationSlug]);
 
   const handleCreateDraftControl = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -132,15 +143,85 @@ export function ControlsPage() {
     }
   };
 
+  const handleArchiveStateChange = async (control: ControlListItem, reason = '') => {
+    if (!organizationSlug) return;
+
+    setError(null);
+    setStatus(null);
+    try {
+      if (archivedView) {
+        await restoreControl(organizationSlug, control.id);
+        setStatus('Control restored.');
+      } else {
+        await archiveControl(organizationSlug, control.id, { reason });
+        setArchiveControlId(null);
+        setArchiveReason('');
+        setStatus('Control archived.');
+      }
+      setControls((currentControls) =>
+        currentControls.filter((currentControl) => currentControl.id !== control.id),
+      );
+    } catch (caughtError) {
+      const action = archivedView ? 'restore' : 'archive';
+      const rawMessage =
+        caughtError instanceof Error ? caughtError.message : `Unable to ${action} Control.`;
+      setError(humanizeAuthError(null, rawMessage, `Unable to ${action} Control.`));
+    }
+  };
+
+  const handleCancelDraftControl = async (draftControl: DraftControlListItem) => {
+    if (!organizationSlug) return;
+
+    setError(null);
+    setStatus(null);
+    try {
+      await cancelDraftControl(organizationSlug, draftControl.id);
+      setDraftControls((currentDrafts) =>
+        currentDrafts.filter((currentDraft) => currentDraft.id !== draftControl.id),
+      );
+      setStatus('Draft Control canceled.');
+    } catch (caughtError) {
+      const rawMessage =
+        caughtError instanceof Error ? caughtError.message : 'Unable to cancel Draft Control.';
+      setError(humanizeAuthError(null, rawMessage, 'Unable to cancel Draft Control.'));
+    }
+  };
+
   const canPublish = canPublishControls(currentRole);
+  const emptyTitle = archivedView ? 'No archived Controls' : 'No active Controls yet';
+  const emptyDescription = archivedView
+    ? 'Archived Controls will appear here after they are hidden from active use.'
+    : 'Published Controls will appear here after a Draft Control is completed.';
 
   return (
     <div className="mx-auto w-full max-w-5xl space-y-6">
-      <header className="space-y-1">
-        <h1 className="text-2xl font-semibold tracking-tight">Controls</h1>
-        <p className="text-sm text-muted-foreground">
-          Publish complete Controls into the active Control Library.
-        </p>
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight">Controls</h1>
+          <p className="text-sm text-muted-foreground">
+            {archivedView
+              ? 'Review Archived Controls hidden from active Control Library use.'
+              : 'Publish complete Controls into the active Control Library.'}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant={archivedView ? 'outline' : 'default'}
+            onClick={() => setSearchParams({})}
+          >
+            Active
+          </Button>
+          {canPublish ? (
+            <Button
+              type="button"
+              variant={archivedView ? 'default' : 'outline'}
+              onClick={() => setSearchParams({ status: 'archived' })}
+            >
+              Archived
+            </Button>
+          ) : null}
+        </div>
       </header>
 
       {error ? (
@@ -158,58 +239,64 @@ export function ControlsPage() {
         </Alert>
       ) : null}
 
-      <section className="rounded-xl border bg-card p-5">
-        <div className="space-y-1">
-          <h2 className="text-lg font-semibold">Create Draft Control</h2>
-          <p className="text-sm text-muted-foreground">
-            Only Control Code and title are required while a Control is still a draft.
-          </p>
-        </div>
-        <form
-          className="mt-5 grid gap-4 sm:grid-cols-[12rem_1fr_auto]"
-          onSubmit={handleCreateDraftControl}
-        >
-          <div className="space-y-2">
-            <Label htmlFor="control-code">Control Code</Label>
-            <Input
-              id="control-code"
-              value={controlCode}
-              onChange={(event) => setControlCode(event.target.value)}
-              placeholder="AUTH-001"
-              required
-            />
+      {!archivedView ? (
+        <section className="rounded-xl border bg-card p-5">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold">Create Draft Control</h2>
+            <p className="text-sm text-muted-foreground">
+              Only Control Code and title are required while a Control is still a draft.
+            </p>
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="control-title">Title</Label>
-            <Input
-              id="control-title"
-              value={title}
-              onChange={(event) => setTitle(event.target.value)}
-              placeholder="Require multi-factor authentication"
-              required
-            />
-          </div>
-          <Button className="self-end" type="submit" disabled={isCreating}>
-            <Plus />
-            {isCreating ? 'Saving...' : 'Save Draft'}
-          </Button>
-        </form>
-      </section>
+          <form
+            className="mt-5 grid gap-4 sm:grid-cols-[12rem_1fr_auto]"
+            onSubmit={handleCreateDraftControl}
+          >
+            <div className="space-y-2">
+              <Label htmlFor="control-code">Control Code</Label>
+              <Input
+                id="control-code"
+                value={controlCode}
+                onChange={(event) => setControlCode(event.target.value)}
+                placeholder="AUTH-001"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="control-title">Title</Label>
+              <Input
+                id="control-title"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder="Require multi-factor authentication"
+                required
+              />
+            </div>
+            <Button className="self-end" type="submit" disabled={isCreating}>
+              <Plus />
+              {isCreating ? 'Saving...' : 'Save Draft'}
+            </Button>
+          </form>
+        </section>
+      ) : null}
 
       <section className="space-y-3">
         <div className="space-y-1">
-          <h2 className="text-lg font-semibold">Active Control Library</h2>
+          <h2 className="text-lg font-semibold">
+            {archivedView ? 'Archived Controls' : 'Active Control Library'}
+          </h2>
           <p className="text-sm text-muted-foreground">
-            Published Controls are visible to every Organization member.
+            {archivedView
+              ? 'Archived Controls keep their Control Codes reserved and are unavailable for new use.'
+              : 'Published Controls are visible to every Organization member.'}
           </p>
         </div>
         {isLoading ? (
           <p className="text-sm text-muted-foreground">Loading Controls...</p>
         ) : controls.length === 0 ? (
           <div className="rounded-xl border border-dashed p-8 text-center">
-            <h3 className="text-lg font-medium">No active Controls yet</h3>
+            <h3 className="text-lg font-medium">{emptyTitle}</h3>
             <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
-              Published Controls will appear here after a Draft Control is completed.
+              {emptyDescription}
             </p>
           </div>
         ) : (
@@ -228,25 +315,89 @@ export function ControlsPage() {
                     <p className="text-sm">{control.currentVersion.businessMeaning}</p>
                   </div>
                   <p className="shrink-0 text-xs text-muted-foreground">
-                    Published {formatDate(control.createdAt)}
+                    {archivedView && control.archivedAt
+                      ? `Archived ${formatDate(control.archivedAt)}`
+                      : `Published ${formatDate(control.createdAt)}`}
                   </p>
                 </div>
+                {archivedView && control.archiveReason ? (
+                  <p className="mt-3 text-sm text-muted-foreground">
+                    Archive reason: {control.archiveReason}
+                  </p>
+                ) : null}
+                {canPublish ? (
+                  <div className="mt-4 flex justify-end gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        if (archivedView) {
+                          void handleArchiveStateChange(control);
+                          return;
+                        }
+
+                        setArchiveControlId(control.id);
+                        setArchiveReason('');
+                      }}
+                    >
+                      {archivedView ? <RotateCcw /> : <Archive />}
+                      {archivedView ? 'Restore' : 'Archive'}
+                    </Button>
+                  </div>
+                ) : null}
+                {!archivedView && archiveControlId === control.id ? (
+                  <form
+                    className="mt-4 space-y-3 rounded-lg border bg-muted/30 p-3"
+                    onSubmit={(event) => {
+                      event.preventDefault();
+                      void handleArchiveStateChange(control, archiveReason);
+                    }}
+                  >
+                    <div className="space-y-2">
+                      <Label htmlFor={`${control.id}-archive-reason`}>Archive reason</Label>
+                      <textarea
+                        id={`${control.id}-archive-reason`}
+                        value={archiveReason}
+                        onChange={(event) => setArchiveReason(event.target.value)}
+                        className="min-h-20 w-full rounded-md border bg-background px-3 py-2 text-sm"
+                        placeholder="Optional context for why this Control is no longer used."
+                      />
+                    </div>
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          setArchiveControlId(null);
+                          setArchiveReason('');
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                      <Button type="submit" size="sm">
+                        Archive Control
+                      </Button>
+                    </div>
+                  </form>
+                ) : null}
               </article>
             ))}
           </div>
         )}
       </section>
 
-      {isLoading ? (
+      {!archivedView && isLoading ? (
         <p className="text-sm text-muted-foreground">Loading Draft Controls...</p>
-      ) : draftControls.length === 0 ? (
+      ) : !archivedView && draftControls.length === 0 ? (
         <section className="rounded-xl border border-dashed p-8 text-center">
           <h2 className="text-lg font-medium">No Draft Controls yet</h2>
           <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
             Draft Controls you can access will appear here after they are saved.
           </p>
         </section>
-      ) : (
+      ) : !archivedView ? (
         <section className="grid gap-3">
           {draftControls.map((draftControl) => (
             <article key={draftControl.id} className="rounded-xl border bg-card p-5">
@@ -260,9 +411,20 @@ export function ControlsPage() {
                     Author: {draftControl.author.name} ({draftControl.author.email})
                   </p>
                 </div>
-                <p className="shrink-0 text-xs text-muted-foreground">
-                  Saved {formatDate(draftControl.createdAt)}
-                </p>
+                <div className="flex shrink-0 items-center gap-2">
+                  <p className="text-xs text-muted-foreground">
+                    Saved {formatDate(draftControl.createdAt)}
+                  </p>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void handleCancelDraftControl(draftControl)}
+                  >
+                    <Trash2 />
+                    Cancel
+                  </Button>
+                </div>
               </div>
               {canPublish ? (
                 <form
@@ -338,7 +500,7 @@ export function ControlsPage() {
             </article>
           ))}
         </section>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/auth/auth-api.ts
+++ b/apps/web/src/features/auth/auth-api.ts
@@ -71,6 +71,8 @@ export type DraftControlListItem = {
 };
 
 export type ControlListItem = {
+  archivedAt: string | null;
+  archiveReason: string | null;
   controlCode: string;
   createdAt: string;
   currentVersion: {
@@ -251,9 +253,11 @@ export function listDraftControls(organizationSlug: string) {
   );
 }
 
-export function listControls(organizationSlug: string) {
+export function listControls(organizationSlug: string, status: 'active' | 'archived' = 'active') {
+  const query = status === 'archived' ? '?status=archived' : '';
+
   return request<{ controls: ControlListItem[] }>(
-    `/api/organizations/${organizationSlug}/controls`,
+    `/api/organizations/${organizationSlug}/controls${query}`,
     {
       method: 'GET',
     },
@@ -292,6 +296,38 @@ export function publishDraftControl(
     {
       method: 'POST',
       body: JSON.stringify(input),
+    },
+  );
+}
+
+export function cancelDraftControl(organizationSlug: string, draftControlId: string) {
+  return request<{ canceled: boolean }>(
+    `/api/organizations/${organizationSlug}/controls/drafts/${draftControlId}`,
+    {
+      method: 'DELETE',
+    },
+  );
+}
+
+export function archiveControl(
+  organizationSlug: string,
+  controlId: string,
+  input: { reason?: string } = {},
+) {
+  return request<{ control: ControlListItem }>(
+    `/api/organizations/${organizationSlug}/controls/${controlId}/archive`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify(input),
+    },
+  );
+}
+
+export function restoreControl(organizationSlug: string, controlId: string) {
+  return request<{ control: ControlListItem }>(
+    `/api/organizations/${organizationSlug}/controls/${controlId}/restore`,
+    {
+      method: 'PATCH',
     },
   );
 }


### PR DESCRIPTION
## Summary
- Add archived metadata and APIs to archive, restore, and list Archived Controls for Organization owners/admins.
- Update Controls UI with active/archived views, inline archive reason capture, restore actions, and Draft Control cancellation.
- Cover archived visibility, role enforcement, and Control Code reservation/reuse behavior in backend tests.

## Checks
- pnpm format:check
- pnpm lint
- pnpm check-types
- pnpm test
- pnpm build

Closes #24