### PR TITLE
Submit Control Publish Requests

### DIFF
--- a/apps/backend-hono/drizzle/migrations/0006_control_publish_requests.sql
+++ b/apps/backend-hono/drizzle/migrations/0006_control_publish_requests.sql
@@ -1,0 +1,31 @@
+CREATE TABLE `control_publish_requests` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`author_member_id` text NOT NULL,
+	`request_type` text NOT NULL,
+	`draft_control_id` text,
+	`control_id` text,
+	`proposed_update_id` text,
+	`control_code` text NOT NULL,
+	`title` text NOT NULL,
+	`business_meaning` text NOT NULL,
+	`verification_method` text NOT NULL,
+	`accepted_evidence_types` text NOT NULL,
+	`applicability_conditions` text NOT NULL,
+	`release_impact` text NOT NULL,
+	`external_standards_mappings` text NOT NULL,
+	`approval_count` integer DEFAULT 0 NOT NULL,
+	`required_approval_count` integer NOT NULL,
+	`status` text DEFAULT 'submitted' NOT NULL,
+	`submitted_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`author_member_id`) REFERENCES `members`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`draft_control_id`) REFERENCES `draft_controls`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`control_id`) REFERENCES `controls`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`proposed_update_id`) REFERENCES `control_proposed_updates`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `control_publish_request_organization_id_idx` ON `control_publish_requests` (`organization_id`);--> statement-breakpoint
+CREATE INDEX `control_publish_request_author_member_id_idx` ON `control_publish_requests` (`author_member_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `control_publish_request_draft_unique` ON `control_publish_requests` (`draft_control_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `control_publish_request_proposed_update_unique` ON `control_publish_requests` (`proposed_update_id`);

--- a/apps/backend-hono/src/db/schema.ts
+++ b/apps/backend-hono/src/db/schema.ts
@@ -309,3 +309,44 @@ export const controlProposedUpdates = sqliteTable(
     uniqueIndex('control_proposed_update_control_id_unique').on(table.controlId),
   ],
 );
+
+export const controlPublishRequests = sqliteTable(
+  'control_publish_requests',
+  {
+    id: text('id').primaryKey(),
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    authorMemberId: text('author_member_id')
+      .notNull()
+      .references(() => members.id, { onDelete: 'cascade' }),
+    requestType: text('request_type').notNull(),
+    draftControlId: text('draft_control_id').references(() => draftControls.id, {
+      onDelete: 'cascade',
+    }),
+    controlId: text('control_id').references(() => controls.id, { onDelete: 'cascade' }),
+    proposedUpdateId: text('proposed_update_id').references(() => controlProposedUpdates.id, {
+      onDelete: 'cascade',
+    }),
+    controlCode: text('control_code').notNull(),
+    title: text('title').notNull(),
+    businessMeaning: text('business_meaning').notNull(),
+    verificationMethod: text('verification_method').notNull(),
+    acceptedEvidenceTypes: text('accepted_evidence_types').notNull(),
+    applicabilityConditions: text('applicability_conditions').notNull(),
+    releaseImpact: text('release_impact').notNull(),
+    externalStandardsMappings: text('external_standards_mappings').notNull(),
+    approvalCount: integer('approval_count').default(0).notNull(),
+    requiredApprovalCount: integer('required_approval_count').notNull(),
+    status: text('status').default('submitted').notNull(),
+    submittedAt: integer('submitted_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+  },
+  (table) => [
+    index('control_publish_request_organization_id_idx').on(table.organizationId),
+    index('control_publish_request_author_member_id_idx').on(table.authorMemberId),
+    uniqueIndex('control_publish_request_draft_unique').on(table.draftControlId),
+    uniqueIndex('control_publish_request_proposed_update_unique').on(table.proposedUpdateId),
+  ],
+);

--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -15,12 +15,14 @@ import {
   canPublishControls,
   cancelDraftControl,
   ControlProposedUpdateInputError,
+  ControlPublishRequestInputError,
   createControlProposedUpdate,
   ControlPublishInputError,
   createDraftControl,
   DraftControlInputError,
   getControlDetail,
   listControlProposedUpdates,
+  listControlPublishRequests,
   listControls,
   listDraftControls,
   normalizeControlArchiveBody,
@@ -32,6 +34,8 @@ import {
   publishControlProposedUpdate,
   publishDraftControl,
   setControlArchivedForMembership,
+  submitControlProposedUpdatePublishRequest,
+  submitDraftControlPublishRequest,
 } from './lib/controls';
 import {
   canManageProjects,
@@ -283,6 +287,27 @@ app.get('/api/organizations/:organizationSlug/controls/proposed-updates', async 
   return c.json({ proposedUpdates: await listControlProposedUpdates(membership) });
 });
 
+app.get('/api/organizations/:organizationSlug/controls/publish-requests', async (c) => {
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(
+    c.req.param('organizationSlug'),
+    session.user.id,
+  );
+
+  if (!membership) {
+    return c.json({ error: 'Organization not found' }, 404);
+  }
+
+  return c.json({ publishRequests: await listControlPublishRequests(membership) });
+});
+
 app.get('/api/organizations/:organizationSlug/controls/:controlId', async (c) => {
   const session = await auth.api.getSession({
     headers: c.req.raw.headers,
@@ -429,6 +454,48 @@ app.post(
   },
 );
 
+app.post(
+  '/api/organizations/:organizationSlug/controls/drafts/:draftControlId/publish-requests',
+  async (c) => {
+    const session = await auth.api.getSession({
+      headers: c.req.raw.headers,
+    });
+
+    if (!session) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    const membership = await getOrganizationMembership(
+      c.req.param('organizationSlug'),
+      session.user.id,
+    );
+
+    if (!membership) {
+      return c.json({ error: 'Draft Control unavailable' }, 404);
+    }
+
+    try {
+      const publishRequest = await submitDraftControlPublishRequest(
+        membership,
+        c.req.param('draftControlId'),
+        normalizeDraftControlPublishBody(await c.req.json().catch(() => null)),
+      );
+
+      if (!publishRequest) {
+        return c.json({ error: 'Draft Control unavailable' }, 404);
+      }
+
+      return c.json({ publishRequest }, 201);
+    } catch (caughtError) {
+      if (caughtError instanceof ControlPublishRequestInputError) {
+        return c.json({ error: caughtError.message }, 400);
+      }
+
+      throw caughtError;
+    }
+  },
+);
+
 app.delete('/api/organizations/:organizationSlug/controls/drafts/:draftControlId', async (c) => {
   const session = await auth.api.getSession({
     headers: c.req.raw.headers,
@@ -502,6 +569,52 @@ app.post(
       return c.json({ control }, 201);
     } catch (caughtError) {
       if (caughtError instanceof ControlProposedUpdateInputError) {
+        return c.json({ error: caughtError.message }, 400);
+      }
+
+      if (caughtError instanceof ControlPublishInputError) {
+        return c.json({ error: caughtError.message }, 400);
+      }
+
+      throw caughtError;
+    }
+  },
+);
+
+app.post(
+  '/api/organizations/:organizationSlug/controls/:controlId/proposed-updates/:proposedUpdateId/publish-requests',
+  async (c) => {
+    const session = await auth.api.getSession({
+      headers: c.req.raw.headers,
+    });
+
+    if (!session) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    const membership = await getOrganizationMembership(
+      c.req.param('organizationSlug'),
+      session.user.id,
+    );
+
+    if (!membership) {
+      return c.json({ error: 'Proposed update unavailable' }, 404);
+    }
+
+    try {
+      const publishRequest = await submitControlProposedUpdatePublishRequest(
+        membership,
+        c.req.param('controlId'),
+        c.req.param('proposedUpdateId'),
+      );
+
+      if (!publishRequest) {
+        return c.json({ error: 'Proposed update unavailable' }, 404);
+      }
+
+      return c.json({ publishRequest }, 201);
+    } catch (caughtError) {
+      if (caughtError instanceof ControlPublishRequestInputError) {
         return c.json({ error: caughtError.message }, 400);
       }
 

--- a/apps/backend-hono/src/lib/controls.ts
+++ b/apps/backend-hono/src/lib/controls.ts
@@ -2,10 +2,12 @@ import { and, asc, desc, eq, isNotNull, isNull, ne } from 'drizzle-orm';
 import { db } from '../db/client';
 import {
   controlProposedUpdates,
+  controlPublishRequests,
   controls,
   controlVersions,
   draftControls,
   members,
+  organizations,
   users,
 } from '../db/schema';
 import type { OrganizationMembership } from './projects';
@@ -55,6 +57,22 @@ export type ControlProposedUpdateListItem = ControlVersionResponse & {
     name: string;
   };
   controlId: string;
+};
+
+export type ControlPublishRequestListItem = ControlVersionResponse & {
+  approvalCount: number;
+  author: {
+    email: string;
+    id: string;
+    name: string;
+  };
+  controlId: string | null;
+  draftControlId: string | null;
+  proposedUpdateId: string | null;
+  requestType: 'draft_control' | 'proposed_update';
+  requiredApprovalCount: number;
+  status: 'submitted';
+  submittedAt: string;
 };
 
 export type ControlListFilters = {
@@ -108,6 +126,7 @@ const releaseImpacts = new Set(['advisory', 'blocking', 'needs review']);
 export class DraftControlInputError extends Error {}
 export class ControlPublishInputError extends Error {}
 export class ControlProposedUpdateInputError extends Error {}
+export class ControlPublishRequestInputError extends Error {}
 
 export function canPublishControls(role: string): boolean {
   return publishControlRoles.has(role);
@@ -233,6 +252,79 @@ export async function listControlProposedUpdates(
     },
     controlId,
   }));
+}
+
+export async function listControlPublishRequests(
+  membership: OrganizationMembership,
+): Promise<ControlPublishRequestListItem[]> {
+  const rows = await db
+    .select({
+      acceptedEvidenceTypes: controlPublishRequests.acceptedEvidenceTypes,
+      approvalCount: controlPublishRequests.approvalCount,
+      applicabilityConditions: controlPublishRequests.applicabilityConditions,
+      authorEmail: users.email,
+      authorId: members.id,
+      authorName: users.name,
+      businessMeaning: controlPublishRequests.businessMeaning,
+      controlCode: controlPublishRequests.controlCode,
+      controlId: controlPublishRequests.controlId,
+      createdAt: controlPublishRequests.submittedAt,
+      draftControlId: controlPublishRequests.draftControlId,
+      externalStandardsMappings: controlPublishRequests.externalStandardsMappings,
+      id: controlPublishRequests.id,
+      proposedUpdateId: controlPublishRequests.proposedUpdateId,
+      releaseImpact: controlPublishRequests.releaseImpact,
+      requestType: controlPublishRequests.requestType,
+      requiredApprovalCount: controlPublishRequests.requiredApprovalCount,
+      status: controlPublishRequests.status,
+      submittedAt: controlPublishRequests.submittedAt,
+      title: controlPublishRequests.title,
+      verificationMethod: controlPublishRequests.verificationMethod,
+    })
+    .from(controlPublishRequests)
+    .innerJoin(members, eq(controlPublishRequests.authorMemberId, members.id))
+    .innerJoin(users, eq(members.userId, users.id))
+    .where(
+      draftReviewerRoles.has(membership.role)
+        ? eq(controlPublishRequests.organizationId, membership.organizationId)
+        : and(
+            eq(controlPublishRequests.organizationId, membership.organizationId),
+            eq(controlPublishRequests.authorMemberId, membership.id),
+          ),
+    )
+    .orderBy(desc(controlPublishRequests.submittedAt), asc(controlPublishRequests.controlCode));
+
+  return rows.map(
+    ({
+      approvalCount,
+      authorEmail,
+      authorId,
+      authorName,
+      controlId,
+      draftControlId,
+      proposedUpdateId,
+      requestType,
+      requiredApprovalCount,
+      status,
+      submittedAt,
+      ...row
+    }) => ({
+      ...toControlVersionResponse({ ...row, versionNumber: 0 }),
+      approvalCount,
+      author: {
+        email: authorEmail,
+        id: authorId,
+        name: authorName,
+      },
+      controlId,
+      draftControlId,
+      proposedUpdateId,
+      requestType: requestType as 'draft_control' | 'proposed_update',
+      requiredApprovalCount,
+      status: status as 'submitted',
+      submittedAt: submittedAt.toISOString(),
+    }),
+  );
 }
 
 export async function listDraftControls(
@@ -365,6 +457,12 @@ export async function publishDraftControl(
   input: PublishDraftControlInput,
 ): Promise<ControlListItem | null> {
   validatePublishInput(input);
+
+  await ensureControlPublishAllowed({
+    draftControlId,
+    membership,
+    proposedUpdateId: null,
+  });
 
   const draftControl = await db
     .select()
@@ -548,11 +646,162 @@ export async function createControlProposedUpdate(
   return (await listControlProposedUpdates(membership)).find(({ id }) => id === proposedUpdate.id)!;
 }
 
+export async function submitDraftControlPublishRequest(
+  membership: OrganizationMembership,
+  draftControlId: string,
+  input: PublishDraftControlInput,
+): Promise<ControlPublishRequestListItem | null> {
+  validatePublishInput(input);
+
+  const policy = await getApprovalPolicy(membership.organizationId);
+
+  if (!policy.enabled) {
+    throw new ControlPublishRequestInputError('Control Approval Policy is not enabled.');
+  }
+
+  const draftControl = await db
+    .select()
+    .from(draftControls)
+    .where(
+      and(
+        eq(draftControls.id, draftControlId),
+        eq(draftControls.organizationId, membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!draftControl) {
+    return null;
+  }
+
+  if (draftControl.authorMemberId !== membership.id && !draftReviewerRoles.has(membership.role)) {
+    return null;
+  }
+
+  const existingRequest = await db
+    .select({ id: controlPublishRequests.id })
+    .from(controlPublishRequests)
+    .where(eq(controlPublishRequests.draftControlId, draftControlId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existingRequest) {
+    throw new ControlPublishRequestInputError(
+      'This Draft Control already has a Control Publish Request.',
+    );
+  }
+
+  const request = {
+    acceptedEvidenceTypes: JSON.stringify(input.acceptedEvidenceTypes.map((value) => value.trim())),
+    applicabilityConditions: input.applicabilityConditions.trim(),
+    approvalCount: 0,
+    authorMemberId: membership.id,
+    businessMeaning: input.businessMeaning.trim(),
+    controlCode: draftControl.controlCode,
+    controlId: null,
+    draftControlId,
+    externalStandardsMappings: JSON.stringify(input.externalStandardsMappings),
+    id: crypto.randomUUID(),
+    organizationId: membership.organizationId,
+    proposedUpdateId: null,
+    releaseImpact: input.releaseImpact,
+    requestType: 'draft_control',
+    requiredApprovalCount: policy.requiredApprovals,
+    status: 'submitted',
+    submittedAt: new Date(),
+    title: draftControl.title,
+    verificationMethod: input.verificationMethod.trim(),
+  };
+
+  await db.insert(controlPublishRequests).values(request);
+
+  return (await listControlPublishRequests(membership)).find(({ id }) => id === request.id)!;
+}
+
+export async function submitControlProposedUpdatePublishRequest(
+  membership: OrganizationMembership,
+  controlId: string,
+  proposedUpdateId: string,
+): Promise<ControlPublishRequestListItem | null> {
+  const policy = await getApprovalPolicy(membership.organizationId);
+
+  if (!policy.enabled) {
+    throw new ControlPublishRequestInputError('Control Approval Policy is not enabled.');
+  }
+
+  const proposedUpdate = await db
+    .select()
+    .from(controlProposedUpdates)
+    .where(
+      and(
+        eq(controlProposedUpdates.id, proposedUpdateId),
+        eq(controlProposedUpdates.controlId, controlId),
+        eq(controlProposedUpdates.organizationId, membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!proposedUpdate) {
+    return null;
+  }
+
+  if (proposedUpdate.authorMemberId !== membership.id && !draftReviewerRoles.has(membership.role)) {
+    return null;
+  }
+
+  const existingRequest = await db
+    .select({ id: controlPublishRequests.id })
+    .from(controlPublishRequests)
+    .where(eq(controlPublishRequests.proposedUpdateId, proposedUpdateId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existingRequest) {
+    throw new ControlPublishRequestInputError(
+      'This proposed Control update already has a Control Publish Request.',
+    );
+  }
+
+  const request = {
+    acceptedEvidenceTypes: proposedUpdate.acceptedEvidenceTypes,
+    applicabilityConditions: proposedUpdate.applicabilityConditions,
+    approvalCount: 0,
+    authorMemberId: membership.id,
+    businessMeaning: proposedUpdate.businessMeaning,
+    controlCode: proposedUpdate.controlCode,
+    controlId,
+    draftControlId: null,
+    externalStandardsMappings: proposedUpdate.externalStandardsMappings,
+    id: crypto.randomUUID(),
+    organizationId: membership.organizationId,
+    proposedUpdateId,
+    releaseImpact: proposedUpdate.releaseImpact,
+    requestType: 'proposed_update',
+    requiredApprovalCount: policy.requiredApprovals,
+    status: 'submitted',
+    submittedAt: new Date(),
+    title: proposedUpdate.title,
+    verificationMethod: proposedUpdate.verificationMethod,
+  };
+
+  await db.insert(controlPublishRequests).values(request);
+
+  return (await listControlPublishRequests(membership)).find(({ id }) => id === request.id)!;
+}
+
 export async function publishControlProposedUpdate(
   membership: OrganizationMembership,
   controlId: string,
   proposedUpdateId: string,
 ): Promise<ControlListItem | null> {
+  await ensureControlPublishAllowed({
+    draftControlId: null,
+    membership,
+    proposedUpdateId,
+  });
+
   const proposedUpdate = await db
     .select()
     .from(controlProposedUpdates)
@@ -909,6 +1158,57 @@ async function getControlVersions(controlId: string): Promise<ControlVersionResp
     .orderBy(desc(controlVersions.versionNumber));
 
   return rows.map((row) => toControlVersionResponse(row));
+}
+
+async function getApprovalPolicy(organizationId: string) {
+  const organization = await db
+    .select({
+      enabled: organizations.controlApprovalPolicyEnabled,
+      requiredApprovals: organizations.controlApprovalRequiredCount,
+    })
+    .from(organizations)
+    .where(eq(organizations.id, organizationId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!organization) {
+    throw new ControlPublishInputError('Organization not found.');
+  }
+
+  return organization;
+}
+
+async function ensureControlPublishAllowed(input: {
+  draftControlId: string | null;
+  membership: OrganizationMembership;
+  proposedUpdateId: string | null;
+}) {
+  const policy = await getApprovalPolicy(input.membership.organizationId);
+
+  if (!policy.enabled) {
+    return;
+  }
+
+  const request = await db
+    .select({ approvalCount: controlPublishRequests.approvalCount })
+    .from(controlPublishRequests)
+    .where(
+      and(
+        eq(controlPublishRequests.organizationId, input.membership.organizationId),
+        eq(controlPublishRequests.status, 'submitted'),
+        input.draftControlId
+          ? eq(controlPublishRequests.draftControlId, input.draftControlId)
+          : eq(controlPublishRequests.proposedUpdateId, input.proposedUpdateId ?? ''),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!request || request.approvalCount < policy.requiredApprovals) {
+    throw new ControlPublishInputError(
+      'Control Approval Policy requires an approved Control Publish Request before publishing.',
+    );
+  }
 }
 
 function toControlVersionResponse(row: {

--- a/apps/backend-hono/test/draft-controls.spec.ts
+++ b/apps/backend-hono/test/draft-controls.spec.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import app from '../src/index';
 import { db } from '../src/db/client';
-import { controlVersions, controls, users } from '../src/db/schema';
+import { controlPublishRequests, controlVersions, controls, users } from '../src/db/schema';
 import { auth } from '../src/lib/auth';
 
 const authHeaders = {
@@ -185,6 +185,27 @@ async function publishDraftControlRequest(
   };
 }
 
+async function submitDraftControlPublishRequest(
+  organizationSlug: string,
+  draftControlId: string,
+  headers: Headers,
+  body: Record<string, unknown> = completePublishBody,
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls/drafts/${draftControlId}/publish-requests`,
+    {
+      body: JSON.stringify(body),
+      headers,
+      method: 'POST',
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
 async function listControlsRequest(
   organizationSlug: string,
   headers: Headers,
@@ -307,6 +328,31 @@ async function listControlProposedUpdatesRequest(organizationSlug: string, heade
   };
 }
 
+async function listControlPublishRequestsRequest(organizationSlug: string, headers: Headers) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls/publish-requests`,
+    { headers },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function enableControlApprovalPolicy(organizationSlug: string, headers: Headers) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/control-approval-policy`,
+    {
+      body: JSON.stringify({ enabled: true, requiredApprovals: 1 }),
+      headers,
+      method: 'PATCH',
+    },
+  );
+
+  expect(response.status).toBe(200);
+}
+
 async function publishControlProposedUpdateRequest(
   organizationSlug: string,
   controlId: string,
@@ -315,6 +361,26 @@ async function publishControlProposedUpdateRequest(
 ) {
   const response = await app.request(
     `http://example.com/api/organizations/${organizationSlug}/controls/${controlId}/proposed-updates/${proposedUpdateId}/publish`,
+    {
+      headers,
+      method: 'POST',
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function submitControlProposedUpdatePublishRequest(
+  organizationSlug: string,
+  controlId: string,
+  proposedUpdateId: string,
+  headers: Headers,
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls/${controlId}/proposed-updates/${proposedUpdateId}/publish-requests`,
     {
       headers,
       method: 'POST',
@@ -717,6 +783,142 @@ describe('Draft Controls', () => {
     ).resolves.toMatchObject({ status: 201 });
   });
 
+  it('lets members submit complete Draft Controls for review when Control Approval Policy is enabled', async () => {
+    const { headers: ownerHeaders, organization } =
+      await createSignedInOwner('request-draft-owner');
+    await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-draft-admin',
+      role: 'admin',
+    });
+    const member = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-draft-member',
+      role: 'member',
+    });
+
+    await enableControlApprovalPolicy(organization.slug, ownerHeaders);
+
+    const createResponse = await createDraftControlRequest(organization.slug, member.headers, {
+      controlCode: 'AUTH-026',
+      title: 'Submit MFA Control',
+    });
+    const draftControl = createResponse.body.draftControl as { id: string };
+    const submitResponse = await submitDraftControlPublishRequest(
+      organization.slug,
+      draftControl.id,
+      member.headers,
+    );
+
+    expect(submitResponse.status).toBe(201);
+    expect(submitResponse.body.publishRequest).toMatchObject({
+      approvalCount: 0,
+      author: { email: member.credentials.email },
+      controlCode: 'AUTH-026',
+      draftControlId: draftControl.id,
+      requestType: 'draft_control',
+      requiredApprovalCount: 1,
+      status: 'submitted',
+      title: 'Submit MFA Control',
+    });
+
+    await expect(
+      db
+        .select()
+        .from(controlPublishRequests)
+        .where(eq(controlPublishRequests.draftControlId, draftControl.id)),
+    ).resolves.toHaveLength(1);
+  });
+
+  it('limits submitted Control Publish Request visibility to author and Organization owners/admins', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'request-visibility-owner',
+    );
+    const admin = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-visibility-admin',
+      role: 'admin',
+    });
+    const firstMember = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-visibility-first-member',
+      role: 'member',
+    });
+    const secondMember = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-visibility-second-member',
+      role: 'member',
+    });
+
+    await enableControlApprovalPolicy(organization.slug, ownerHeaders);
+
+    const draftResponse = await createDraftControlRequest(organization.slug, firstMember.headers, {
+      controlCode: 'AUTH-027',
+      title: 'Visible submitted request',
+    });
+    const draftControl = draftResponse.body.draftControl as { id: string };
+
+    await submitDraftControlPublishRequest(organization.slug, draftControl.id, firstMember.headers);
+
+    await expect(
+      listControlPublishRequestsRequest(organization.slug, firstMember.headers),
+    ).resolves.toMatchObject({
+      body: { publishRequests: [{ controlCode: 'AUTH-027' }] },
+      status: 200,
+    });
+    await expect(
+      listControlPublishRequestsRequest(organization.slug, secondMember.headers),
+    ).resolves.toMatchObject({ body: { publishRequests: [] }, status: 200 });
+    await expect(
+      listControlPublishRequestsRequest(organization.slug, ownerHeaders),
+    ).resolves.toMatchObject({
+      body: { publishRequests: [{ controlCode: 'AUTH-027' }] },
+      status: 200,
+    });
+    await expect(
+      listControlPublishRequestsRequest(organization.slug, admin.headers),
+    ).resolves.toMatchObject({
+      body: { publishRequests: [{ controlCode: 'AUTH-027' }] },
+      status: 200,
+    });
+  });
+
+  it('blocks publishing while Control Approval Policy requires an approved Control Publish Request', async () => {
+    const { headers: ownerHeaders, organization } =
+      await createSignedInOwner('request-block-owner');
+    await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-block-admin',
+      role: 'admin',
+    });
+
+    await enableControlApprovalPolicy(organization.slug, ownerHeaders);
+
+    const createResponse = await createDraftControlRequest(organization.slug, ownerHeaders, {
+      controlCode: 'AUTH-028',
+      title: 'Blocked publish Control',
+    });
+    const draftControl = createResponse.body.draftControl as { id: string };
+
+    await submitDraftControlPublishRequest(organization.slug, draftControl.id, ownerHeaders);
+
+    await expect(
+      publishDraftControlRequest(organization.slug, draftControl.id, ownerHeaders),
+    ).resolves.toMatchObject({
+      body: {
+        error:
+          'Control Approval Policy requires an approved Control Publish Request before publishing.',
+      },
+      status: 400,
+    });
+  });
+
   it('validates required Control publish fields', async () => {
     const { headers: ownerHeaders, organization } = await createSignedInOwner('publish-validation');
     const createResponse = await createDraftControlRequest(organization.slug, ownerHeaders, {
@@ -853,6 +1055,84 @@ describe('Draft Controls', () => {
       createControlProposedUpdateRequest(organization.slug, control.id, ownerHeaders, proposedBody),
     ).resolves.toMatchObject({
       body: { error: 'This Control already has an open proposed update.' },
+      status: 400,
+    });
+  });
+
+  it('lets proposed Control updates be submitted as Control Publish Requests when policy is enabled', async () => {
+    const { headers: ownerHeaders, organization } =
+      await createSignedInOwner('proposal-request-owner');
+    await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'proposal-request-admin',
+      role: 'admin',
+    });
+    const member = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'proposal-request-member',
+      role: 'member',
+    });
+
+    const createResponse = await createDraftControlRequest(organization.slug, ownerHeaders, {
+      controlCode: 'AUTH-029',
+      title: 'Require MFA before request',
+    });
+    const draftControl = createResponse.body.draftControl as { id: string };
+    const publishResponse = await publishDraftControlRequest(
+      organization.slug,
+      draftControl.id,
+      ownerHeaders,
+    );
+    const control = publishResponse.body.control as { id: string };
+
+    await enableControlApprovalPolicy(organization.slug, ownerHeaders);
+
+    const proposedResponse = await createControlProposedUpdateRequest(
+      organization.slug,
+      control.id,
+      member.headers,
+      {
+        ...completePublishBody,
+        businessMeaning: 'Updated proposed release assurance meaning.',
+        controlCode: 'AUTH-029',
+        title: 'Require MFA after request',
+      },
+    );
+    const proposedUpdate = proposedResponse.body.proposedUpdate as { id: string };
+
+    await expect(
+      submitControlProposedUpdatePublishRequest(
+        organization.slug,
+        control.id,
+        proposedUpdate.id,
+        member.headers,
+      ),
+    ).resolves.toMatchObject({
+      body: {
+        publishRequest: {
+          controlCode: 'AUTH-029',
+          controlId: control.id,
+          proposedUpdateId: proposedUpdate.id,
+          requestType: 'proposed_update',
+          requiredApprovalCount: 1,
+        },
+      },
+      status: 201,
+    });
+    await expect(
+      publishControlProposedUpdateRequest(
+        organization.slug,
+        control.id,
+        proposedUpdate.id,
+        ownerHeaders,
+      ),
+    ).resolves.toMatchObject({
+      body: {
+        error:
+          'Control Approval Policy requires an approved Control Publish Request before publishing.',
+      },
       status: 400,
     });
   });

--- a/apps/web/src/components/pages/controls.tsx
+++ b/apps/web/src/components/pages/controls.tsx
@@ -7,15 +7,20 @@ import {
   cancelDraftControl,
   createControlProposedUpdate,
   createDraftControl,
+  getControlApprovalPolicy,
   getMembershipResolution,
   listControlProposedUpdates,
+  listControlPublishRequests,
   listControls,
   listDraftControls,
   publishControlProposedUpdate,
   publishDraftControl,
   restoreControl,
+  submitControlProposedUpdatePublishRequest,
+  submitDraftControlPublishRequest,
   type ControlListItem,
   type ControlProposedUpdateListItem,
+  type ControlPublishRequestListItem,
   type DraftControlListItem,
 } from '../../features/auth/auth-api';
 import { humanizeAuthError } from '../../features/auth/auth-errors';
@@ -46,7 +51,9 @@ export function ControlsPage() {
   const [controls, setControls] = useState<ControlListItem[]>([]);
   const [draftControls, setDraftControls] = useState<DraftControlListItem[]>([]);
   const [proposedUpdates, setProposedUpdates] = useState<ControlProposedUpdateListItem[]>([]);
+  const [publishRequests, setPublishRequests] = useState<ControlPublishRequestListItem[]>([]);
   const [currentRole, setCurrentRole] = useState<string | null>(null);
+  const [approvalPolicyEnabled, setApprovalPolicyEnabled] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [isCreating, setIsCreating] = useState(false);
   const [publishingDraftId, setPublishingDraftId] = useState<string | null>(null);
@@ -80,7 +87,14 @@ export function ControlsPage() {
       setIsLoading(true);
       setError(null);
       try {
-        const [controlResponse, draftResponse, proposalResponse, resolution] = await Promise.all([
+        const [
+          controlResponse,
+          draftResponse,
+          proposalResponse,
+          publishRequestResponse,
+          policyResponse,
+          resolution,
+        ] = await Promise.all([
           statusFilter === 'draft'
             ? Promise.resolve({ controls: [] })
             : listControls(organizationSlug, {
@@ -96,6 +110,10 @@ export function ControlsPage() {
           archivedView
             ? Promise.resolve({ proposedUpdates: [] })
             : listControlProposedUpdates(organizationSlug),
+          archivedView
+            ? Promise.resolve({ publishRequests: [] })
+            : listControlPublishRequests(organizationSlug),
+          getControlApprovalPolicy(organizationSlug),
           getMembershipResolution(),
         ]);
         const organization = resolution.organizations.find((org) => org.slug === organizationSlug);
@@ -103,6 +121,8 @@ export function ControlsPage() {
         setControls(controlResponse.controls);
         setDraftControls(draftResponse.draftControls);
         setProposedUpdates(proposalResponse.proposedUpdates);
+        setPublishRequests(publishRequestResponse.publishRequests);
+        setApprovalPolicyEnabled(policyResponse.policy.enabled);
         setCurrentRole(organization?.role ?? null);
       } catch (caughtError) {
         const rawMessage =
@@ -184,13 +204,26 @@ export function ControlsPage() {
     setError(null);
     setStatus(null);
     try {
-      const response = await publishDraftControl(organizationSlug, draftControl.id, {
+      const payload = {
         acceptedEvidenceTypes,
         applicabilityConditions: String(formData.get('applicabilityConditions') ?? ''),
         businessMeaning: String(formData.get('businessMeaning') ?? ''),
         releaseImpact: String(formData.get('releaseImpact') ?? ''),
         verificationMethod: String(formData.get('verificationMethod') ?? ''),
-      });
+      };
+
+      if (approvalPolicyEnabled) {
+        const response = await submitDraftControlPublishRequest(
+          organizationSlug,
+          draftControl.id,
+          payload,
+        );
+        setPublishRequests((currentRequests) => [...currentRequests, response.publishRequest]);
+        setStatus('Control Publish Request submitted.');
+        return;
+      }
+
+      const response = await publishDraftControl(organizationSlug, draftControl.id, payload);
 
       if ((statusFilter === 'all' || statusFilter === 'active') && !hasActiveControlFilters) {
         setControls((currentControls) => [...currentControls, response.control]);
@@ -323,7 +356,36 @@ export function ControlsPage() {
     }
   };
 
+  const handleSubmitControlProposedUpdate = async (
+    proposedUpdate: ControlProposedUpdateListItem,
+  ) => {
+    if (!organizationSlug) return;
+
+    setPublishingProposalId(proposedUpdate.id);
+    setError(null);
+    setStatus(null);
+    try {
+      const response = await submitControlProposedUpdatePublishRequest(
+        organizationSlug,
+        proposedUpdate.controlId,
+        proposedUpdate.id,
+      );
+
+      setPublishRequests((currentRequests) => [...currentRequests, response.publishRequest]);
+      setStatus('Control Publish Request submitted.');
+    } catch (caughtError) {
+      const rawMessage =
+        caughtError instanceof Error
+          ? caughtError.message
+          : 'Unable to submit Control Publish Request.';
+      setError(humanizeAuthError(null, rawMessage, 'Unable to submit Control Publish Request.'));
+    } finally {
+      setPublishingProposalId(null);
+    }
+  };
+
   const canPublish = canPublishControls(currentRole);
+  const canCompleteDrafts = canPublish || approvalPolicyEnabled;
   const emptyTitle = archivedView ? 'No archived Controls' : 'No active Controls yet';
   const emptyDescription = archivedView
     ? 'Archived Controls will appear here after they are hidden from active use.'
@@ -558,7 +620,27 @@ export function ControlsPage() {
                             Author: {proposedUpdate.author.name} ({proposedUpdate.author.email})
                           </p>
                         </div>
-                        {canPublish ? (
+                        {approvalPolicyEnabled ? (
+                          <Button
+                            type="button"
+                            disabled={
+                              publishingProposalId === proposedUpdate.id ||
+                              publishRequests.some(
+                                (request) => request.proposedUpdateId === proposedUpdate.id,
+                              )
+                            }
+                            onClick={() => void handleSubmitControlProposedUpdate(proposedUpdate)}
+                          >
+                            <CheckCircle2 />
+                            {publishRequests.some(
+                              (request) => request.proposedUpdateId === proposedUpdate.id,
+                            )
+                              ? 'Request Submitted'
+                              : publishingProposalId === proposedUpdate.id
+                                ? 'Submitting...'
+                                : 'Submit for Review'}
+                          </Button>
+                        ) : canPublish ? (
                           <Button
                             type="button"
                             disabled={publishingProposalId === proposedUpdate.id}
@@ -771,7 +853,7 @@ export function ControlsPage() {
                   </Button>
                 </div>
               </div>
-              {canPublish ? (
+              {canCompleteDrafts ? (
                 <form
                   className="mt-5 grid gap-4"
                   onSubmit={(event) => handlePublishDraftControl(event, draftControl)}
@@ -836,14 +918,63 @@ export function ControlsPage() {
                       required
                     />
                   </div>
-                  <Button type="submit" disabled={publishingDraftId === draftControl.id}>
+                  <Button
+                    type="submit"
+                    disabled={
+                      publishingDraftId === draftControl.id ||
+                      publishRequests.some((request) => request.draftControlId === draftControl.id)
+                    }
+                  >
                     <CheckCircle2 />
-                    {publishingDraftId === draftControl.id ? 'Publishing...' : 'Publish Control'}
+                    {publishRequests.some((request) => request.draftControlId === draftControl.id)
+                      ? 'Request Submitted'
+                      : publishingDraftId === draftControl.id
+                        ? approvalPolicyEnabled
+                          ? 'Submitting...'
+                          : 'Publishing...'
+                        : approvalPolicyEnabled
+                          ? 'Submit for Review'
+                          : 'Publish Control'}
                   </Button>
                 </form>
               ) : null}
             </article>
           ))}
+        </section>
+      ) : null}
+
+      {!archivedView && publishRequests.length > 0 ? (
+        <section className="space-y-3">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold">Control Publish Requests</h2>
+            <p className="text-sm text-muted-foreground">
+              Submitted requests wait for approvals before the Control can be published.
+            </p>
+          </div>
+          <div className="grid gap-3">
+            {publishRequests.map((request) => (
+              <article key={request.id} className="rounded-xl border bg-card p-5">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="space-y-1">
+                    <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                      {request.controlCode} ·{' '}
+                      {request.requestType === 'draft_control' ? 'New Control' : 'Control update'}
+                    </p>
+                    <h3 className="text-base font-semibold">{request.title}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Author: {request.author.name} ({request.author.email})
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      Approvals: {request.approvalCount} of {request.requiredApprovalCount}
+                    </p>
+                  </div>
+                  <p className="shrink-0 text-xs text-muted-foreground">
+                    Submitted {formatDate(request.submittedAt)}
+                  </p>
+                </div>
+              </article>
+            ))}
+          </div>
         </section>
       ) : null}
     </div>

--- a/apps/web/src/features/auth/auth-api.ts
+++ b/apps/web/src/features/auth/auth-api.ts
@@ -109,6 +109,22 @@ export type ControlProposedUpdateListItem = ControlVersionResponse & {
   controlId: string;
 };
 
+export type ControlPublishRequestListItem = ControlVersionResponse & {
+  approvalCount: number;
+  author: {
+    email: string;
+    id: string;
+    name: string;
+  };
+  controlId: string | null;
+  draftControlId: string | null;
+  proposedUpdateId: string | null;
+  requestType: 'draft_control' | 'proposed_update';
+  requiredApprovalCount: number;
+  status: 'submitted';
+  submittedAt: string;
+};
+
 export type ControlListFilters = {
   acceptedEvidenceType?: string;
   releaseImpact?: string;
@@ -344,6 +360,15 @@ export function listControlProposedUpdates(organizationSlug: string) {
   );
 }
 
+export function listControlPublishRequests(organizationSlug: string) {
+  return request<{ publishRequests: ControlPublishRequestListItem[] }>(
+    `/api/organizations/${organizationSlug}/controls/publish-requests`,
+    {
+      method: 'GET',
+    },
+  );
+}
+
 export function createDraftControl(
   organizationSlug: string,
   input: {
@@ -373,6 +398,26 @@ export function publishDraftControl(
 ) {
   return request<{ control: ControlListItem }>(
     `/api/organizations/${organizationSlug}/controls/drafts/${draftControlId}/publish`,
+    {
+      method: 'POST',
+      body: JSON.stringify(input),
+    },
+  );
+}
+
+export function submitDraftControlPublishRequest(
+  organizationSlug: string,
+  draftControlId: string,
+  input: {
+    acceptedEvidenceTypes: string[];
+    applicabilityConditions: string;
+    businessMeaning: string;
+    releaseImpact: string;
+    verificationMethod: string;
+  },
+) {
+  return request<{ publishRequest: ControlPublishRequestListItem }>(
+    `/api/organizations/${organizationSlug}/controls/drafts/${draftControlId}/publish-requests`,
     {
       method: 'POST',
       body: JSON.stringify(input),
@@ -441,6 +486,19 @@ export function publishControlProposedUpdate(
 ) {
   return request<{ control: ControlListItem }>(
     `/api/organizations/${organizationSlug}/controls/${controlId}/proposed-updates/${proposedUpdateId}/publish`,
+    {
+      method: 'POST',
+    },
+  );
+}
+
+export function submitControlProposedUpdatePublishRequest(
+  organizationSlug: string,
+  controlId: string,
+  proposedUpdateId: string,
+) {
+  return request<{ publishRequest: ControlPublishRequestListItem }>(
+    `/api/organizations/${organizationSlug}/controls/${controlId}/proposed-updates/${proposedUpdateId}/publish-requests`,
     {
       method: 'POST',
     },


### PR DESCRIPTION
## Summary
- Add Control Publish Request persistence and APIs for draft Controls and proposed Control updates.
- Surface submitted requests in the Control Library UI and submit complete drafts/proposed updates when the Control Approval Policy is enabled.
- Block direct Control publishing while the current Control Approval Policy still requires approvals.

## Checks
- pnpm format
- pnpm format:check
- pnpm lint
- pnpm check-types
- pnpm test
- pnpm build

Closes #26