### PR TITLE
Review control publish requests

### DIFF
--- a/apps/backend-hono/drizzle/migrations/0007_control_publish_request_reviews.sql
+++ b/apps/backend-hono/drizzle/migrations/0007_control_publish_request_reviews.sql
@@ -1,0 +1,12 @@
+ALTER TABLE `control_publish_requests` ADD `rejection_comment` text;--> statement-breakpoint
+CREATE TABLE `control_publish_request_approvals` (
+	`id` text PRIMARY KEY NOT NULL,
+	`request_id` text NOT NULL,
+	`approver_member_id` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`request_id`) REFERENCES `control_publish_requests`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`approver_member_id`) REFERENCES `members`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `control_publish_request_approval_request_id_idx` ON `control_publish_request_approvals` (`request_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `control_publish_request_approval_member_unique` ON `control_publish_request_approvals` (`request_id`,`approver_member_id`);

--- a/apps/backend-hono/src/db/schema.ts
+++ b/apps/backend-hono/src/db/schema.ts
@@ -338,6 +338,7 @@ export const controlPublishRequests = sqliteTable(
     externalStandardsMappings: text('external_standards_mappings').notNull(),
     approvalCount: integer('approval_count').default(0).notNull(),
     requiredApprovalCount: integer('required_approval_count').notNull(),
+    rejectionComment: text('rejection_comment'),
     status: text('status').default('submitted').notNull(),
     submittedAt: integer('submitted_at', { mode: 'timestamp_ms' })
       .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
@@ -348,5 +349,28 @@ export const controlPublishRequests = sqliteTable(
     index('control_publish_request_author_member_id_idx').on(table.authorMemberId),
     uniqueIndex('control_publish_request_draft_unique').on(table.draftControlId),
     uniqueIndex('control_publish_request_proposed_update_unique').on(table.proposedUpdateId),
+  ],
+);
+
+export const controlPublishRequestApprovals = sqliteTable(
+  'control_publish_request_approvals',
+  {
+    id: text('id').primaryKey(),
+    requestId: text('request_id')
+      .notNull()
+      .references(() => controlPublishRequests.id, { onDelete: 'cascade' }),
+    approverMemberId: text('approver_member_id')
+      .notNull()
+      .references(() => members.id, { onDelete: 'cascade' }),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+  },
+  (table) => [
+    index('control_publish_request_approval_request_id_idx').on(table.requestId),
+    uniqueIndex('control_publish_request_approval_member_unique').on(
+      table.requestId,
+      table.approverMemberId,
+    ),
   ],
 );

--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -13,6 +13,7 @@ import {
 import {
   canArchiveControls,
   canPublishControls,
+  approveControlPublishRequest,
   cancelDraftControl,
   ControlProposedUpdateInputError,
   ControlPublishRequestInputError,
@@ -27,15 +28,18 @@ import {
   listDraftControls,
   normalizeControlArchiveBody,
   normalizeControlListFilters,
+  normalizeControlPublishRequestRejectionBody,
   normalizeControlProposedUpdateBody,
   normalizeDraftControlListFilters,
   normalizeDraftControlCreateBody,
   normalizeDraftControlPublishBody,
   publishControlProposedUpdate,
   publishDraftControl,
+  rejectControlPublishRequest,
   setControlArchivedForMembership,
   submitControlProposedUpdatePublishRequest,
   submitDraftControlPublishRequest,
+  withdrawControlPublishRequest,
 } from './lib/controls';
 import {
   canManageProjects,
@@ -334,6 +338,21 @@ app.get('/api/organizations/:organizationSlug/controls/:controlId', async (c) =>
 
   return c.json({ control });
 });
+
+app.post(
+  '/api/organizations/:organizationSlug/controls/publish-requests/:publishRequestId/approve',
+  async (c) => reviewControlPublishRequest(c, 'approve'),
+);
+
+app.post(
+  '/api/organizations/:organizationSlug/controls/publish-requests/:publishRequestId/reject',
+  async (c) => reviewControlPublishRequest(c, 'reject'),
+);
+
+app.post(
+  '/api/organizations/:organizationSlug/controls/publish-requests/:publishRequestId/withdraw',
+  async (c) => reviewControlPublishRequest(c, 'withdraw'),
+);
 
 app.post('/api/organizations/:organizationSlug/controls/drafts', async (c) => {
   const session = await auth.api.getSession({
@@ -824,6 +843,54 @@ async function setControlArchived(c: Context, archived: boolean) {
   }
 
   return c.json({ control });
+}
+
+async function reviewControlPublishRequest(c: Context, action: 'approve' | 'reject' | 'withdraw') {
+  const organizationSlug = c.req.param('organizationSlug');
+  const publishRequestId = c.req.param('publishRequestId');
+
+  if (!organizationSlug || !publishRequestId) {
+    return c.json({ error: 'Control Publish Request unavailable' }, 404);
+  }
+
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(organizationSlug, session.user.id);
+
+  if (!membership) {
+    return c.json({ error: 'Control Publish Request unavailable' }, 404);
+  }
+
+  try {
+    const publishRequest =
+      action === 'approve'
+        ? await approveControlPublishRequest(membership, publishRequestId)
+        : action === 'reject'
+          ? await rejectControlPublishRequest(
+              membership,
+              publishRequestId,
+              normalizeControlPublishRequestRejectionBody(await c.req.json().catch(() => null)),
+            )
+          : await withdrawControlPublishRequest(membership, publishRequestId);
+
+    if (!publishRequest) {
+      return c.json({ error: 'Control Publish Request unavailable' }, 404);
+    }
+
+    return c.json({ publishRequest });
+  } catch (caughtError) {
+    if (caughtError instanceof ControlPublishRequestInputError) {
+      return c.json({ error: caughtError.message }, 400);
+    }
+
+    throw caughtError;
+  }
 }
 
 app.on(['POST', 'GET'], '/api/auth/*', (c) => auth.handler(c.req.raw));

--- a/apps/backend-hono/src/lib/auth-organization.ts
+++ b/apps/backend-hono/src/lib/auth-organization.ts
@@ -25,6 +25,7 @@ export type MembershipResolutionResponse = {
   activeOrganizationId: string | null;
   organizations: Array<{
     id: string;
+    memberId: string;
     name: string;
     slug: string;
     role: string;
@@ -246,8 +247,9 @@ export async function resolveMembershipResolution({
     organizations: orderMembershipOrganizations(
       membershipOrganizations,
       resolvedActiveOrganizationId,
-    ).map(({ id, membershipCreatedAt: _membershipCreatedAt, name, role, slug }) => ({
+    ).map(({ id, memberId, membershipCreatedAt: _membershipCreatedAt, name, role, slug }) => ({
       id,
+      memberId,
       name,
       role,
       slug,
@@ -388,6 +390,7 @@ async function listMembershipOrganizations(userId: string): Promise<MembershipOr
   return db
     .select({
       id: organizations.id,
+      memberId: members.id,
       membershipCreatedAt: members.createdAt,
       name: organizations.name,
       role: members.role,

--- a/apps/backend-hono/src/lib/controls.ts
+++ b/apps/backend-hono/src/lib/controls.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, isNotNull, isNull, ne } from 'drizzle-orm';
 import { db } from '../db/client';
 import {
   controlProposedUpdates,
+  controlPublishRequestApprovals,
   controlPublishRequests,
   controls,
   controlVersions,
@@ -69,9 +70,10 @@ export type ControlPublishRequestListItem = ControlVersionResponse & {
   controlId: string | null;
   draftControlId: string | null;
   proposedUpdateId: string | null;
+  rejectionComment: string | null;
   requestType: 'draft_control' | 'proposed_update';
   requiredApprovalCount: number;
-  status: 'submitted';
+  status: 'draft' | 'submitted';
   submittedAt: string;
 };
 
@@ -116,6 +118,10 @@ type ArchiveControlInput = {
 type CreateControlProposedUpdateInput = PublishDraftControlInput & {
   controlCode: string;
   title: string;
+};
+
+type RejectControlPublishRequestInput = {
+  comment: string;
 };
 
 const draftReviewerRoles = new Set(['owner', 'admin']);
@@ -273,6 +279,7 @@ export async function listControlPublishRequests(
       externalStandardsMappings: controlPublishRequests.externalStandardsMappings,
       id: controlPublishRequests.id,
       proposedUpdateId: controlPublishRequests.proposedUpdateId,
+      rejectionComment: controlPublishRequests.rejectionComment,
       releaseImpact: controlPublishRequests.releaseImpact,
       requestType: controlPublishRequests.requestType,
       requiredApprovalCount: controlPublishRequests.requiredApprovalCount,
@@ -303,6 +310,7 @@ export async function listControlPublishRequests(
       controlId,
       draftControlId,
       proposedUpdateId,
+      rejectionComment,
       requestType,
       requiredApprovalCount,
       status,
@@ -319,9 +327,10 @@ export async function listControlPublishRequests(
       controlId,
       draftControlId,
       proposedUpdateId,
+      rejectionComment,
       requestType: requestType as 'draft_control' | 'proposed_update',
       requiredApprovalCount,
-      status: status as 'submitted',
+      status: status as 'draft' | 'submitted',
       submittedAt: submittedAt.toISOString(),
     }),
   );
@@ -686,12 +695,6 @@ export async function submitDraftControlPublishRequest(
     .limit(1)
     .then((rows) => rows[0] ?? null);
 
-  if (existingRequest) {
-    throw new ControlPublishRequestInputError(
-      'This Draft Control already has a Control Publish Request.',
-    );
-  }
-
   const request = {
     acceptedEvidenceTypes: JSON.stringify(input.acceptedEvidenceTypes.map((value) => value.trim())),
     applicabilityConditions: input.applicabilityConditions.trim(),
@@ -708,15 +711,22 @@ export async function submitDraftControlPublishRequest(
     releaseImpact: input.releaseImpact,
     requestType: 'draft_control',
     requiredApprovalCount: policy.requiredApprovals,
+    rejectionComment: null,
     status: 'submitted',
     submittedAt: new Date(),
     title: draftControl.title,
     verificationMethod: input.verificationMethod.trim(),
   };
 
-  await db.insert(controlPublishRequests).values(request);
+  if (existingRequest) {
+    await resetControlPublishRequest(existingRequest.id, request);
+  } else {
+    await db.insert(controlPublishRequests).values(request);
+  }
 
-  return (await listControlPublishRequests(membership)).find(({ id }) => id === request.id)!;
+  return (await listControlPublishRequests(membership)).find(
+    ({ id }) => id === (existingRequest?.id ?? request.id),
+  )!;
 }
 
 export async function submitControlProposedUpdatePublishRequest(
@@ -758,12 +768,6 @@ export async function submitControlProposedUpdatePublishRequest(
     .limit(1)
     .then((rows) => rows[0] ?? null);
 
-  if (existingRequest) {
-    throw new ControlPublishRequestInputError(
-      'This proposed Control update already has a Control Publish Request.',
-    );
-  }
-
   const request = {
     acceptedEvidenceTypes: proposedUpdate.acceptedEvidenceTypes,
     applicabilityConditions: proposedUpdate.applicabilityConditions,
@@ -780,15 +784,144 @@ export async function submitControlProposedUpdatePublishRequest(
     releaseImpact: proposedUpdate.releaseImpact,
     requestType: 'proposed_update',
     requiredApprovalCount: policy.requiredApprovals,
+    rejectionComment: null,
     status: 'submitted',
     submittedAt: new Date(),
     title: proposedUpdate.title,
     verificationMethod: proposedUpdate.verificationMethod,
   };
 
-  await db.insert(controlPublishRequests).values(request);
+  if (existingRequest) {
+    await resetControlPublishRequest(existingRequest.id, request);
+  } else {
+    await db.insert(controlPublishRequests).values(request);
+  }
 
-  return (await listControlPublishRequests(membership)).find(({ id }) => id === request.id)!;
+  return (await listControlPublishRequests(membership)).find(
+    ({ id }) => id === (existingRequest?.id ?? request.id),
+  )!;
+}
+
+export async function approveControlPublishRequest(
+  membership: OrganizationMembership,
+  publishRequestId: string,
+): Promise<ControlPublishRequestListItem | null> {
+  const request = await getReviewableControlPublishRequest(membership, publishRequestId);
+
+  if (!request) {
+    return null;
+  }
+
+  if (!publishControlRoles.has(membership.role)) {
+    throw new ControlPublishRequestInputError(
+      'Only Organization owners and admins can approve Control Publish Requests.',
+    );
+  }
+
+  if (request.authorMemberId === membership.id) {
+    throw new ControlPublishRequestInputError(
+      'Authors cannot approve their own Control Publish Requests.',
+    );
+  }
+
+  if (request.status !== 'submitted') {
+    throw new ControlPublishRequestInputError(
+      'Only submitted Control Publish Requests can be approved.',
+    );
+  }
+
+  const existingApproval = await db
+    .select({ id: controlPublishRequestApprovals.id })
+    .from(controlPublishRequestApprovals)
+    .where(
+      and(
+        eq(controlPublishRequestApprovals.requestId, publishRequestId),
+        eq(controlPublishRequestApprovals.approverMemberId, membership.id),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!existingApproval) {
+    await db.insert(controlPublishRequestApprovals).values({
+      approverMemberId: membership.id,
+      createdAt: new Date(),
+      id: crypto.randomUUID(),
+      requestId: publishRequestId,
+    });
+  }
+
+  await updateControlPublishRequestApprovalCount(publishRequestId);
+
+  return (await listControlPublishRequests(membership)).find(({ id }) => id === publishRequestId)!;
+}
+
+export async function rejectControlPublishRequest(
+  membership: OrganizationMembership,
+  publishRequestId: string,
+  input: RejectControlPublishRequestInput,
+): Promise<ControlPublishRequestListItem | null> {
+  const request = await getReviewableControlPublishRequest(membership, publishRequestId);
+  const comment = input.comment.trim();
+
+  if (!request) {
+    return null;
+  }
+
+  if (!publishControlRoles.has(membership.role)) {
+    throw new ControlPublishRequestInputError(
+      'Only Organization owners and admins can reject Control Publish Requests.',
+    );
+  }
+
+  if (!comment) {
+    throw new ControlPublishRequestInputError('Rejection comment is required.');
+  }
+
+  if (request.status !== 'submitted') {
+    throw new ControlPublishRequestInputError(
+      'Only submitted Control Publish Requests can be rejected.',
+    );
+  }
+
+  await clearControlPublishRequestApprovals(publishRequestId);
+  await db
+    .update(controlPublishRequests)
+    .set({ approvalCount: 0, rejectionComment: comment, status: 'draft' })
+    .where(eq(controlPublishRequests.id, publishRequestId));
+
+  return (await listControlPublishRequests(membership)).find(({ id }) => id === publishRequestId)!;
+}
+
+export async function withdrawControlPublishRequest(
+  membership: OrganizationMembership,
+  publishRequestId: string,
+): Promise<ControlPublishRequestListItem | null> {
+  const request = await getReviewableControlPublishRequest(membership, publishRequestId);
+
+  if (!request) {
+    return null;
+  }
+
+  if (request.authorMemberId !== membership.id) {
+    throw new ControlPublishRequestInputError(
+      'Only the author can withdraw a Control Publish Request.',
+    );
+  }
+
+  if (request.status !== 'submitted') {
+    throw new ControlPublishRequestInputError(
+      'Only submitted Control Publish Requests can be withdrawn.',
+    );
+  }
+
+  await clearControlPublishRequestApprovals(publishRequestId);
+  await db
+    .update(controlPublishRequests)
+    .set({ approvalCount: 0, rejectionComment: null, status: 'draft' })
+    .where(eq(controlPublishRequests.id, publishRequestId));
+
+  return (await listControlPublishRequests(membership)).find(({ id }) => id === publishRequestId)!;
 }
 
 export async function publishControlProposedUpdate(
@@ -966,6 +1099,15 @@ export function normalizeControlProposedUpdateBody(
     controlCode: typeof record.controlCode === 'string' ? record.controlCode : '',
     title: typeof record.title === 'string' ? record.title : '',
   };
+}
+
+export function normalizeControlPublishRequestRejectionBody(
+  body: unknown,
+): RejectControlPublishRequestInput {
+  const value = typeof body === 'object' && body !== null ? body : {};
+  const record = value as Record<string, unknown>;
+
+  return { comment: typeof record.comment === 'string' ? record.comment : '' };
 }
 
 function validateDraftControlInput(input: CreateDraftControlInput) {
@@ -1209,6 +1351,56 @@ async function ensureControlPublishAllowed(input: {
       'Control Approval Policy requires an approved Control Publish Request before publishing.',
     );
   }
+}
+
+async function getReviewableControlPublishRequest(
+  membership: OrganizationMembership,
+  publishRequestId: string,
+) {
+  return db
+    .select({
+      authorMemberId: controlPublishRequests.authorMemberId,
+      id: controlPublishRequests.id,
+      status: controlPublishRequests.status,
+    })
+    .from(controlPublishRequests)
+    .where(
+      and(
+        eq(controlPublishRequests.id, publishRequestId),
+        eq(controlPublishRequests.organizationId, membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+}
+
+async function resetControlPublishRequest(
+  requestId: string,
+  values: typeof controlPublishRequests.$inferInsert,
+) {
+  await clearControlPublishRequestApprovals(requestId);
+  await db
+    .update(controlPublishRequests)
+    .set({ ...values, id: requestId })
+    .where(eq(controlPublishRequests.id, requestId));
+}
+
+async function clearControlPublishRequestApprovals(requestId: string) {
+  await db
+    .delete(controlPublishRequestApprovals)
+    .where(eq(controlPublishRequestApprovals.requestId, requestId));
+}
+
+async function updateControlPublishRequestApprovalCount(requestId: string) {
+  const approvals = await db
+    .select({ id: controlPublishRequestApprovals.id })
+    .from(controlPublishRequestApprovals)
+    .where(eq(controlPublishRequestApprovals.requestId, requestId));
+
+  await db
+    .update(controlPublishRequests)
+    .set({ approvalCount: approvals.length })
+    .where(eq(controlPublishRequests.id, requestId));
 }
 
 function toControlVersionResponse(row: {

--- a/apps/backend-hono/test/draft-controls.spec.ts
+++ b/apps/backend-hono/test/draft-controls.spec.ts
@@ -3,7 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import app from '../src/index';
 import { db } from '../src/db/client';
-import { controlPublishRequests, controlVersions, controls, users } from '../src/db/schema';
+import {
+  controlPublishRequestApprovals,
+  controlPublishRequests,
+  controlVersions,
+  controls,
+  users,
+} from '../src/db/schema';
 import { auth } from '../src/lib/auth';
 
 const authHeaders = {
@@ -332,6 +338,65 @@ async function listControlPublishRequestsRequest(organizationSlug: string, heade
   const response = await app.request(
     `http://example.com/api/organizations/${organizationSlug}/controls/publish-requests`,
     { headers },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function approveControlPublishRequest(
+  organizationSlug: string,
+  publishRequestId: string,
+  headers: Headers,
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls/publish-requests/${publishRequestId}/approve`,
+    {
+      headers,
+      method: 'POST',
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function rejectControlPublishRequest(
+  organizationSlug: string,
+  publishRequestId: string,
+  headers: Headers,
+  body: Record<string, unknown>,
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls/publish-requests/${publishRequestId}/reject`,
+    {
+      body: JSON.stringify(body),
+      headers,
+      method: 'POST',
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function withdrawControlPublishRequest(
+  organizationSlug: string,
+  publishRequestId: string,
+  headers: Headers,
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls/publish-requests/${publishRequestId}/withdraw`,
+    {
+      headers,
+      method: 'POST',
+    },
   );
 
   return {
@@ -916,6 +981,223 @@ describe('Draft Controls', () => {
           'Control Approval Policy requires an approved Control Publish Request before publishing.',
       },
       status: 400,
+    });
+  });
+
+  it('lets eligible owners and admins approve submitted Control Publish Requests except their own', async () => {
+    const { headers: ownerHeaders, organization } =
+      await createSignedInOwner('request-approve-owner');
+    const admin = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-approve-admin',
+      role: 'admin',
+    });
+    const member = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-approve-member',
+      role: 'member',
+    });
+
+    await enableControlApprovalPolicy(organization.slug, ownerHeaders);
+
+    const createResponse = await createDraftControlRequest(organization.slug, member.headers, {
+      controlCode: 'AUTH-030',
+      title: 'Approval reviewed Control',
+    });
+    const draftControl = createResponse.body.draftControl as { id: string };
+    const submitResponse = await submitDraftControlPublishRequest(
+      organization.slug,
+      draftControl.id,
+      member.headers,
+    );
+    const publishRequest = submitResponse.body.publishRequest as { id: string };
+
+    await expect(
+      approveControlPublishRequest(organization.slug, publishRequest.id, member.headers),
+    ).resolves.toMatchObject({
+      body: { error: 'Only Organization owners and admins can approve Control Publish Requests.' },
+      status: 400,
+    });
+
+    const adminApproveResponse = await approveControlPublishRequest(
+      organization.slug,
+      publishRequest.id,
+      admin.headers,
+    );
+
+    expect(adminApproveResponse.status).toBe(200);
+    expect(adminApproveResponse.body.publishRequest).toMatchObject({
+      approvalCount: 1,
+      status: 'submitted',
+    });
+
+    await expect(
+      approveControlPublishRequest(organization.slug, publishRequest.id, admin.headers),
+    ).resolves.toMatchObject({
+      body: { publishRequest: { approvalCount: 1 } },
+      status: 200,
+    });
+  });
+
+  it('prevents Control Publish Request authors from approving their own requests', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'request-self-approve-owner',
+    );
+    await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-self-approve-admin',
+      role: 'admin',
+    });
+
+    await enableControlApprovalPolicy(organization.slug, ownerHeaders);
+
+    const createResponse = await createDraftControlRequest(organization.slug, ownerHeaders, {
+      controlCode: 'AUTH-031',
+      title: 'Self approval Control',
+    });
+    const draftControl = createResponse.body.draftControl as { id: string };
+    const submitResponse = await submitDraftControlPublishRequest(
+      organization.slug,
+      draftControl.id,
+      ownerHeaders,
+    );
+    const publishRequest = submitResponse.body.publishRequest as { id: string };
+
+    await expect(
+      approveControlPublishRequest(organization.slug, publishRequest.id, ownerHeaders),
+    ).resolves.toMatchObject({
+      body: { error: 'Authors cannot approve their own Control Publish Requests.' },
+      status: 400,
+    });
+  });
+
+  it('requires a rejection comment and returns submitted requests to draft with approvals reset', async () => {
+    const { headers: ownerHeaders, organization } =
+      await createSignedInOwner('request-reject-owner');
+    const admin = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-reject-admin',
+      role: 'admin',
+    });
+    const member = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-reject-member',
+      role: 'member',
+    });
+
+    await enableControlApprovalPolicy(organization.slug, ownerHeaders);
+
+    const createResponse = await createDraftControlRequest(organization.slug, member.headers, {
+      controlCode: 'AUTH-032',
+      title: 'Rejected Control',
+    });
+    const draftControl = createResponse.body.draftControl as { id: string };
+    const submitResponse = await submitDraftControlPublishRequest(
+      organization.slug,
+      draftControl.id,
+      member.headers,
+    );
+    const publishRequest = submitResponse.body.publishRequest as { id: string };
+
+    await approveControlPublishRequest(organization.slug, publishRequest.id, admin.headers);
+
+    await expect(
+      rejectControlPublishRequest(organization.slug, publishRequest.id, ownerHeaders, {
+        comment: '',
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Rejection comment is required.' },
+      status: 400,
+    });
+
+    const rejectResponse = await rejectControlPublishRequest(
+      organization.slug,
+      publishRequest.id,
+      ownerHeaders,
+      { comment: 'Evidence does not cover the applicability conditions.' },
+    );
+
+    expect(rejectResponse.status).toBe(200);
+    expect(rejectResponse.body.publishRequest).toMatchObject({
+      approvalCount: 0,
+      rejectionComment: 'Evidence does not cover the applicability conditions.',
+      status: 'draft',
+    });
+    await expect(
+      db
+        .select()
+        .from(controlPublishRequestApprovals)
+        .where(eq(controlPublishRequestApprovals.requestId, publishRequest.id)),
+    ).resolves.toHaveLength(0);
+  });
+
+  it('lets authors withdraw submitted requests and resubmit edits with approvals reset', async () => {
+    const { headers: ownerHeaders, organization } =
+      await createSignedInOwner('request-withdraw-owner');
+    const admin = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-withdraw-admin',
+      role: 'admin',
+    });
+    const member = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-withdraw-member',
+      role: 'member',
+    });
+
+    await enableControlApprovalPolicy(organization.slug, ownerHeaders);
+
+    const createResponse = await createDraftControlRequest(organization.slug, member.headers, {
+      controlCode: 'AUTH-033',
+      title: 'Withdrawn Control',
+    });
+    const draftControl = createResponse.body.draftControl as { id: string };
+    const submitResponse = await submitDraftControlPublishRequest(
+      organization.slug,
+      draftControl.id,
+      member.headers,
+    );
+    const publishRequest = submitResponse.body.publishRequest as { id: string };
+
+    await approveControlPublishRequest(organization.slug, publishRequest.id, admin.headers);
+
+    await expect(
+      withdrawControlPublishRequest(organization.slug, publishRequest.id, ownerHeaders),
+    ).resolves.toMatchObject({
+      body: { error: 'Only the author can withdraw a Control Publish Request.' },
+      status: 400,
+    });
+
+    await expect(
+      withdrawControlPublishRequest(organization.slug, publishRequest.id, member.headers),
+    ).resolves.toMatchObject({
+      body: { publishRequest: { approvalCount: 0, status: 'draft' } },
+      status: 200,
+    });
+
+    const resubmitResponse = await submitDraftControlPublishRequest(
+      organization.slug,
+      draftControl.id,
+      member.headers,
+      {
+        ...completePublishBody,
+        businessMeaning: 'Edited after review so approvals must be recollected.',
+      },
+    );
+
+    expect(resubmitResponse.status).toBe(201);
+    expect(resubmitResponse.body.publishRequest).toMatchObject({
+      approvalCount: 0,
+      businessMeaning: 'Edited after review so approvals must be recollected.',
+      id: publishRequest.id,
+      status: 'submitted',
     });
   });
 

--- a/apps/web/src/components/pages/controls.tsx
+++ b/apps/web/src/components/pages/controls.tsx
@@ -4,6 +4,7 @@ import { AlertCircle, Archive, CheckCircle2, Plus, RotateCcw, Trash2 } from 'luc
 import { useParams, useSearchParams } from 'react-router';
 import {
   archiveControl,
+  approveControlPublishRequest,
   cancelDraftControl,
   createControlProposedUpdate,
   createDraftControl,
@@ -15,9 +16,11 @@ import {
   listDraftControls,
   publishControlProposedUpdate,
   publishDraftControl,
+  rejectControlPublishRequest,
   restoreControl,
   submitControlProposedUpdatePublishRequest,
   submitDraftControlPublishRequest,
+  withdrawControlPublishRequest,
   type ControlListItem,
   type ControlProposedUpdateListItem,
   type ControlPublishRequestListItem,
@@ -53,12 +56,16 @@ export function ControlsPage() {
   const [proposedUpdates, setProposedUpdates] = useState<ControlProposedUpdateListItem[]>([]);
   const [publishRequests, setPublishRequests] = useState<ControlPublishRequestListItem[]>([]);
   const [currentRole, setCurrentRole] = useState<string | null>(null);
+  const [currentMemberId, setCurrentMemberId] = useState<string | null>(null);
   const [approvalPolicyEnabled, setApprovalPolicyEnabled] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [isCreating, setIsCreating] = useState(false);
   const [publishingDraftId, setPublishingDraftId] = useState<string | null>(null);
   const [creatingProposalControlId, setCreatingProposalControlId] = useState<string | null>(null);
   const [publishingProposalId, setPublishingProposalId] = useState<string | null>(null);
+  const [reviewingRequestId, setReviewingRequestId] = useState<string | null>(null);
+  const [rejectingRequestId, setRejectingRequestId] = useState<string | null>(null);
+  const [rejectionComment, setRejectionComment] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
   const [controlCode, setControlCode] = useState('');
@@ -124,6 +131,7 @@ export function ControlsPage() {
         setPublishRequests(publishRequestResponse.publishRequests);
         setApprovalPolicyEnabled(policyResponse.policy.enabled);
         setCurrentRole(organization?.role ?? null);
+        setCurrentMemberId(organization?.memberId ?? null);
       } catch (caughtError) {
         const rawMessage =
           caughtError instanceof Error ? caughtError.message : 'Unable to load Draft Controls.';
@@ -218,7 +226,9 @@ export function ControlsPage() {
           draftControl.id,
           payload,
         );
-        setPublishRequests((currentRequests) => [...currentRequests, response.publishRequest]);
+        setPublishRequests((currentRequests) =>
+          upsertPublishRequest(currentRequests, response.publishRequest),
+        );
         setStatus('Control Publish Request submitted.');
         return;
       }
@@ -371,7 +381,9 @@ export function ControlsPage() {
         proposedUpdate.id,
       );
 
-      setPublishRequests((currentRequests) => [...currentRequests, response.publishRequest]);
+      setPublishRequests((currentRequests) =>
+        upsertPublishRequest(currentRequests, response.publishRequest),
+      );
       setStatus('Control Publish Request submitted.');
     } catch (caughtError) {
       const rawMessage =
@@ -381,6 +393,86 @@ export function ControlsPage() {
       setError(humanizeAuthError(null, rawMessage, 'Unable to submit Control Publish Request.'));
     } finally {
       setPublishingProposalId(null);
+    }
+  };
+
+  const handleApproveControlPublishRequest = async (request: ControlPublishRequestListItem) => {
+    if (!organizationSlug) return;
+
+    setReviewingRequestId(request.id);
+    setError(null);
+    setStatus(null);
+    try {
+      const response = await approveControlPublishRequest(organizationSlug, request.id);
+
+      setPublishRequests((currentRequests) =>
+        upsertPublishRequest(currentRequests, response.publishRequest),
+      );
+      setStatus('Control Publish Request approved.');
+    } catch (caughtError) {
+      const rawMessage =
+        caughtError instanceof Error
+          ? caughtError.message
+          : 'Unable to approve Control Publish Request.';
+      setError(humanizeAuthError(null, rawMessage, 'Unable to approve Control Publish Request.'));
+    } finally {
+      setReviewingRequestId(null);
+    }
+  };
+
+  const handleRejectControlPublishRequest = async (
+    event: FormEvent<HTMLFormElement>,
+    request: ControlPublishRequestListItem,
+  ) => {
+    event.preventDefault();
+    if (!organizationSlug) return;
+
+    setReviewingRequestId(request.id);
+    setError(null);
+    setStatus(null);
+    try {
+      const response = await rejectControlPublishRequest(organizationSlug, request.id, {
+        comment: rejectionComment,
+      });
+
+      setPublishRequests((currentRequests) =>
+        upsertPublishRequest(currentRequests, response.publishRequest),
+      );
+      setRejectingRequestId(null);
+      setRejectionComment('');
+      setStatus('Control Publish Request rejected and returned to draft.');
+    } catch (caughtError) {
+      const rawMessage =
+        caughtError instanceof Error
+          ? caughtError.message
+          : 'Unable to reject Control Publish Request.';
+      setError(humanizeAuthError(null, rawMessage, 'Unable to reject Control Publish Request.'));
+    } finally {
+      setReviewingRequestId(null);
+    }
+  };
+
+  const handleWithdrawControlPublishRequest = async (request: ControlPublishRequestListItem) => {
+    if (!organizationSlug) return;
+
+    setReviewingRequestId(request.id);
+    setError(null);
+    setStatus(null);
+    try {
+      const response = await withdrawControlPublishRequest(organizationSlug, request.id);
+
+      setPublishRequests((currentRequests) =>
+        upsertPublishRequest(currentRequests, response.publishRequest),
+      );
+      setStatus('Control Publish Request withdrawn.');
+    } catch (caughtError) {
+      const rawMessage =
+        caughtError instanceof Error
+          ? caughtError.message
+          : 'Unable to withdraw Control Publish Request.';
+      setError(humanizeAuthError(null, rawMessage, 'Unable to withdraw Control Publish Request.'));
+    } finally {
+      setReviewingRequestId(null);
     }
   };
 
@@ -626,14 +718,18 @@ export function ControlsPage() {
                             disabled={
                               publishingProposalId === proposedUpdate.id ||
                               publishRequests.some(
-                                (request) => request.proposedUpdateId === proposedUpdate.id,
+                                (request) =>
+                                  request.proposedUpdateId === proposedUpdate.id &&
+                                  request.status === 'submitted',
                               )
                             }
                             onClick={() => void handleSubmitControlProposedUpdate(proposedUpdate)}
                           >
                             <CheckCircle2 />
                             {publishRequests.some(
-                              (request) => request.proposedUpdateId === proposedUpdate.id,
+                              (request) =>
+                                request.proposedUpdateId === proposedUpdate.id &&
+                                request.status === 'submitted',
                             )
                               ? 'Request Submitted'
                               : publishingProposalId === proposedUpdate.id
@@ -922,11 +1018,19 @@ export function ControlsPage() {
                     type="submit"
                     disabled={
                       publishingDraftId === draftControl.id ||
-                      publishRequests.some((request) => request.draftControlId === draftControl.id)
+                      publishRequests.some(
+                        (request) =>
+                          request.draftControlId === draftControl.id &&
+                          request.status === 'submitted',
+                      )
                     }
                   >
                     <CheckCircle2 />
-                    {publishRequests.some((request) => request.draftControlId === draftControl.id)
+                    {publishRequests.some(
+                      (request) =>
+                        request.draftControlId === draftControl.id &&
+                        request.status === 'submitted',
+                    )
                       ? 'Request Submitted'
                       : publishingDraftId === draftControl.id
                         ? approvalPolicyEnabled
@@ -967,11 +1071,89 @@ export function ControlsPage() {
                     <p className="text-sm text-muted-foreground">
                       Approvals: {request.approvalCount} of {request.requiredApprovalCount}
                     </p>
+                    <p className="text-sm text-muted-foreground">Status: {request.status}</p>
+                    {request.rejectionComment ? (
+                      <p className="text-sm text-muted-foreground">
+                        Rejection comment: {request.rejectionComment}
+                      </p>
+                    ) : null}
                   </div>
                   <p className="shrink-0 text-xs text-muted-foreground">
                     Submitted {formatDate(request.submittedAt)}
                   </p>
                 </div>
+                {request.status === 'submitted' ? (
+                  <div className="mt-4 flex flex-wrap justify-end gap-2">
+                    {request.author.id === currentMemberId ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={reviewingRequestId === request.id}
+                        onClick={() => void handleWithdrawControlPublishRequest(request)}
+                      >
+                        Withdraw
+                      </Button>
+                    ) : null}
+                    {canPublish && request.author.id !== currentMemberId ? (
+                      <>
+                        <Button
+                          type="button"
+                          size="sm"
+                          disabled={reviewingRequestId === request.id}
+                          onClick={() => void handleApproveControlPublishRequest(request)}
+                        >
+                          Approve
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          disabled={reviewingRequestId === request.id}
+                          onClick={() => {
+                            setRejectingRequestId(request.id);
+                            setRejectionComment('');
+                          }}
+                        >
+                          Reject
+                        </Button>
+                      </>
+                    ) : null}
+                  </div>
+                ) : null}
+                {rejectingRequestId === request.id ? (
+                  <form
+                    className="mt-4 space-y-3 rounded-lg border bg-muted/30 p-3"
+                    onSubmit={(event) => handleRejectControlPublishRequest(event, request)}
+                  >
+                    <div className="space-y-2">
+                      <Label htmlFor={`${request.id}-rejection-comment`}>Rejection comment</Label>
+                      <textarea
+                        id={`${request.id}-rejection-comment`}
+                        value={rejectionComment}
+                        onChange={(event) => setRejectionComment(event.target.value)}
+                        className="min-h-20 w-full rounded-md border bg-background px-3 py-2 text-sm"
+                        required
+                      />
+                    </div>
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          setRejectingRequestId(null);
+                          setRejectionComment('');
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                      <Button type="submit" size="sm" disabled={reviewingRequestId === request.id}>
+                        Reject Request
+                      </Button>
+                    </div>
+                  </form>
+                ) : null}
               </article>
             ))}
           </div>
@@ -979,4 +1161,13 @@ export function ControlsPage() {
       ) : null}
     </div>
   );
+}
+
+function upsertPublishRequest(
+  requests: ControlPublishRequestListItem[],
+  nextRequest: ControlPublishRequestListItem,
+) {
+  return requests.some((request) => request.id === nextRequest.id)
+    ? requests.map((request) => (request.id === nextRequest.id ? nextRequest : request))
+    : [...requests, nextRequest];
 }

--- a/apps/web/src/features/auth/auth-api.ts
+++ b/apps/web/src/features/auth/auth-api.ts
@@ -5,6 +5,7 @@ export type MembershipResolutionResponse = {
   canCreateOrganization: boolean;
   organizations: Array<{
     id: string;
+    memberId: string;
     name: string;
     role: string;
     slug: string;
@@ -119,9 +120,10 @@ export type ControlPublishRequestListItem = ControlVersionResponse & {
   controlId: string | null;
   draftControlId: string | null;
   proposedUpdateId: string | null;
+  rejectionComment: string | null;
   requestType: 'draft_control' | 'proposed_update';
   requiredApprovalCount: number;
-  status: 'submitted';
+  status: 'draft' | 'submitted';
   submittedAt: string;
 };
 
@@ -365,6 +367,38 @@ export function listControlPublishRequests(organizationSlug: string) {
     `/api/organizations/${organizationSlug}/controls/publish-requests`,
     {
       method: 'GET',
+    },
+  );
+}
+
+export function approveControlPublishRequest(organizationSlug: string, publishRequestId: string) {
+  return request<{ publishRequest: ControlPublishRequestListItem }>(
+    `/api/organizations/${organizationSlug}/controls/publish-requests/${publishRequestId}/approve`,
+    {
+      method: 'POST',
+    },
+  );
+}
+
+export function rejectControlPublishRequest(
+  organizationSlug: string,
+  publishRequestId: string,
+  input: { comment: string },
+) {
+  return request<{ publishRequest: ControlPublishRequestListItem }>(
+    `/api/organizations/${organizationSlug}/controls/publish-requests/${publishRequestId}/reject`,
+    {
+      method: 'POST',
+      body: JSON.stringify(input),
+    },
+  );
+}
+
+export function withdrawControlPublishRequest(organizationSlug: string, publishRequestId: string) {
+  return request<{ publishRequest: ControlPublishRequestListItem }>(
+    `/api/organizations/${organizationSlug}/controls/publish-requests/${publishRequestId}/withdraw`,
+    {
+      method: 'POST',
     },
   );
 }


### PR DESCRIPTION
## Summary
- Add Control Publish Request approval records and review actions for approve, reject, and withdraw.
- Return rejected/withdrawn requests to draft and reset approvals when requests are resubmitted with edits.
- Expose review state and actions in the Controls UI.

Closes #27