### PR TITLE
Publish approved Control requests

### DIFF
--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -33,6 +33,7 @@ import {
   normalizeDraftControlListFilters,
   normalizeDraftControlCreateBody,
   normalizeDraftControlPublishBody,
+  publishControlPublishRequest,
   publishControlProposedUpdate,
   publishDraftControl,
   rejectControlPublishRequest,
@@ -352,6 +353,11 @@ app.post(
 app.post(
   '/api/organizations/:organizationSlug/controls/publish-requests/:publishRequestId/withdraw',
   async (c) => reviewControlPublishRequest(c, 'withdraw'),
+);
+
+app.post(
+  '/api/organizations/:organizationSlug/controls/publish-requests/:publishRequestId/publish',
+  async (c) => publishReviewedControlPublishRequest(c),
 );
 
 app.post('/api/organizations/:organizationSlug/controls/drafts', async (c) => {
@@ -886,6 +892,48 @@ async function reviewControlPublishRequest(c: Context, action: 'approve' | 'reje
     return c.json({ publishRequest });
   } catch (caughtError) {
     if (caughtError instanceof ControlPublishRequestInputError) {
+      return c.json({ error: caughtError.message }, 400);
+    }
+
+    throw caughtError;
+  }
+}
+
+async function publishReviewedControlPublishRequest(c: Context) {
+  const organizationSlug = c.req.param('organizationSlug');
+  const publishRequestId = c.req.param('publishRequestId');
+
+  if (!organizationSlug || !publishRequestId) {
+    return c.json({ error: 'Control Publish Request unavailable' }, 404);
+  }
+
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(organizationSlug, session.user.id);
+
+  if (!membership) {
+    return c.json({ error: 'Control Publish Request unavailable' }, 404);
+  }
+
+  try {
+    const control = await publishControlPublishRequest(membership, publishRequestId);
+
+    if (!control) {
+      return c.json({ error: 'Control Publish Request unavailable' }, 404);
+    }
+
+    return c.json({ control }, 201);
+  } catch (caughtError) {
+    if (
+      caughtError instanceof ControlPublishInputError ||
+      caughtError instanceof ControlProposedUpdateInputError
+    ) {
       return c.json({ error: caughtError.message }, 400);
     }
 

--- a/apps/backend-hono/src/lib/controls.ts
+++ b/apps/backend-hono/src/lib/controls.ts
@@ -69,6 +69,7 @@ export type ControlPublishRequestListItem = ControlVersionResponse & {
   };
   controlId: string | null;
   draftControlId: string | null;
+  isPublishable: boolean;
   proposedUpdateId: string | null;
   rejectionComment: string | null;
   requestType: 'draft_control' | 'proposed_update';
@@ -263,6 +264,7 @@ export async function listControlProposedUpdates(
 export async function listControlPublishRequests(
   membership: OrganizationMembership,
 ): Promise<ControlPublishRequestListItem[]> {
+  const policy = await getApprovalPolicy(membership.organizationId);
   const rows = await db
     .select({
       acceptedEvidenceTypes: controlPublishRequests.acceptedEvidenceTypes,
@@ -326,6 +328,8 @@ export async function listControlPublishRequests(
       },
       controlId,
       draftControlId,
+      isPublishable:
+        status === 'submitted' && (!policy.enabled || approvalCount >= policy.requiredApprovals),
       proposedUpdateId,
       rejectionComment,
       requestType: requestType as 'draft_control' | 'proposed_update',
@@ -334,6 +338,47 @@ export async function listControlPublishRequests(
       submittedAt: submittedAt.toISOString(),
     }),
   );
+}
+
+export async function publishControlPublishRequest(
+  membership: OrganizationMembership,
+  publishRequestId: string,
+): Promise<ControlListItem | null> {
+  const request = await db
+    .select()
+    .from(controlPublishRequests)
+    .where(
+      and(
+        eq(controlPublishRequests.id, publishRequestId),
+        eq(controlPublishRequests.organizationId, membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!request) {
+    return null;
+  }
+
+  if (!publishControlRoles.has(membership.role)) {
+    throw new ControlPublishInputError(
+      'Only Organization owners and admins can publish Control Publish Requests.',
+    );
+  }
+
+  if (request.status !== 'submitted') {
+    throw new ControlPublishInputError('Only submitted Control Publish Requests can be published.');
+  }
+
+  if (request.requestType === 'draft_control' && request.draftControlId) {
+    return publishDraftControl(membership, request.draftControlId, toPublishInput(request));
+  }
+
+  if (request.requestType === 'proposed_update' && request.controlId && request.proposedUpdateId) {
+    return publishControlProposedUpdate(membership, request.controlId, request.proposedUpdateId);
+  }
+
+  return null;
 }
 
 export async function listDraftControls(
@@ -1401,6 +1446,21 @@ async function updateControlPublishRequestApprovalCount(requestId: string) {
     .update(controlPublishRequests)
     .set({ approvalCount: approvals.length })
     .where(eq(controlPublishRequests.id, requestId));
+}
+
+function toPublishInput(
+  request: typeof controlPublishRequests.$inferSelect,
+): PublishDraftControlInput {
+  return {
+    acceptedEvidenceTypes: JSON.parse(request.acceptedEvidenceTypes) as string[],
+    applicabilityConditions: request.applicabilityConditions,
+    businessMeaning: request.businessMeaning,
+    externalStandardsMappings: JSON.parse(
+      request.externalStandardsMappings,
+    ) as ExternalStandardsMapping[],
+    releaseImpact: request.releaseImpact as ReleaseImpact,
+    verificationMethod: request.verificationMethod,
+  };
 }
 
 function toControlVersionResponse(row: {

--- a/apps/backend-hono/test/draft-controls.spec.ts
+++ b/apps/backend-hono/test/draft-controls.spec.ts
@@ -405,15 +405,50 @@ async function withdrawControlPublishRequest(
   };
 }
 
-async function enableControlApprovalPolicy(organizationSlug: string, headers: Headers) {
+async function publishControlPublishRequest(
+  organizationSlug: string,
+  publishRequestId: string,
+  headers: Headers,
+) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${organizationSlug}/controls/publish-requests/${publishRequestId}/publish`,
+    {
+      headers,
+      method: 'POST',
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function updateControlApprovalPolicyRequest(
+  organizationSlug: string,
+  headers: Headers,
+  body: Record<string, unknown>,
+) {
   const response = await app.request(
     `http://example.com/api/organizations/${organizationSlug}/control-approval-policy`,
     {
-      body: JSON.stringify({ enabled: true, requiredApprovals: 1 }),
+      body: JSON.stringify(body),
       headers,
       method: 'PATCH',
     },
   );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function enableControlApprovalPolicy(organizationSlug: string, headers: Headers) {
+  const response = await updateControlApprovalPolicyRequest(organizationSlug, headers, {
+    enabled: true,
+    requiredApprovals: 1,
+  });
 
   expect(response.status).toBe(200);
 }
@@ -1198,6 +1233,226 @@ describe('Draft Controls', () => {
       businessMeaning: 'Edited after review so approvals must be recollected.',
       id: publishRequest.id,
       status: 'submitted',
+    });
+  });
+
+  it('publishes approved Draft Control requests as v1 Controls', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'request-publish-draft-owner',
+    );
+    const admin = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-publish-draft-admin',
+      role: 'admin',
+    });
+    const member = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-publish-draft-member',
+      role: 'member',
+    });
+
+    await enableControlApprovalPolicy(organization.slug, ownerHeaders);
+
+    const createResponse = await createDraftControlRequest(organization.slug, member.headers, {
+      controlCode: 'AUTH-034',
+      title: 'Approved new Control',
+    });
+    const draftControl = createResponse.body.draftControl as { id: string };
+    const submitResponse = await submitDraftControlPublishRequest(
+      organization.slug,
+      draftControl.id,
+      member.headers,
+    );
+    const publishRequest = submitResponse.body.publishRequest as { id: string };
+
+    await approveControlPublishRequest(organization.slug, publishRequest.id, admin.headers);
+
+    const publishResponse = await publishControlPublishRequest(
+      organization.slug,
+      publishRequest.id,
+      ownerHeaders,
+    );
+
+    expect(publishResponse.status).toBe(201);
+    expect(publishResponse.body.control).toMatchObject({
+      controlCode: 'AUTH-034',
+      currentVersion: { title: 'Approved new Control', versionNumber: 1 },
+      versions: [{ versionNumber: 1 }],
+    });
+    await expect(
+      listControlPublishRequestsRequest(organization.slug, ownerHeaders),
+    ).resolves.toMatchObject({ body: { publishRequests: [] }, status: 200 });
+  });
+
+  it('publishes approved proposed update requests as the next Control Version', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'request-publish-update-owner',
+    );
+    const admin = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-publish-update-admin',
+      role: 'admin',
+    });
+
+    const createResponse = await createDraftControlRequest(organization.slug, ownerHeaders, {
+      controlCode: 'AUTH-035',
+      title: 'Before approved update',
+    });
+    const draftControl = createResponse.body.draftControl as { id: string };
+    const initialPublishResponse = await publishDraftControlRequest(
+      organization.slug,
+      draftControl.id,
+      ownerHeaders,
+    );
+    const control = initialPublishResponse.body.control as { id: string };
+
+    await enableControlApprovalPolicy(organization.slug, ownerHeaders);
+
+    const proposedResponse = await createControlProposedUpdateRequest(
+      organization.slug,
+      control.id,
+      ownerHeaders,
+      {
+        ...completePublishBody,
+        businessMeaning: 'Approved request creates the next Control Version.',
+        controlCode: 'AUTH-035',
+        title: 'After approved update',
+      },
+    );
+    const proposedUpdate = proposedResponse.body.proposedUpdate as { id: string };
+    const submitResponse = await submitControlProposedUpdatePublishRequest(
+      organization.slug,
+      control.id,
+      proposedUpdate.id,
+      ownerHeaders,
+    );
+    const publishRequest = submitResponse.body.publishRequest as { id: string };
+
+    await approveControlPublishRequest(organization.slug, publishRequest.id, admin.headers);
+
+    const publishResponse = await publishControlPublishRequest(
+      organization.slug,
+      publishRequest.id,
+      admin.headers,
+    );
+
+    expect(publishResponse.status).toBe(201);
+    expect(publishResponse.body.control).toMatchObject({
+      currentVersion: {
+        businessMeaning: 'Approved request creates the next Control Version.',
+        title: 'After approved update',
+        versionNumber: 2,
+      },
+      versions: [{ versionNumber: 2 }, { versionNumber: 1 }],
+    });
+  });
+
+  it('uses current Control Approval Policy settings when publishing in-flight requests', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'request-policy-current-owner',
+    );
+    const firstAdmin = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-policy-current-first-admin',
+      role: 'admin',
+    });
+    const secondAdmin = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-policy-current-second-admin',
+      role: 'admin',
+    });
+    const member = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'request-policy-current-member',
+      role: 'member',
+    });
+
+    await expect(
+      updateControlApprovalPolicyRequest(organization.slug, ownerHeaders, {
+        enabled: true,
+        requiredApprovals: 2,
+      }),
+    ).resolves.toMatchObject({ status: 200 });
+
+    const firstDraftResponse = await createDraftControlRequest(organization.slug, member.headers, {
+      controlCode: 'AUTH-036',
+      title: 'Policy count follows current settings',
+    });
+    const firstDraft = firstDraftResponse.body.draftControl as { id: string };
+    const firstSubmitResponse = await submitDraftControlPublishRequest(
+      organization.slug,
+      firstDraft.id,
+      member.headers,
+    );
+    const firstRequest = firstSubmitResponse.body.publishRequest as { id: string };
+
+    await approveControlPublishRequest(organization.slug, firstRequest.id, firstAdmin.headers);
+    await expect(
+      publishControlPublishRequest(organization.slug, firstRequest.id, ownerHeaders),
+    ).resolves.toMatchObject({
+      body: {
+        error:
+          'Control Approval Policy requires an approved Control Publish Request before publishing.',
+      },
+      status: 400,
+    });
+
+    await expect(
+      updateControlApprovalPolicyRequest(organization.slug, ownerHeaders, {
+        enabled: true,
+        requiredApprovals: 1,
+      }),
+    ).resolves.toMatchObject({ status: 200 });
+
+    await expect(
+      listControlPublishRequestsRequest(organization.slug, ownerHeaders),
+    ).resolves.toMatchObject({
+      body: { publishRequests: [{ controlCode: 'AUTH-036', isPublishable: true }] },
+      status: 200,
+    });
+    await expect(
+      publishControlPublishRequest(organization.slug, firstRequest.id, secondAdmin.headers),
+    ).resolves.toMatchObject({
+      body: { control: { controlCode: 'AUTH-036', currentVersion: { versionNumber: 1 } } },
+      status: 201,
+    });
+
+    await expect(
+      updateControlApprovalPolicyRequest(organization.slug, ownerHeaders, {
+        enabled: true,
+        requiredApprovals: 2,
+      }),
+    ).resolves.toMatchObject({ status: 200 });
+
+    const secondDraftResponse = await createDraftControlRequest(organization.slug, member.headers, {
+      controlCode: 'AUTH-037',
+      title: 'Disabled policy allows submitted requests',
+    });
+    const secondDraft = secondDraftResponse.body.draftControl as { id: string };
+    const secondSubmitResponse = await submitDraftControlPublishRequest(
+      organization.slug,
+      secondDraft.id,
+      member.headers,
+    );
+    const secondRequest = secondSubmitResponse.body.publishRequest as { id: string };
+
+    await expect(
+      updateControlApprovalPolicyRequest(organization.slug, ownerHeaders, {
+        enabled: false,
+        requiredApprovals: 1,
+      }),
+    ).resolves.toMatchObject({ status: 200 });
+    await expect(
+      publishControlPublishRequest(organization.slug, secondRequest.id, ownerHeaders),
+    ).resolves.toMatchObject({
+      body: { control: { controlCode: 'AUTH-037', currentVersion: { versionNumber: 1 } } },
+      status: 201,
     });
   });
 

--- a/apps/web/src/components/pages/controls.tsx
+++ b/apps/web/src/components/pages/controls.tsx
@@ -14,6 +14,7 @@ import {
   listControlPublishRequests,
   listControls,
   listDraftControls,
+  publishControlPublishRequest,
   publishControlProposedUpdate,
   publishDraftControl,
   rejectControlPublishRequest,
@@ -471,6 +472,41 @@ export function ControlsPage() {
           ? caughtError.message
           : 'Unable to withdraw Control Publish Request.';
       setError(humanizeAuthError(null, rawMessage, 'Unable to withdraw Control Publish Request.'));
+    } finally {
+      setReviewingRequestId(null);
+    }
+  };
+
+  const handlePublishControlPublishRequest = async (request: ControlPublishRequestListItem) => {
+    if (!organizationSlug) return;
+
+    setReviewingRequestId(request.id);
+    setError(null);
+    setStatus(null);
+    try {
+      const response = await publishControlPublishRequest(organizationSlug, request.id);
+
+      setControls((currentControls) => upsertControl(currentControls, response.control));
+      setDraftControls((currentDrafts) =>
+        request.draftControlId
+          ? currentDrafts.filter((draft) => draft.id !== request.draftControlId)
+          : currentDrafts,
+      );
+      setProposedUpdates((currentUpdates) =>
+        request.proposedUpdateId
+          ? currentUpdates.filter((update) => update.id !== request.proposedUpdateId)
+          : currentUpdates,
+      );
+      setPublishRequests((currentRequests) =>
+        currentRequests.filter((currentRequest) => currentRequest.id !== request.id),
+      );
+      setStatus('Control Publish Request published.');
+    } catch (caughtError) {
+      const rawMessage =
+        caughtError instanceof Error
+          ? caughtError.message
+          : 'Unable to publish Control Publish Request.';
+      setError(humanizeAuthError(null, rawMessage, 'Unable to publish Control Publish Request.'));
     } finally {
       setReviewingRequestId(null);
     }
@@ -1119,6 +1155,16 @@ export function ControlsPage() {
                         </Button>
                       </>
                     ) : null}
+                    {canPublish ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        disabled={reviewingRequestId === request.id || !request.isPublishable}
+                        onClick={() => void handlePublishControlPublishRequest(request)}
+                      >
+                        Publish
+                      </Button>
+                    ) : null}
                   </div>
                 ) : null}
                 {rejectingRequestId === request.id ? (
@@ -1170,4 +1216,10 @@ function upsertPublishRequest(
   return requests.some((request) => request.id === nextRequest.id)
     ? requests.map((request) => (request.id === nextRequest.id ? nextRequest : request))
     : [...requests, nextRequest];
+}
+
+function upsertControl(controls: ControlListItem[], nextControl: ControlListItem) {
+  return controls.some((control) => control.id === nextControl.id)
+    ? controls.map((control) => (control.id === nextControl.id ? nextControl : control))
+    : [nextControl, ...controls];
 }

--- a/apps/web/src/features/auth/auth-api.ts
+++ b/apps/web/src/features/auth/auth-api.ts
@@ -119,6 +119,7 @@ export type ControlPublishRequestListItem = ControlVersionResponse & {
   };
   controlId: string | null;
   draftControlId: string | null;
+  isPublishable: boolean;
   proposedUpdateId: string | null;
   rejectionComment: string | null;
   requestType: 'draft_control' | 'proposed_update';
@@ -397,6 +398,15 @@ export function rejectControlPublishRequest(
 export function withdrawControlPublishRequest(organizationSlug: string, publishRequestId: string) {
   return request<{ publishRequest: ControlPublishRequestListItem }>(
     `/api/organizations/${organizationSlug}/controls/publish-requests/${publishRequestId}/withdraw`,
+    {
+      method: 'POST',
+    },
+  );
+}
+
+export function publishControlPublishRequest(organizationSlug: string, publishRequestId: string) {
+  return request<{ control: ControlListItem }>(
+    `/api/organizations/${organizationSlug}/controls/publish-requests/${publishRequestId}/publish`,
     {
       method: 'POST',
     },


### PR DESCRIPTION
## Summary
- Add a final publish endpoint for submitted Control Publish Requests that creates v1 Controls or the next Control Version.
- Surface request publishability using the current Control Approval Policy and add a UI Publish action for owners/admins.
- Cover approved draft publishing, approved proposed update publishing, policy count changes, and disabled-policy publishing.

Closes #28