### PR TITLE
feat(controls): propose updates to active controls

### DIFF
--- a/apps/backend-hono/drizzle/migrations/0005_control_proposed_updates.sql
+++ b/apps/backend-hono/drizzle/migrations/0005_control_proposed_updates.sql
@@ -1,0 +1,23 @@
+CREATE TABLE `control_proposed_updates` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`control_id` text NOT NULL,
+	`author_member_id` text NOT NULL,
+	`control_code` text NOT NULL,
+	`title` text NOT NULL,
+	`business_meaning` text NOT NULL,
+	`verification_method` text NOT NULL,
+	`accepted_evidence_types` text NOT NULL,
+	`applicability_conditions` text NOT NULL,
+	`release_impact` text NOT NULL,
+	`external_standards_mappings` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`control_id`) REFERENCES `controls`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`author_member_id`) REFERENCES `members`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `control_proposed_update_organization_id_idx` ON `control_proposed_updates` (`organization_id`);--> statement-breakpoint
+CREATE INDEX `control_proposed_update_author_member_id_idx` ON `control_proposed_updates` (`author_member_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `control_proposed_update_control_id_unique` ON `control_proposed_updates` (`control_id`);

--- a/apps/backend-hono/src/db/schema.ts
+++ b/apps/backend-hono/src/db/schema.ts
@@ -263,3 +263,39 @@ export const controlVersions = sqliteTable(
     uniqueIndex('control_version_number_unique').on(table.controlId, table.versionNumber),
   ],
 );
+
+export const controlProposedUpdates = sqliteTable(
+  'control_proposed_updates',
+  {
+    id: text('id').primaryKey(),
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    controlId: text('control_id')
+      .notNull()
+      .references(() => controls.id, { onDelete: 'cascade' }),
+    authorMemberId: text('author_member_id')
+      .notNull()
+      .references(() => members.id, { onDelete: 'cascade' }),
+    controlCode: text('control_code').notNull(),
+    title: text('title').notNull(),
+    businessMeaning: text('business_meaning').notNull(),
+    verificationMethod: text('verification_method').notNull(),
+    acceptedEvidenceTypes: text('accepted_evidence_types').notNull(),
+    applicabilityConditions: text('applicability_conditions').notNull(),
+    releaseImpact: text('release_impact').notNull(),
+    externalStandardsMappings: text('external_standards_mappings').notNull(),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    index('control_proposed_update_organization_id_idx').on(table.organizationId),
+    index('control_proposed_update_author_member_id_idx').on(table.authorMemberId),
+    uniqueIndex('control_proposed_update_control_id_unique').on(table.controlId),
+  ],
+);

--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -5,14 +5,19 @@ import { env } from 'cloudflare:workers';
 import { resolveInvitationEntryState, resolveMembershipResolution } from './lib/auth-organization';
 import {
   canPublishControls,
+  ControlProposedUpdateInputError,
+  createControlProposedUpdate,
   ControlPublishInputError,
   createDraftControl,
   DraftControlInputError,
   getControlDetail,
+  listControlProposedUpdates,
   listControls,
   listDraftControls,
+  normalizeControlProposedUpdateBody,
   normalizeDraftControlCreateBody,
   normalizeDraftControlPublishBody,
+  publishControlProposedUpdate,
   publishDraftControl,
 } from './lib/controls';
 import {
@@ -166,6 +171,27 @@ app.get('/api/organizations/:organizationSlug/controls', async (c) => {
   return c.json({ controls: await listControls(membership.organizationId) });
 });
 
+app.get('/api/organizations/:organizationSlug/controls/proposed-updates', async (c) => {
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(
+    c.req.param('organizationSlug'),
+    session.user.id,
+  );
+
+  if (!membership) {
+    return c.json({ error: 'Organization not found' }, 404);
+  }
+
+  return c.json({ proposedUpdates: await listControlProposedUpdates(membership) });
+});
+
 app.get('/api/organizations/:organizationSlug/controls/:controlId', async (c) => {
   const session = await auth.api.getSession({
     headers: c.req.raw.headers,
@@ -227,6 +253,45 @@ app.post('/api/organizations/:organizationSlug/controls/drafts', async (c) => {
   }
 });
 
+app.post('/api/organizations/:organizationSlug/controls/:controlId/proposed-updates', async (c) => {
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(
+    c.req.param('organizationSlug'),
+    session.user.id,
+  );
+
+  if (!membership) {
+    return c.json({ error: 'Control unavailable' }, 404);
+  }
+
+  try {
+    const proposedUpdate = await createControlProposedUpdate(
+      membership,
+      c.req.param('controlId'),
+      normalizeControlProposedUpdateBody(await c.req.json().catch(() => null)),
+    );
+
+    if (!proposedUpdate) {
+      return c.json({ error: 'Control unavailable' }, 404);
+    }
+
+    return c.json({ proposedUpdate }, 201);
+  } catch (caughtError) {
+    if (caughtError instanceof ControlProposedUpdateInputError) {
+      return c.json({ error: caughtError.message }, 400);
+    }
+
+    throw caughtError;
+  }
+});
+
 app.post(
   '/api/organizations/:organizationSlug/controls/drafts/:draftControlId/publish',
   async (c) => {
@@ -265,6 +330,52 @@ app.post(
       return c.json({ control }, 201);
     } catch (caughtError) {
       if (caughtError instanceof ControlPublishInputError) {
+        return c.json({ error: caughtError.message }, 400);
+      }
+
+      throw caughtError;
+    }
+  },
+);
+
+app.post(
+  '/api/organizations/:organizationSlug/controls/:controlId/proposed-updates/:proposedUpdateId/publish',
+  async (c) => {
+    const session = await auth.api.getSession({
+      headers: c.req.raw.headers,
+    });
+
+    if (!session) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    const membership = await getOrganizationMembership(
+      c.req.param('organizationSlug'),
+      session.user.id,
+    );
+
+    if (!membership) {
+      return c.json({ error: 'Proposed update unavailable' }, 404);
+    }
+
+    if (!canPublishControls(membership.role)) {
+      return c.json({ error: 'Only Organization owners and admins can publish Controls.' }, 403);
+    }
+
+    try {
+      const control = await publishControlProposedUpdate(
+        membership,
+        c.req.param('controlId'),
+        c.req.param('proposedUpdateId'),
+      );
+
+      if (!control) {
+        return c.json({ error: 'Proposed update unavailable' }, 404);
+      }
+
+      return c.json({ control }, 201);
+    } catch (caughtError) {
+      if (caughtError instanceof ControlProposedUpdateInputError) {
         return c.json({ error: caughtError.message }, 400);
       }
 

--- a/apps/backend-hono/src/lib/controls.ts
+++ b/apps/backend-hono/src/lib/controls.ts
@@ -1,6 +1,13 @@
-import { and, asc, eq } from 'drizzle-orm';
+import { and, asc, desc, eq, ne } from 'drizzle-orm';
 import { db } from '../db/client';
-import { controls, controlVersions, draftControls, members, users } from '../db/schema';
+import {
+  controlProposedUpdates,
+  controls,
+  controlVersions,
+  draftControls,
+  members,
+  users,
+} from '../db/schema';
 import type { OrganizationMembership } from './projects';
 
 export type DraftControlListItem = {
@@ -35,6 +42,16 @@ export type ControlListItem = {
   currentVersion: ControlVersionResponse;
   id: string;
   title: string;
+  versions: ControlVersionResponse[];
+};
+
+export type ControlProposedUpdateListItem = ControlVersionResponse & {
+  author: {
+    email: string;
+    id: string;
+    name: string;
+  };
+  controlId: string;
 };
 
 type CreateDraftControlInput = {
@@ -59,12 +76,18 @@ type PublishDraftControlInput = {
   verificationMethod: string;
 };
 
+type CreateControlProposedUpdateInput = PublishDraftControlInput & {
+  controlCode: string;
+  title: string;
+};
+
 const draftReviewerRoles = new Set(['owner', 'admin']);
 const publishControlRoles = new Set(['owner', 'admin']);
 const releaseImpacts = new Set(['advisory', 'blocking', 'needs review']);
 
 export class DraftControlInputError extends Error {}
 export class ControlPublishInputError extends Error {}
+export class ControlProposedUpdateInputError extends Error {}
 
 export function canPublishControls(role: string): boolean {
   return publishControlRoles.has(role);
@@ -92,7 +115,7 @@ export async function listControls(organizationId: string): Promise<ControlListI
     .where(eq(controls.organizationId, organizationId))
     .orderBy(asc(controlVersions.controlCode), asc(controlVersions.title));
 
-  return rows.map((row) => toControlListItem(row));
+  return Promise.all(rows.map((row) => toControlListItem(row)));
 }
 
 export async function getControlDetail(
@@ -122,6 +145,50 @@ export async function getControlDetail(
     .then((rows) => rows[0] ?? null);
 
   return row ? toControlListItem(row) : null;
+}
+
+export async function listControlProposedUpdates(
+  membership: OrganizationMembership,
+): Promise<ControlProposedUpdateListItem[]> {
+  const rows = await db
+    .select({
+      acceptedEvidenceTypes: controlProposedUpdates.acceptedEvidenceTypes,
+      applicabilityConditions: controlProposedUpdates.applicabilityConditions,
+      authorEmail: users.email,
+      authorId: members.id,
+      authorName: users.name,
+      businessMeaning: controlProposedUpdates.businessMeaning,
+      controlCode: controlProposedUpdates.controlCode,
+      controlId: controlProposedUpdates.controlId,
+      createdAt: controlProposedUpdates.createdAt,
+      externalStandardsMappings: controlProposedUpdates.externalStandardsMappings,
+      id: controlProposedUpdates.id,
+      releaseImpact: controlProposedUpdates.releaseImpact,
+      title: controlProposedUpdates.title,
+      verificationMethod: controlProposedUpdates.verificationMethod,
+    })
+    .from(controlProposedUpdates)
+    .innerJoin(members, eq(controlProposedUpdates.authorMemberId, members.id))
+    .innerJoin(users, eq(members.userId, users.id))
+    .where(
+      draftReviewerRoles.has(membership.role)
+        ? eq(controlProposedUpdates.organizationId, membership.organizationId)
+        : and(
+            eq(controlProposedUpdates.organizationId, membership.organizationId),
+            eq(controlProposedUpdates.authorMemberId, membership.id),
+          ),
+    )
+    .orderBy(asc(controlProposedUpdates.createdAt), asc(controlProposedUpdates.controlCode));
+
+  return rows.map(({ authorEmail, authorId, authorName, controlId, ...row }) => ({
+    ...toControlVersionResponse({ ...row, versionNumber: 0 }),
+    author: {
+      email: authorEmail,
+      id: authorId,
+      name: authorName,
+    },
+    controlId,
+  }));
 }
 
 export async function listDraftControls(
@@ -269,6 +336,156 @@ export async function publishDraftControl(
   return getControlDetail(membership, controlId);
 }
 
+export async function createControlProposedUpdate(
+  membership: OrganizationMembership,
+  controlId: string,
+  input: CreateControlProposedUpdateInput,
+): Promise<ControlProposedUpdateListItem | null> {
+  validateProposedUpdateInput(input);
+
+  const control = await db
+    .select({ id: controls.id })
+    .from(controls)
+    .where(and(eq(controls.id, controlId), eq(controls.organizationId, membership.organizationId)))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!control) {
+    return null;
+  }
+
+  const existingProposal = await db
+    .select({ id: controlProposedUpdates.id })
+    .from(controlProposedUpdates)
+    .where(eq(controlProposedUpdates.controlId, controlId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existingProposal) {
+    throw new ControlProposedUpdateInputError('This Control already has an open proposed update.');
+  }
+
+  const existingControlWithCode = await db
+    .select({ id: controls.id })
+    .from(controls)
+    .where(
+      and(
+        eq(controls.organizationId, membership.organizationId),
+        eq(controls.currentControlCode, input.controlCode.trim()),
+        ne(controls.id, controlId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existingControlWithCode) {
+    throw new ControlProposedUpdateInputError('Control Code is already used in this Organization.');
+  }
+
+  const now = new Date();
+  const proposedUpdate = {
+    acceptedEvidenceTypes: JSON.stringify(input.acceptedEvidenceTypes.map((value) => value.trim())),
+    applicabilityConditions: input.applicabilityConditions.trim(),
+    authorMemberId: membership.id,
+    businessMeaning: input.businessMeaning.trim(),
+    controlCode: input.controlCode.trim(),
+    controlId,
+    createdAt: now,
+    externalStandardsMappings: JSON.stringify(input.externalStandardsMappings),
+    id: crypto.randomUUID(),
+    organizationId: membership.organizationId,
+    releaseImpact: input.releaseImpact,
+    title: input.title.trim(),
+    updatedAt: now,
+    verificationMethod: input.verificationMethod.trim(),
+  };
+
+  await db.insert(controlProposedUpdates).values(proposedUpdate);
+
+  return (await listControlProposedUpdates(membership)).find(({ id }) => id === proposedUpdate.id)!;
+}
+
+export async function publishControlProposedUpdate(
+  membership: OrganizationMembership,
+  controlId: string,
+  proposedUpdateId: string,
+): Promise<ControlListItem | null> {
+  const proposedUpdate = await db
+    .select()
+    .from(controlProposedUpdates)
+    .where(
+      and(
+        eq(controlProposedUpdates.id, proposedUpdateId),
+        eq(controlProposedUpdates.controlId, controlId),
+        eq(controlProposedUpdates.organizationId, membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!proposedUpdate) {
+    return null;
+  }
+
+  const existingControlWithCode = await db
+    .select({ id: controls.id })
+    .from(controls)
+    .where(
+      and(
+        eq(controls.organizationId, membership.organizationId),
+        eq(controls.currentControlCode, proposedUpdate.controlCode),
+        ne(controls.id, controlId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existingControlWithCode) {
+    throw new ControlProposedUpdateInputError('Control Code is already used in this Organization.');
+  }
+
+  const latestVersion = await db
+    .select({ versionNumber: controlVersions.versionNumber })
+    .from(controlVersions)
+    .where(eq(controlVersions.controlId, controlId))
+    .orderBy(desc(controlVersions.versionNumber))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!latestVersion) {
+    return null;
+  }
+
+  const now = new Date();
+  const versionId = crypto.randomUUID();
+
+  await db.insert(controlVersions).values({
+    acceptedEvidenceTypes: proposedUpdate.acceptedEvidenceTypes,
+    applicabilityConditions: proposedUpdate.applicabilityConditions,
+    businessMeaning: proposedUpdate.businessMeaning,
+    controlCode: proposedUpdate.controlCode,
+    controlId,
+    createdAt: now,
+    externalStandardsMappings: proposedUpdate.externalStandardsMappings,
+    id: versionId,
+    releaseImpact: proposedUpdate.releaseImpact,
+    title: proposedUpdate.title,
+    verificationMethod: proposedUpdate.verificationMethod,
+    versionNumber: latestVersion.versionNumber + 1,
+  });
+  await db
+    .update(controls)
+    .set({
+      currentControlCode: proposedUpdate.controlCode,
+      currentVersionId: versionId,
+      updatedAt: now,
+    })
+    .where(eq(controls.id, controlId));
+  await db.delete(controlProposedUpdates).where(eq(controlProposedUpdates.id, proposedUpdateId));
+
+  return getControlDetail(membership, controlId);
+}
+
 export function normalizeDraftControlCreateBody(body: unknown): CreateDraftControlInput {
   const value = typeof body === 'object' && body !== null ? body : {};
   const record = value as Record<string, unknown>;
@@ -295,6 +512,20 @@ export function normalizeDraftControlPublishBody(body: unknown): PublishDraftCon
         : '',
     verificationMethod:
       typeof record.verificationMethod === 'string' ? record.verificationMethod : '',
+  };
+}
+
+export function normalizeControlProposedUpdateBody(
+  body: unknown,
+): CreateControlProposedUpdateInput {
+  const value = typeof body === 'object' && body !== null ? body : {};
+  const record = value as Record<string, unknown>;
+  const publishInput = normalizeDraftControlPublishBody(body);
+
+  return {
+    ...publishInput,
+    controlCode: typeof record.controlCode === 'string' ? record.controlCode : '',
+    title: typeof record.title === 'string' ? record.title : '',
   };
 }
 
@@ -330,6 +561,11 @@ function validatePublishInput(input: PublishDraftControlInput) {
   }
 }
 
+function validateProposedUpdateInput(input: CreateControlProposedUpdateInput) {
+  validateDraftControlInput(input);
+  validatePublishInput(input);
+}
+
 function toStringArray(value: unknown): string[] {
   return Array.isArray(value)
     ? value.filter((entry): entry is string => typeof entry === 'string' && Boolean(entry.trim()))
@@ -360,7 +596,7 @@ function toExternalStandardsMappings(value: unknown): ExternalStandardsMapping[]
   });
 }
 
-function toControlListItem(row: {
+async function toControlListItem(row: {
   acceptedEvidenceTypes: string;
   applicabilityConditions: string;
   businessMeaning: string;
@@ -374,26 +610,67 @@ function toControlListItem(row: {
   versionCreatedAt: Date;
   versionId: string;
   versionNumber: number;
-}): ControlListItem {
+}): Promise<ControlListItem> {
+  const versions = await getControlVersions(row.controlId);
+
   return {
     controlCode: row.controlCode,
     createdAt: row.controlCreatedAt.toISOString(),
-    currentVersion: {
-      acceptedEvidenceTypes: JSON.parse(row.acceptedEvidenceTypes) as string[],
+    currentVersion: toControlVersionResponse({
+      acceptedEvidenceTypes: row.acceptedEvidenceTypes,
       applicabilityConditions: row.applicabilityConditions,
       businessMeaning: row.businessMeaning,
       controlCode: row.controlCode,
-      createdAt: row.versionCreatedAt.toISOString(),
-      externalStandardsMappings: JSON.parse(
-        row.externalStandardsMappings,
-      ) as ExternalStandardsMapping[],
+      createdAt: row.versionCreatedAt,
+      externalStandardsMappings: row.externalStandardsMappings,
       id: row.versionId,
-      releaseImpact: row.releaseImpact as ReleaseImpact,
+      releaseImpact: row.releaseImpact,
       title: row.title,
       verificationMethod: row.verificationMethod,
       versionNumber: row.versionNumber,
-    },
+    }),
     id: row.controlId,
     title: row.title,
+    versions,
+  };
+}
+
+async function getControlVersions(controlId: string): Promise<ControlVersionResponse[]> {
+  const rows = await db
+    .select()
+    .from(controlVersions)
+    .where(eq(controlVersions.controlId, controlId))
+    .orderBy(desc(controlVersions.versionNumber));
+
+  return rows.map((row) => toControlVersionResponse(row));
+}
+
+function toControlVersionResponse(row: {
+  acceptedEvidenceTypes: string;
+  applicabilityConditions: string;
+  businessMeaning: string;
+  controlCode: string;
+  createdAt: Date;
+  externalStandardsMappings: string;
+  id: string;
+  releaseImpact: string;
+  title: string;
+  verificationMethod: string;
+  versionNumber: number;
+}): ControlVersionResponse {
+  return {
+    acceptedEvidenceTypes: JSON.parse(row.acceptedEvidenceTypes) as string[],
+    applicabilityConditions: row.applicabilityConditions,
+    businessMeaning: row.businessMeaning,
+    controlCode: row.controlCode,
+    createdAt: row.createdAt.toISOString(),
+    externalStandardsMappings: JSON.parse(
+      row.externalStandardsMappings,
+    ) as ExternalStandardsMapping[],
+    id: row.id,
+    releaseImpact: row.releaseImpact as ReleaseImpact,
+    title: row.title,
+    verificationMethod: row.verificationMethod,
+    versionNumber: row.versionNumber,
   };
 }

--- a/apps/backend-hono/test/draft-controls.spec.ts
+++ b/apps/backend-hono/test/draft-controls.spec.ts
@@ -193,6 +193,59 @@ async function getControlRequest(organizationSlug: string, controlId: string, he
   };
 }
 
+async function createControlProposedUpdateRequest(
+  organizationSlug: string,
+  controlId: string,
+  headers: Headers,
+  body: Record<string, unknown>,
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls/${controlId}/proposed-updates`,
+    {
+      body: JSON.stringify(body),
+      headers,
+      method: 'POST',
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function listControlProposedUpdatesRequest(organizationSlug: string, headers: Headers) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls/proposed-updates`,
+    { headers },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function publishControlProposedUpdateRequest(
+  organizationSlug: string,
+  controlId: string,
+  proposedUpdateId: string,
+  headers: Headers,
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls/${controlId}/proposed-updates/${proposedUpdateId}/publish`,
+    {
+      headers,
+      method: 'POST',
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
 beforeEach(() => {
   const originalFetch = globalThis.fetch;
 
@@ -492,5 +545,116 @@ describe('Draft Controls', () => {
     expect(publishResponse.body).toMatchObject({
       error: 'At least one Accepted Evidence Type is required.',
     });
+  });
+
+  it('creates one proposed update for an active Control without changing the current version', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner('proposal-create');
+    const createResponse = await createDraftControlRequest(organization.slug, ownerHeaders, {
+      controlCode: 'AUTH-008',
+      title: 'Require MFA',
+    });
+    const draftControl = createResponse.body.draftControl as { id: string };
+    const publishResponse = await publishDraftControlRequest(
+      organization.slug,
+      draftControl.id,
+      ownerHeaders,
+    );
+    const control = publishResponse.body.control as { id: string };
+
+    const proposedBody = {
+      ...completePublishBody,
+      businessMeaning: 'Release teams must verify phishing-resistant authentication factors.',
+      controlCode: 'AUTH-008',
+      title: 'Require phishing-resistant MFA',
+    };
+    const proposedResponse = await createControlProposedUpdateRequest(
+      organization.slug,
+      control.id,
+      ownerHeaders,
+      proposedBody,
+    );
+
+    expect(proposedResponse.status).toBe(201);
+    expect(proposedResponse.body.proposedUpdate).toMatchObject({
+      businessMeaning: proposedBody.businessMeaning,
+      controlCode: 'AUTH-008',
+      title: 'Require phishing-resistant MFA',
+    });
+
+    await expect(
+      getControlRequest(organization.slug, control.id, ownerHeaders),
+    ).resolves.toMatchObject({
+      body: {
+        control: {
+          currentVersion: {
+            businessMeaning: completePublishBody.businessMeaning,
+            versionNumber: 1,
+          },
+          versions: [{ versionNumber: 1 }],
+        },
+      },
+      status: 200,
+    });
+    await expect(
+      createControlProposedUpdateRequest(organization.slug, control.id, ownerHeaders, proposedBody),
+    ).resolves.toMatchObject({
+      body: { error: 'This Control already has an open proposed update.' },
+      status: 400,
+    });
+  });
+
+  it('publishes a proposed update as the next Control Version and clears the open proposal', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner('proposal-publish');
+    const createResponse = await createDraftControlRequest(organization.slug, ownerHeaders, {
+      controlCode: 'AUTH-009',
+      title: 'Require MFA before update',
+    });
+    const draftControl = createResponse.body.draftControl as { id: string };
+    const publishResponse = await publishDraftControlRequest(
+      organization.slug,
+      draftControl.id,
+      ownerHeaders,
+    );
+    const control = publishResponse.body.control as { id: string };
+    const proposedResponse = await createControlProposedUpdateRequest(
+      organization.slug,
+      control.id,
+      ownerHeaders,
+      {
+        ...completePublishBody,
+        businessMeaning: 'Updated release assurance meaning.',
+        controlCode: 'AUTH-009A',
+        title: 'Require MFA after update',
+      },
+    );
+    const proposedUpdate = proposedResponse.body.proposedUpdate as { id: string };
+
+    const proposedPublishResponse = await publishControlProposedUpdateRequest(
+      organization.slug,
+      control.id,
+      proposedUpdate.id,
+      ownerHeaders,
+    );
+
+    expect(proposedPublishResponse.status).toBe(201);
+    expect(proposedPublishResponse.body.control).toMatchObject({
+      controlCode: 'AUTH-009A',
+      currentVersion: {
+        businessMeaning: 'Updated release assurance meaning.',
+        title: 'Require MFA after update',
+        versionNumber: 2,
+      },
+      versions: [{ versionNumber: 2 }, { versionNumber: 1 }],
+    });
+
+    const versions = await db
+      .select()
+      .from(controlVersions)
+      .where(eq(controlVersions.controlId, control.id));
+    expect(versions).toHaveLength(2);
+    expect(versions.map((version) => version.versionNumber).sort()).toEqual([1, 2]);
+    await expect(
+      listControlProposedUpdatesRequest(organization.slug, ownerHeaders),
+    ).resolves.toMatchObject({ body: { proposedUpdates: [] }, status: 200 });
   });
 });

--- a/apps/web/src/components/pages/controls.tsx
+++ b/apps/web/src/components/pages/controls.tsx
@@ -3,12 +3,16 @@ import type { FormEvent } from 'react';
 import { AlertCircle, CheckCircle2, Plus } from 'lucide-react';
 import { useParams } from 'react-router';
 import {
+  createControlProposedUpdate,
   createDraftControl,
   getMembershipResolution,
+  listControlProposedUpdates,
   listControls,
   listDraftControls,
+  publishControlProposedUpdate,
   publishDraftControl,
   type ControlListItem,
+  type ControlProposedUpdateListItem,
   type DraftControlListItem,
 } from '../../features/auth/auth-api';
 import { humanizeAuthError } from '../../features/auth/auth-errors';
@@ -33,10 +37,13 @@ export function ControlsPage() {
   const { organizationSlug } = useParams();
   const [controls, setControls] = useState<ControlListItem[]>([]);
   const [draftControls, setDraftControls] = useState<DraftControlListItem[]>([]);
+  const [proposedUpdates, setProposedUpdates] = useState<ControlProposedUpdateListItem[]>([]);
   const [currentRole, setCurrentRole] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isCreating, setIsCreating] = useState(false);
   const [publishingDraftId, setPublishingDraftId] = useState<string | null>(null);
+  const [creatingProposalControlId, setCreatingProposalControlId] = useState<string | null>(null);
+  const [publishingProposalId, setPublishingProposalId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
   const [controlCode, setControlCode] = useState('');
@@ -49,15 +56,17 @@ export function ControlsPage() {
       setIsLoading(true);
       setError(null);
       try {
-        const [controlResponse, draftResponse, resolution] = await Promise.all([
+        const [controlResponse, draftResponse, proposalResponse, resolution] = await Promise.all([
           listControls(organizationSlug),
           listDraftControls(organizationSlug),
+          listControlProposedUpdates(organizationSlug),
           getMembershipResolution(),
         ]);
         const organization = resolution.organizations.find((org) => org.slug === organizationSlug);
 
         setControls(controlResponse.controls);
         setDraftControls(draftResponse.draftControls);
+        setProposedUpdates(proposalResponse.proposedUpdates);
         setCurrentRole(organization?.role ?? null);
       } catch (caughtError) {
         const rawMessage =
@@ -129,6 +138,77 @@ export function ControlsPage() {
       setError(humanizeAuthError(null, rawMessage, 'Unable to publish Control.'));
     } finally {
       setPublishingDraftId(null);
+    }
+  };
+
+  const handleCreateControlProposedUpdate = async (
+    event: FormEvent<HTMLFormElement>,
+    control: ControlListItem,
+  ) => {
+    event.preventDefault();
+    if (!organizationSlug) return;
+
+    const formData = new FormData(event.currentTarget);
+    const acceptedEvidenceTypes = String(formData.get('acceptedEvidenceTypes') ?? '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean);
+
+    setCreatingProposalControlId(control.id);
+    setError(null);
+    setStatus(null);
+    try {
+      const response = await createControlProposedUpdate(organizationSlug, control.id, {
+        acceptedEvidenceTypes,
+        applicabilityConditions: String(formData.get('applicabilityConditions') ?? ''),
+        businessMeaning: String(formData.get('businessMeaning') ?? ''),
+        controlCode: String(formData.get('controlCode') ?? ''),
+        releaseImpact: String(formData.get('releaseImpact') ?? ''),
+        title: String(formData.get('title') ?? ''),
+        verificationMethod: String(formData.get('verificationMethod') ?? ''),
+      });
+
+      setProposedUpdates((currentUpdates) => [...currentUpdates, response.proposedUpdate]);
+      setStatus('Proposed update saved.');
+    } catch (caughtError) {
+      const rawMessage =
+        caughtError instanceof Error ? caughtError.message : 'Unable to save proposed update.';
+      setError(humanizeAuthError(null, rawMessage, 'Unable to save proposed update.'));
+    } finally {
+      setCreatingProposalControlId(null);
+    }
+  };
+
+  const handlePublishControlProposedUpdate = async (
+    proposedUpdate: ControlProposedUpdateListItem,
+  ) => {
+    if (!organizationSlug) return;
+
+    setPublishingProposalId(proposedUpdate.id);
+    setError(null);
+    setStatus(null);
+    try {
+      const response = await publishControlProposedUpdate(
+        organizationSlug,
+        proposedUpdate.controlId,
+        proposedUpdate.id,
+      );
+
+      setControls((currentControls) =>
+        currentControls.map((control) =>
+          control.id === response.control.id ? response.control : control,
+        ),
+      );
+      setProposedUpdates((currentUpdates) =>
+        currentUpdates.filter((currentUpdate) => currentUpdate.id !== proposedUpdate.id),
+      );
+      setStatus('Proposed update published.');
+    } catch (caughtError) {
+      const rawMessage =
+        caughtError instanceof Error ? caughtError.message : 'Unable to publish proposed update.';
+      setError(humanizeAuthError(null, rawMessage, 'Unable to publish proposed update.'));
+    } finally {
+      setPublishingProposalId(null);
     }
   };
 
@@ -214,25 +294,167 @@ export function ControlsPage() {
           </div>
         ) : (
           <div className="grid gap-3">
-            {controls.map((control) => (
-              <article key={control.id} className="rounded-xl border bg-card p-5">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                  <div className="space-y-2">
-                    <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-                      {control.controlCode} · v{control.currentVersion.versionNumber}
+            {controls.map((control) => {
+              const proposedUpdate = proposedUpdates.find(
+                (update) => update.controlId === control.id,
+              );
+
+              return (
+                <article key={control.id} className="rounded-xl border bg-card p-5">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="space-y-2">
+                      <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                        {control.controlCode} · v{control.currentVersion.versionNumber}
+                      </p>
+                      <h3 className="text-base font-semibold">{control.title}</h3>
+                      <p className="text-sm text-muted-foreground">
+                        Release Impact: {control.currentVersion.releaseImpact}
+                      </p>
+                      <p className="text-sm">{control.currentVersion.businessMeaning}</p>
+                    </div>
+                    <p className="shrink-0 text-xs text-muted-foreground">
+                      Published {formatDate(control.createdAt)}
                     </p>
-                    <h3 className="text-base font-semibold">{control.title}</h3>
-                    <p className="text-sm text-muted-foreground">
-                      Release Impact: {control.currentVersion.releaseImpact}
-                    </p>
-                    <p className="text-sm">{control.currentVersion.businessMeaning}</p>
                   </div>
-                  <p className="shrink-0 text-xs text-muted-foreground">
-                    Published {formatDate(control.createdAt)}
-                  </p>
-                </div>
-              </article>
-            ))}
+                  {control.versions.length > 0 ? (
+                    <div className="mt-4 rounded-lg border bg-muted/30 p-3">
+                      <h4 className="text-sm font-medium">Version history</h4>
+                      <div className="mt-2 space-y-2">
+                        {control.versions.map((version) => (
+                          <div key={version.id} className="text-sm text-muted-foreground">
+                            v{version.versionNumber} · {version.controlCode} · {version.title} ·{' '}
+                            {formatDate(version.createdAt)}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                  {proposedUpdate ? (
+                    <div className="mt-4 rounded-lg border border-dashed p-4">
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                        <div className="space-y-1">
+                          <h4 className="text-sm font-medium">Open proposed update</h4>
+                          <p className="text-sm text-muted-foreground">
+                            {proposedUpdate.controlCode} · {proposedUpdate.title}
+                          </p>
+                          <p className="text-sm text-muted-foreground">
+                            Author: {proposedUpdate.author.name} ({proposedUpdate.author.email})
+                          </p>
+                        </div>
+                        {canPublish ? (
+                          <Button
+                            type="button"
+                            disabled={publishingProposalId === proposedUpdate.id}
+                            onClick={() => void handlePublishControlProposedUpdate(proposedUpdate)}
+                          >
+                            <CheckCircle2 />
+                            {publishingProposalId === proposedUpdate.id
+                              ? 'Publishing...'
+                              : 'Publish Proposed Update'}
+                          </Button>
+                        ) : null}
+                      </div>
+                    </div>
+                  ) : (
+                    <form
+                      className="mt-4 grid gap-4 rounded-lg border p-4"
+                      onSubmit={(event) => handleCreateControlProposedUpdate(event, control)}
+                    >
+                      <h4 className="text-sm font-medium">Propose update</h4>
+                      <div className="grid gap-4 sm:grid-cols-2">
+                        <div className="space-y-2">
+                          <Label htmlFor={`${control.id}-proposal-code`}>Control Code</Label>
+                          <Input
+                            id={`${control.id}-proposal-code`}
+                            name="controlCode"
+                            defaultValue={control.currentVersion.controlCode}
+                            required
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor={`${control.id}-proposal-title`}>Title</Label>
+                          <Input
+                            id={`${control.id}-proposal-title`}
+                            name="title"
+                            defaultValue={control.currentVersion.title}
+                            required
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor={`${control.id}-proposal-business-meaning`}>
+                            Business meaning
+                          </Label>
+                          <textarea
+                            id={`${control.id}-proposal-business-meaning`}
+                            name="businessMeaning"
+                            className="min-h-24 w-full rounded-md border bg-background px-3 py-2 text-sm"
+                            defaultValue={control.currentVersion.businessMeaning}
+                            required
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor={`${control.id}-proposal-verification-method`}>
+                            Verification method
+                          </Label>
+                          <textarea
+                            id={`${control.id}-proposal-verification-method`}
+                            name="verificationMethod"
+                            className="min-h-24 w-full rounded-md border bg-background px-3 py-2 text-sm"
+                            defaultValue={control.currentVersion.verificationMethod}
+                            required
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor={`${control.id}-proposal-evidence-types`}>
+                            Accepted Evidence Types
+                          </Label>
+                          <Input
+                            id={`${control.id}-proposal-evidence-types`}
+                            name="acceptedEvidenceTypes"
+                            defaultValue={control.currentVersion.acceptedEvidenceTypes.join(', ')}
+                            required
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor={`${control.id}-proposal-release-impact`}>
+                            Release Impact
+                          </Label>
+                          <select
+                            id={`${control.id}-proposal-release-impact`}
+                            name="releaseImpact"
+                            className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                            defaultValue={control.currentVersion.releaseImpact}
+                            required
+                          >
+                            <option value="blocking">blocking</option>
+                            <option value="needs review">needs review</option>
+                            <option value="advisory">advisory</option>
+                          </select>
+                        </div>
+                        <div className="space-y-2 sm:col-span-2">
+                          <Label htmlFor={`${control.id}-proposal-applicability`}>
+                            Applicability conditions
+                          </Label>
+                          <textarea
+                            id={`${control.id}-proposal-applicability`}
+                            name="applicabilityConditions"
+                            className="min-h-20 w-full rounded-md border bg-background px-3 py-2 text-sm"
+                            defaultValue={control.currentVersion.applicabilityConditions}
+                            required
+                          />
+                        </div>
+                      </div>
+                      <Button type="submit" disabled={creatingProposalControlId === control.id}>
+                        <Plus />
+                        {creatingProposalControlId === control.id
+                          ? 'Saving...'
+                          : 'Save Proposed Update'}
+                      </Button>
+                    </form>
+                  )}
+                </article>
+              );
+            })}
           </div>
         )}
       </section>

--- a/apps/web/src/features/auth/auth-api.ts
+++ b/apps/web/src/features/auth/auth-api.ts
@@ -73,25 +73,37 @@ export type DraftControlListItem = {
 export type ControlListItem = {
   controlCode: string;
   createdAt: string;
-  currentVersion: {
-    acceptedEvidenceTypes: string[];
-    applicabilityConditions: string;
-    businessMeaning: string;
-    controlCode: string;
-    createdAt: string;
-    externalStandardsMappings: Array<{
-      description?: string;
-      framework: string;
-      reference: string;
-    }>;
-    id: string;
-    releaseImpact: 'advisory' | 'blocking' | 'needs review';
-    title: string;
-    verificationMethod: string;
-    versionNumber: number;
-  };
+  currentVersion: ControlVersionResponse;
   id: string;
   title: string;
+  versions: ControlVersionResponse[];
+};
+
+export type ControlVersionResponse = {
+  acceptedEvidenceTypes: string[];
+  applicabilityConditions: string;
+  businessMeaning: string;
+  controlCode: string;
+  createdAt: string;
+  externalStandardsMappings: Array<{
+    description?: string;
+    framework: string;
+    reference: string;
+  }>;
+  id: string;
+  releaseImpact: 'advisory' | 'blocking' | 'needs review';
+  title: string;
+  verificationMethod: string;
+  versionNumber: number;
+};
+
+export type ControlProposedUpdateListItem = ControlVersionResponse & {
+  author: {
+    email: string;
+    id: string;
+    name: string;
+  };
+  controlId: string;
 };
 
 export type OrganizationMemberListItem = {
@@ -260,6 +272,15 @@ export function listControls(organizationSlug: string) {
   );
 }
 
+export function listControlProposedUpdates(organizationSlug: string) {
+  return request<{ proposedUpdates: ControlProposedUpdateListItem[] }>(
+    `/api/organizations/${organizationSlug}/controls/proposed-updates`,
+    {
+      method: 'GET',
+    },
+  );
+}
+
 export function createDraftControl(
   organizationSlug: string,
   input: {
@@ -292,6 +313,41 @@ export function publishDraftControl(
     {
       method: 'POST',
       body: JSON.stringify(input),
+    },
+  );
+}
+
+export function createControlProposedUpdate(
+  organizationSlug: string,
+  controlId: string,
+  input: {
+    acceptedEvidenceTypes: string[];
+    applicabilityConditions: string;
+    businessMeaning: string;
+    controlCode: string;
+    releaseImpact: string;
+    title: string;
+    verificationMethod: string;
+  },
+) {
+  return request<{ proposedUpdate: ControlProposedUpdateListItem }>(
+    `/api/organizations/${organizationSlug}/controls/${controlId}/proposed-updates`,
+    {
+      method: 'POST',
+      body: JSON.stringify(input),
+    },
+  );
+}
+
+export function publishControlProposedUpdate(
+  organizationSlug: string,
+  controlId: string,
+  proposedUpdateId: string,
+) {
+  return request<{ control: ControlListItem }>(
+    `/api/organizations/${organizationSlug}/controls/${controlId}/proposed-updates/${proposedUpdateId}/publish`,
+    {
+      method: 'POST',
     },
   );
 }


### PR DESCRIPTION
## Summary
- Add open proposed updates for active Controls without mutating the current Control Version.
- Enforce one open proposed update per Control and publish proposals as the next sequential Control Version when approval is disabled.
- Show open proposed updates and simple version history in the Control Library UI.

Closes #23