### PR TITLE
feat(checklists): record verification history

### DIFF
--- a/apps/backend-hono/drizzle/migrations/0012_project_checklists.sql
+++ b/apps/backend-hono/drizzle/migrations/0012_project_checklists.sql
@@ -1,0 +1,49 @@
+CREATE TABLE `project_checklists` (
+	`id` text PRIMARY KEY NOT NULL,
+	`component_id` text NOT NULL,
+	`template_id` text NOT NULL,
+	`display_name` text NOT NULL,
+	`normalized_display_name` text NOT NULL,
+	`archived_at` integer,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`component_id`) REFERENCES `project_components`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`template_id`) REFERENCES `checklist_templates`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+CREATE INDEX `project_checklist_component_id_idx` ON `project_checklists` (`component_id`);--> statement-breakpoint
+CREATE INDEX `project_checklist_template_id_idx` ON `project_checklists` (`template_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `project_checklist_component_template_unique` ON `project_checklists` (`component_id`,`template_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `project_checklist_component_display_name_unique` ON `project_checklists` (`component_id`,`normalized_display_name`);--> statement-breakpoint
+CREATE TABLE `project_checklist_verification_records` (
+	`id` text PRIMARY KEY NOT NULL,
+	`control_version_id` text NOT NULL,
+	`status` text DEFAULT 'unchecked' NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`control_version_id`) REFERENCES `control_versions`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+CREATE INDEX `project_checklist_verification_control_version_id_idx` ON `project_checklist_verification_records` (`control_version_id`);--> statement-breakpoint
+CREATE TABLE `project_checklist_items` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_checklist_id` text NOT NULL,
+	`template_item_id` text NOT NULL,
+	`control_id` text NOT NULL,
+	`control_version_id` text NOT NULL,
+	`verification_record_id` text NOT NULL,
+	`display_order` integer DEFAULT 0 NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`project_checklist_id`) REFERENCES `project_checklists`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`template_item_id`) REFERENCES `checklist_template_items`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`control_id`) REFERENCES `controls`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`control_version_id`) REFERENCES `control_versions`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`verification_record_id`) REFERENCES `project_checklist_verification_records`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+CREATE INDEX `project_checklist_item_project_checklist_id_idx` ON `project_checklist_items` (`project_checklist_id`);--> statement-breakpoint
+CREATE INDEX `project_checklist_item_template_item_id_idx` ON `project_checklist_items` (`template_item_id`);--> statement-breakpoint
+CREATE INDEX `project_checklist_item_control_id_idx` ON `project_checklist_items` (`control_id`);--> statement-breakpoint
+CREATE INDEX `project_checklist_item_control_version_id_idx` ON `project_checklist_items` (`control_version_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `project_checklist_item_verification_record_unique` ON `project_checklist_items` (`verification_record_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `project_checklist_item_template_item_unique` ON `project_checklist_items` (`project_checklist_id`,`template_item_id`);

--- a/apps/backend-hono/drizzle/migrations/0013_project_checklist_verification_history.sql
+++ b/apps/backend-hono/drizzle/migrations/0013_project_checklist_verification_history.sql
@@ -1,0 +1,17 @@
+ALTER TABLE `project_checklist_verification_records` ADD `not_applicable_explanation` text;--> statement-breakpoint
+CREATE TABLE `project_checklist_verification_history` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_checklist_item_id` text NOT NULL,
+	`control_version_id` text NOT NULL,
+	`actor_member_id` text NOT NULL,
+	`status` text NOT NULL,
+	`not_applicable_explanation` text,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`project_checklist_item_id`) REFERENCES `project_checklist_items`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`control_version_id`) REFERENCES `control_versions`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`actor_member_id`) REFERENCES `members`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+CREATE INDEX `project_checklist_verification_history_item_id_idx` ON `project_checklist_verification_history` (`project_checklist_item_id`);--> statement-breakpoint
+CREATE INDEX `project_checklist_verification_history_control_version_id_idx` ON `project_checklist_verification_history` (`control_version_id`);--> statement-breakpoint
+CREATE INDEX `project_checklist_verification_history_actor_member_id_idx` ON `project_checklist_verification_history` (`actor_member_id`);

--- a/apps/backend-hono/src/db/schema.ts
+++ b/apps/backend-hono/src/db/schema.ts
@@ -486,3 +486,96 @@ export const checklistTemplateItems = sqliteTable(
     ),
   ],
 );
+
+export const projectChecklists = sqliteTable(
+  'project_checklists',
+  {
+    id: text('id').primaryKey(),
+    componentId: text('component_id')
+      .notNull()
+      .references(() => projectComponents.id, { onDelete: 'cascade' }),
+    templateId: text('template_id')
+      .notNull()
+      .references(() => checklistTemplates.id, { onDelete: 'restrict' }),
+    displayName: text('display_name').notNull(),
+    normalizedDisplayName: text('normalized_display_name').notNull(),
+    archivedAt: integer('archived_at', { mode: 'timestamp_ms' }),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    index('project_checklist_component_id_idx').on(table.componentId),
+    index('project_checklist_template_id_idx').on(table.templateId),
+    uniqueIndex('project_checklist_component_template_unique').on(
+      table.componentId,
+      table.templateId,
+    ),
+    uniqueIndex('project_checklist_component_display_name_unique').on(
+      table.componentId,
+      table.normalizedDisplayName,
+    ),
+  ],
+);
+
+export const projectChecklistVerificationRecords = sqliteTable(
+  'project_checklist_verification_records',
+  {
+    id: text('id').primaryKey(),
+    controlVersionId: text('control_version_id')
+      .notNull()
+      .references(() => controlVersions.id, { onDelete: 'restrict' }),
+    status: text('status').default('unchecked').notNull(),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    index('project_checklist_verification_control_version_id_idx').on(table.controlVersionId),
+  ],
+);
+
+export const projectChecklistItems = sqliteTable(
+  'project_checklist_items',
+  {
+    id: text('id').primaryKey(),
+    projectChecklistId: text('project_checklist_id')
+      .notNull()
+      .references(() => projectChecklists.id, { onDelete: 'cascade' }),
+    templateItemId: text('template_item_id')
+      .notNull()
+      .references(() => checklistTemplateItems.id, { onDelete: 'restrict' }),
+    controlId: text('control_id')
+      .notNull()
+      .references(() => controls.id, { onDelete: 'restrict' }),
+    controlVersionId: text('control_version_id')
+      .notNull()
+      .references(() => controlVersions.id, { onDelete: 'restrict' }),
+    verificationRecordId: text('verification_record_id')
+      .notNull()
+      .references(() => projectChecklistVerificationRecords.id, { onDelete: 'restrict' }),
+    displayOrder: integer('display_order').default(0).notNull(),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+  },
+  (table) => [
+    index('project_checklist_item_project_checklist_id_idx').on(table.projectChecklistId),
+    index('project_checklist_item_template_item_id_idx').on(table.templateItemId),
+    index('project_checklist_item_control_id_idx').on(table.controlId),
+    index('project_checklist_item_control_version_id_idx').on(table.controlVersionId),
+    uniqueIndex('project_checklist_item_verification_record_unique').on(table.verificationRecordId),
+    uniqueIndex('project_checklist_item_template_item_unique').on(
+      table.projectChecklistId,
+      table.templateItemId,
+    ),
+  ],
+);

--- a/apps/backend-hono/src/db/schema.ts
+++ b/apps/backend-hono/src/db/schema.ts
@@ -530,6 +530,7 @@ export const projectChecklistVerificationRecords = sqliteTable(
       .notNull()
       .references(() => controlVersions.id, { onDelete: 'restrict' }),
     status: text('status').default('unchecked').notNull(),
+    notApplicableExplanation: text('not_applicable_explanation'),
     createdAt: integer('created_at', { mode: 'timestamp_ms' })
       .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
       .notNull(),
@@ -577,5 +578,33 @@ export const projectChecklistItems = sqliteTable(
       table.projectChecklistId,
       table.templateItemId,
     ),
+  ],
+);
+
+export const projectChecklistVerificationHistory = sqliteTable(
+  'project_checklist_verification_history',
+  {
+    id: text('id').primaryKey(),
+    projectChecklistItemId: text('project_checklist_item_id')
+      .notNull()
+      .references(() => projectChecklistItems.id, { onDelete: 'cascade' }),
+    controlVersionId: text('control_version_id')
+      .notNull()
+      .references(() => controlVersions.id, { onDelete: 'restrict' }),
+    actorMemberId: text('actor_member_id')
+      .notNull()
+      .references(() => members.id, { onDelete: 'restrict' }),
+    status: text('status').notNull(),
+    notApplicableExplanation: text('not_applicable_explanation'),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+  },
+  (table) => [
+    index('project_checklist_verification_history_item_id_idx').on(table.projectChecklistItemId),
+    index('project_checklist_verification_history_control_version_id_idx').on(
+      table.controlVersionId,
+    ),
+    index('project_checklist_verification_history_actor_member_id_idx').on(table.actorMemberId),
   ],
 );

--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -85,6 +85,7 @@ import {
 import {
   applyChecklistTemplateToProjectComponent,
   canApplyProjectChecklists,
+  getProjectChecklistForMembership,
   normalizeApplyChecklistTemplateBody,
   ProjectChecklistInputError,
 } from './lib/project-checklists';
@@ -1359,6 +1360,41 @@ app.post(
 
       throw caughtError;
     }
+  },
+);
+
+app.get(
+  '/api/organizations/:organizationSlug/projects/:projectSlug/components/:componentId/checklists/:checklistId',
+  async (c) => {
+    const session = await auth.api.getSession({
+      headers: c.req.raw.headers,
+    });
+
+    if (!session) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    const membership = await getOrganizationMembership(
+      c.req.param('organizationSlug'),
+      session.user.id,
+    );
+
+    if (!membership) {
+      return c.json({ error: 'Project Checklist unavailable' }, 404);
+    }
+
+    const projectChecklist = await getProjectChecklistForMembership({
+      checklistId: c.req.param('checklistId'),
+      componentId: c.req.param('componentId'),
+      membership,
+      projectSlug: c.req.param('projectSlug'),
+    });
+
+    if (!projectChecklist) {
+      return c.json({ error: 'Project Checklist unavailable' }, 404);
+    }
+
+    return c.json({ projectChecklist });
   },
 );
 

--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -87,7 +87,9 @@ import {
   canApplyProjectChecklists,
   getProjectChecklistForMembership,
   normalizeApplyChecklistTemplateBody,
+  normalizeChecklistItemVerificationBody,
   ProjectChecklistInputError,
+  updateProjectChecklistItemVerification,
 } from './lib/project-checklists';
 
 const app = new Hono();
@@ -1395,6 +1397,51 @@ app.get(
     }
 
     return c.json({ projectChecklist });
+  },
+);
+
+app.patch(
+  '/api/organizations/:organizationSlug/projects/:projectSlug/components/:componentId/checklists/:checklistId/items/:itemId/verification',
+  async (c) => {
+    const session = await auth.api.getSession({
+      headers: c.req.raw.headers,
+    });
+
+    if (!session) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    const membership = await getOrganizationMembership(
+      c.req.param('organizationSlug'),
+      session.user.id,
+    );
+
+    if (!membership) {
+      return c.json({ error: 'Project Checklist Item unavailable' }, 404);
+    }
+
+    try {
+      const projectChecklist = await updateProjectChecklistItemVerification({
+        checklistId: c.req.param('checklistId'),
+        componentId: c.req.param('componentId'),
+        itemId: c.req.param('itemId'),
+        membership,
+        projectSlug: c.req.param('projectSlug'),
+        values: normalizeChecklistItemVerificationBody(await c.req.json().catch(() => null)),
+      });
+
+      if (!projectChecklist) {
+        return c.json({ error: 'Project Checklist Item unavailable' }, 404);
+      }
+
+      return c.json({ projectChecklist });
+    } catch (caughtError) {
+      if (caughtError instanceof ProjectChecklistInputError) {
+        return c.json({ error: caughtError.message }, 400);
+      }
+
+      throw caughtError;
+    }
   },
 );
 

--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -82,6 +82,12 @@ import {
   updateProjectComponentForMembership,
   updateProjectForMembership,
 } from './lib/projects';
+import {
+  applyChecklistTemplateToProjectComponent,
+  canApplyProjectChecklists,
+  normalizeApplyChecklistTemplateBody,
+  ProjectChecklistInputError,
+} from './lib/project-checklists';
 
 const app = new Hono();
 
@@ -1299,6 +1305,61 @@ app.patch(
 app.patch(
   '/api/organizations/:organizationSlug/projects/:projectSlug/components/:componentId/restore',
   async (c) => setProjectComponentArchived(c, false),
+);
+
+app.post(
+  '/api/organizations/:organizationSlug/projects/:projectSlug/components/:componentId/checklists',
+  async (c) => {
+    const session = await auth.api.getSession({
+      headers: c.req.raw.headers,
+    });
+
+    if (!session) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    const membership = await getOrganizationMembership(
+      c.req.param('organizationSlug'),
+      session.user.id,
+    );
+
+    if (!membership) {
+      return c.json({ error: 'Project Component unavailable' }, 404);
+    }
+
+    if (
+      !(await canApplyProjectChecklists({ membership, projectSlug: c.req.param('projectSlug') }))
+    ) {
+      return c.json(
+        {
+          error:
+            'Only Organization owners, admins, and the Project Owner can apply Checklist Templates to Project Components.',
+        },
+        403,
+      );
+    }
+
+    try {
+      const projectChecklist = await applyChecklistTemplateToProjectComponent({
+        componentId: c.req.param('componentId'),
+        membership,
+        projectSlug: c.req.param('projectSlug'),
+        values: normalizeApplyChecklistTemplateBody(await c.req.json().catch(() => null)),
+      });
+
+      if (!projectChecklist) {
+        return c.json({ error: 'Project Component unavailable' }, 404);
+      }
+
+      return c.json({ projectChecklist }, 201);
+    } catch (caughtError) {
+      if (caughtError instanceof ProjectChecklistInputError) {
+        return c.json({ error: caughtError.message }, 400);
+      }
+
+      throw caughtError;
+    }
+  },
 );
 
 app.patch('/api/organizations/:organizationSlug/projects/:projectSlug', async (c) => {

--- a/apps/backend-hono/src/lib/project-checklists.ts
+++ b/apps/backend-hono/src/lib/project-checklists.ts
@@ -1,0 +1,350 @@
+import { and, asc, eq, isNull } from 'drizzle-orm';
+import { db } from '../db/client';
+import {
+  checklistTemplateItems,
+  checklistTemplates,
+  controls,
+  controlVersions,
+  projectChecklistItems,
+  projectChecklists,
+  projectChecklistVerificationRecords,
+  projectComponents,
+  projects,
+} from '../db/schema';
+import { canManageProjects, type OrganizationMembership } from './projects';
+
+export type ProjectChecklistResponse = {
+  archivedAt: string | null;
+  componentId: string;
+  createdAt: string;
+  displayName: string;
+  id: string;
+  items: ProjectChecklistItemResponse[];
+  templateId: string;
+  updatedAt: string;
+};
+
+export type ProjectChecklistItemResponse = {
+  control: {
+    controlCode: string;
+    id: string;
+    title: string;
+  };
+  controlVersion: {
+    id: string;
+    versionNumber: number;
+  };
+  displayOrder: number;
+  id: string;
+  templateItemId: string;
+  verificationRecord: {
+    id: string;
+    status: string;
+  };
+};
+
+type ApplyChecklistTemplateInput = {
+  displayName: string | null;
+  templateId: string;
+};
+
+export class ProjectChecklistInputError extends Error {}
+
+export async function canApplyProjectChecklists(input: {
+  membership: OrganizationMembership;
+  projectSlug: string;
+}): Promise<boolean> {
+  if (canManageProjects(input.membership.role)) {
+    return true;
+  }
+
+  const project = await getProjectForMembership(input.membership, input.projectSlug);
+
+  return project?.projectOwnerMemberId === input.membership.id;
+}
+
+export async function applyChecklistTemplateToProjectComponent(input: {
+  componentId: string;
+  membership: OrganizationMembership;
+  projectSlug: string;
+  values: ApplyChecklistTemplateInput;
+}): Promise<ProjectChecklistResponse | null> {
+  const project = await getProjectForMembership(input.membership, input.projectSlug);
+
+  if (!project || project.archivedAt) {
+    return null;
+  }
+
+  const component = await db
+    .select({ archivedAt: projectComponents.archivedAt, id: projectComponents.id })
+    .from(projectComponents)
+    .where(
+      and(eq(projectComponents.id, input.componentId), eq(projectComponents.projectId, project.id)),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!component || component.archivedAt) {
+    return null;
+  }
+
+  const template = await db
+    .select({ id: checklistTemplates.id, name: checklistTemplates.name })
+    .from(checklistTemplates)
+    .where(
+      and(
+        eq(checklistTemplates.id, input.values.templateId),
+        eq(checklistTemplates.organizationId, input.membership.organizationId),
+        eq(checklistTemplates.status, 'active'),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!template) {
+    throw new ProjectChecklistInputError('Only active Checklist Templates can be applied.');
+  }
+
+  const displayName = (input.values.displayName ?? template.name).trim();
+
+  if (!displayName) {
+    throw new ProjectChecklistInputError('Project Checklist display name is required.');
+  }
+
+  const normalizedDisplayName = normalizeProjectChecklistDisplayName(displayName);
+
+  await assertProjectChecklistIsUnique({
+    componentId: component.id,
+    normalizedDisplayName,
+    templateId: template.id,
+  });
+
+  const templateItems = await db
+    .select({
+      controlId: controls.id,
+      controlVersionId: controls.currentVersionId,
+      displayOrder: checklistTemplateItems.displayOrder,
+      templateItemId: checklistTemplateItems.id,
+    })
+    .from(checklistTemplateItems)
+    .innerJoin(controls, eq(checklistTemplateItems.controlId, controls.id))
+    .where(
+      and(
+        eq(checklistTemplateItems.templateId, template.id),
+        eq(controls.organizationId, input.membership.organizationId),
+        isNull(controls.archivedAt),
+      ),
+    )
+    .orderBy(
+      asc(checklistTemplateItems.sectionId),
+      asc(checklistTemplateItems.displayOrder),
+      asc(checklistTemplateItems.createdAt),
+    );
+
+  const allTemplateItemIds = await db
+    .select({ id: checklistTemplateItems.id })
+    .from(checklistTemplateItems)
+    .where(eq(checklistTemplateItems.templateId, template.id));
+
+  if (templateItems.length !== allTemplateItemIds.length) {
+    throw new ProjectChecklistInputError(
+      'Checklist Template contains Controls that are no longer active.',
+    );
+  }
+
+  if (templateItems.some((item) => !item.controlVersionId)) {
+    throw new ProjectChecklistInputError(
+      'Checklist Template contains Controls that are no longer active.',
+    );
+  }
+
+  const checklistId = crypto.randomUUID();
+  const now = new Date();
+
+  await db.insert(projectChecklists).values({
+    archivedAt: null,
+    componentId: component.id,
+    createdAt: now,
+    displayName,
+    id: checklistId,
+    normalizedDisplayName,
+    templateId: template.id,
+    updatedAt: now,
+  });
+
+  for (const [displayOrder, item] of templateItems.entries()) {
+    const controlVersionId = item.controlVersionId!;
+    const verificationRecordId = crypto.randomUUID();
+
+    await db.insert(projectChecklistVerificationRecords).values({
+      controlVersionId,
+      createdAt: now,
+      id: verificationRecordId,
+      status: 'unchecked',
+      updatedAt: now,
+    });
+    await db.insert(projectChecklistItems).values({
+      controlId: item.controlId,
+      controlVersionId,
+      createdAt: now,
+      displayOrder,
+      id: crypto.randomUUID(),
+      projectChecklistId: checklistId,
+      templateItemId: item.templateItemId,
+      verificationRecordId,
+    });
+  }
+
+  return getProjectChecklistForMembership(input.membership, checklistId);
+}
+
+export function normalizeApplyChecklistTemplateBody(body: unknown): ApplyChecklistTemplateInput {
+  const value = typeof body === 'object' && body !== null ? body : {};
+  const record = value as Record<string, unknown>;
+
+  return {
+    displayName: typeof record.displayName === 'string' ? record.displayName : null,
+    templateId: typeof record.templateId === 'string' ? record.templateId : '',
+  };
+}
+
+async function getProjectChecklistForMembership(
+  membership: OrganizationMembership,
+  checklistId: string,
+): Promise<ProjectChecklistResponse | null> {
+  const checklist = await db
+    .select({
+      archivedAt: projectChecklists.archivedAt,
+      componentId: projectChecklists.componentId,
+      createdAt: projectChecklists.createdAt,
+      displayName: projectChecklists.displayName,
+      id: projectChecklists.id,
+      templateId: projectChecklists.templateId,
+      updatedAt: projectChecklists.updatedAt,
+    })
+    .from(projectChecklists)
+    .innerJoin(projectComponents, eq(projectChecklists.componentId, projectComponents.id))
+    .innerJoin(projects, eq(projectComponents.projectId, projects.id))
+    .where(
+      and(
+        eq(projectChecklists.id, checklistId),
+        eq(projects.organizationId, membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!checklist) {
+    return null;
+  }
+
+  const itemRows = await db
+    .select({
+      controlCode: controlVersions.controlCode,
+      controlId: projectChecklistItems.controlId,
+      controlVersionId: projectChecklistItems.controlVersionId,
+      displayOrder: projectChecklistItems.displayOrder,
+      id: projectChecklistItems.id,
+      status: projectChecklistVerificationRecords.status,
+      templateItemId: projectChecklistItems.templateItemId,
+      title: controlVersions.title,
+      verificationRecordId: projectChecklistItems.verificationRecordId,
+      versionNumber: controlVersions.versionNumber,
+    })
+    .from(projectChecklistItems)
+    .innerJoin(controlVersions, eq(projectChecklistItems.controlVersionId, controlVersions.id))
+    .innerJoin(
+      projectChecklistVerificationRecords,
+      eq(projectChecklistItems.verificationRecordId, projectChecklistVerificationRecords.id),
+    )
+    .where(eq(projectChecklistItems.projectChecklistId, checklist.id))
+    .orderBy(asc(projectChecklistItems.displayOrder), asc(projectChecklistItems.createdAt));
+
+  return {
+    ...checklist,
+    archivedAt: checklist.archivedAt?.toISOString() ?? null,
+    createdAt: checklist.createdAt.toISOString(),
+    items: itemRows.map((item) => ({
+      control: {
+        controlCode: item.controlCode,
+        id: item.controlId,
+        title: item.title,
+      },
+      controlVersion: {
+        id: item.controlVersionId,
+        versionNumber: item.versionNumber,
+      },
+      displayOrder: item.displayOrder,
+      id: item.id,
+      templateItemId: item.templateItemId,
+      verificationRecord: {
+        id: item.verificationRecordId,
+        status: item.status,
+      },
+    })),
+    updatedAt: checklist.updatedAt.toISOString(),
+  };
+}
+
+async function assertProjectChecklistIsUnique(input: {
+  componentId: string;
+  normalizedDisplayName: string;
+  templateId: string;
+}) {
+  const existingForTemplate = await db
+    .select({ id: projectChecklists.id })
+    .from(projectChecklists)
+    .where(
+      and(
+        eq(projectChecklists.componentId, input.componentId),
+        eq(projectChecklists.templateId, input.templateId),
+        isNull(projectChecklists.archivedAt),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existingForTemplate) {
+    throw new ProjectChecklistInputError(
+      'Project Component already has an active Project Checklist for this Checklist Template.',
+    );
+  }
+
+  const existingForName = await db
+    .select({ id: projectChecklists.id })
+    .from(projectChecklists)
+    .where(
+      and(
+        eq(projectChecklists.componentId, input.componentId),
+        eq(projectChecklists.normalizedDisplayName, input.normalizedDisplayName),
+        isNull(projectChecklists.archivedAt),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existingForName) {
+    throw new ProjectChecklistInputError(
+      'Project Checklist display name is already used for this Project Component.',
+    );
+  }
+}
+
+async function getProjectForMembership(membership: OrganizationMembership, projectSlug: string) {
+  return db
+    .select({
+      archivedAt: projects.archivedAt,
+      id: projects.id,
+      projectOwnerMemberId: projects.projectOwnerMemberId,
+    })
+    .from(projects)
+    .where(
+      and(eq(projects.organizationId, membership.organizationId), eq(projects.slug, projectSlug)),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+}
+
+function normalizeProjectChecklistDisplayName(value: string): string {
+  return value.trim().replace(/\s+/g, ' ').toLowerCase();
+}

--- a/apps/backend-hono/src/lib/project-checklists.ts
+++ b/apps/backend-hono/src/lib/project-checklists.ts
@@ -2,6 +2,7 @@ import { and, asc, eq, isNull } from 'drizzle-orm';
 import { db } from '../db/client';
 import {
   checklistTemplateItems,
+  checklistTemplateSections,
   checklistTemplates,
   controls,
   controlVersions,
@@ -18,9 +19,15 @@ export type ProjectChecklistResponse = {
   componentId: string;
   createdAt: string;
   displayName: string;
+  completion: {
+    completedItems: number;
+    totalItems: number;
+  };
   id: string;
   items: ProjectChecklistItemResponse[];
+  sections: ProjectChecklistSectionResponse[];
   templateId: string;
+  unsectionedItems: ProjectChecklistItemResponse[];
   updatedAt: string;
 };
 
@@ -28,6 +35,7 @@ export type ProjectChecklistItemResponse = {
   control: {
     controlCode: string;
     id: string;
+    releaseImpact: string;
     title: string;
   };
   controlVersion: {
@@ -36,11 +44,19 @@ export type ProjectChecklistItemResponse = {
   };
   displayOrder: number;
   id: string;
+  sectionId: string | null;
   templateItemId: string;
   verificationRecord: {
     id: string;
     status: string;
   };
+};
+
+export type ProjectChecklistSectionResponse = {
+  displayOrder: number;
+  id: string;
+  items: ProjectChecklistItemResponse[];
+  name: string;
 };
 
 type ApplyChecklistTemplateInput = {
@@ -195,7 +211,7 @@ export async function applyChecklistTemplateToProjectComponent(input: {
     });
   }
 
-  return getProjectChecklistForMembership(input.membership, checklistId);
+  return getProjectChecklistForMembership({ checklistId, membership: input.membership });
 }
 
 export function normalizeApplyChecklistTemplateBody(body: unknown): ApplyChecklistTemplateInput {
@@ -208,10 +224,12 @@ export function normalizeApplyChecklistTemplateBody(body: unknown): ApplyCheckli
   };
 }
 
-async function getProjectChecklistForMembership(
-  membership: OrganizationMembership,
-  checklistId: string,
-): Promise<ProjectChecklistResponse | null> {
+export async function getProjectChecklistForMembership(input: {
+  checklistId: string;
+  componentId?: string;
+  membership: OrganizationMembership;
+  projectSlug?: string;
+}): Promise<ProjectChecklistResponse | null> {
   const checklist = await db
     .select({
       archivedAt: projectChecklists.archivedAt,
@@ -227,8 +245,10 @@ async function getProjectChecklistForMembership(
     .innerJoin(projects, eq(projectComponents.projectId, projects.id))
     .where(
       and(
-        eq(projectChecklists.id, checklistId),
-        eq(projects.organizationId, membership.organizationId),
+        eq(projectChecklists.id, input.checklistId),
+        eq(projects.organizationId, input.membership.organizationId),
+        input.componentId ? eq(projectChecklists.componentId, input.componentId) : undefined,
+        input.projectSlug ? eq(projects.slug, input.projectSlug) : undefined,
       ),
     )
     .limit(1)
@@ -245,6 +265,10 @@ async function getProjectChecklistForMembership(
       controlVersionId: projectChecklistItems.controlVersionId,
       displayOrder: projectChecklistItems.displayOrder,
       id: projectChecklistItems.id,
+      releaseImpact: controlVersions.releaseImpact,
+      sectionDisplayOrder: checklistTemplateSections.displayOrder,
+      sectionId: checklistTemplateItems.sectionId,
+      sectionName: checklistTemplateSections.name,
       status: projectChecklistVerificationRecords.status,
       templateItemId: projectChecklistItems.templateItemId,
       title: controlVersions.title,
@@ -252,38 +276,96 @@ async function getProjectChecklistForMembership(
       versionNumber: controlVersions.versionNumber,
     })
     .from(projectChecklistItems)
+    .innerJoin(
+      checklistTemplateItems,
+      and(
+        eq(projectChecklistItems.templateItemId, checklistTemplateItems.id),
+        eq(checklistTemplateItems.templateId, checklist.templateId),
+      ),
+    )
+    .leftJoin(
+      checklistTemplateSections,
+      eq(checklistTemplateItems.sectionId, checklistTemplateSections.id),
+    )
     .innerJoin(controlVersions, eq(projectChecklistItems.controlVersionId, controlVersions.id))
     .innerJoin(
       projectChecklistVerificationRecords,
       eq(projectChecklistItems.verificationRecordId, projectChecklistVerificationRecords.id),
     )
     .where(eq(projectChecklistItems.projectChecklistId, checklist.id))
-    .orderBy(asc(projectChecklistItems.displayOrder), asc(projectChecklistItems.createdAt));
+    .orderBy(
+      asc(checklistTemplateSections.displayOrder),
+      asc(checklistTemplateItems.sectionId),
+      asc(projectChecklistItems.displayOrder),
+      asc(projectChecklistItems.createdAt),
+    );
+
+  const items = itemRows.map((item) => ({
+    control: {
+      controlCode: item.controlCode,
+      id: item.controlId,
+      releaseImpact: item.releaseImpact,
+      title: item.title,
+    },
+    controlVersion: {
+      id: item.controlVersionId,
+      versionNumber: item.versionNumber,
+    },
+    displayOrder: item.displayOrder,
+    id: item.id,
+    sectionId: item.sectionId,
+    templateItemId: item.templateItemId,
+    verificationRecord: {
+      id: item.verificationRecordId,
+      status: item.status,
+    },
+  }));
+  const completedItems = items.filter((item) =>
+    isCompleteVerificationStatus(item.verificationRecord.status),
+  ).length;
+  const sections = itemRows.reduce<ProjectChecklistSectionResponse[]>((result, row) => {
+    if (!row.sectionId || !row.sectionName || row.sectionDisplayOrder === null) {
+      return result;
+    }
+
+    let section = result.find(({ id }) => id === row.sectionId);
+
+    if (!section) {
+      section = {
+        displayOrder: row.sectionDisplayOrder,
+        id: row.sectionId,
+        items: [],
+        name: row.sectionName,
+      };
+      result.push(section);
+    }
+
+    const item = items.find(({ templateItemId }) => templateItemId === row.templateItemId);
+
+    if (item) {
+      section.items.push(item);
+    }
+
+    return result;
+  }, []);
 
   return {
     ...checklist,
     archivedAt: checklist.archivedAt?.toISOString() ?? null,
+    completion: {
+      completedItems,
+      totalItems: items.length,
+    },
     createdAt: checklist.createdAt.toISOString(),
-    items: itemRows.map((item) => ({
-      control: {
-        controlCode: item.controlCode,
-        id: item.controlId,
-        title: item.title,
-      },
-      controlVersion: {
-        id: item.controlVersionId,
-        versionNumber: item.versionNumber,
-      },
-      displayOrder: item.displayOrder,
-      id: item.id,
-      templateItemId: item.templateItemId,
-      verificationRecord: {
-        id: item.verificationRecordId,
-        status: item.status,
-      },
-    })),
+    items,
+    sections,
+    unsectionedItems: items.filter(({ sectionId }) => !sectionId),
     updatedAt: checklist.updatedAt.toISOString(),
   };
+}
+
+function isCompleteVerificationStatus(status: string): boolean {
+  return status === 'checked' || status === 'not-applicable' || status === 'not_applicable';
 }
 
 async function assertProjectChecklistIsUnique(input: {

--- a/apps/backend-hono/src/lib/project-checklists.ts
+++ b/apps/backend-hono/src/lib/project-checklists.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, isNull } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNull } from 'drizzle-orm';
 import { db } from '../db/client';
 import {
   checklistTemplateItems,
@@ -8,6 +8,7 @@ import {
   controlVersions,
   projectChecklistItems,
   projectChecklists,
+  projectChecklistVerificationHistory,
   projectChecklistVerificationRecords,
   projectComponents,
   projects,
@@ -47,9 +48,23 @@ export type ProjectChecklistItemResponse = {
   sectionId: string | null;
   templateItemId: string;
   verificationRecord: {
+    history: ProjectChecklistVerificationHistoryResponse[];
     id: string;
+    notApplicableExplanation: string | null;
     status: string;
   };
+};
+
+export type ProjectChecklistVerificationHistoryResponse = {
+  actorMemberId: string;
+  controlVersion: {
+    id: string;
+    versionNumber: number;
+  };
+  createdAt: string;
+  id: string;
+  notApplicableExplanation: string | null;
+  status: string;
 };
 
 export type ProjectChecklistSectionResponse = {
@@ -62,6 +77,13 @@ export type ProjectChecklistSectionResponse = {
 type ApplyChecklistTemplateInput = {
   displayName: string | null;
   templateId: string;
+};
+
+type VerificationStatus = 'checked' | 'unchecked' | 'not-applicable';
+
+type UpdateChecklistItemVerificationInput = {
+  notApplicableExplanation: string | null;
+  status: VerificationStatus | null;
 };
 
 export class ProjectChecklistInputError extends Error {}
@@ -224,6 +246,111 @@ export function normalizeApplyChecklistTemplateBody(body: unknown): ApplyCheckli
   };
 }
 
+export function normalizeChecklistItemVerificationBody(
+  body: unknown,
+): UpdateChecklistItemVerificationInput {
+  const value = typeof body === 'object' && body !== null ? body : {};
+  const record = value as Record<string, unknown>;
+  const status = typeof record.status === 'string' ? record.status : null;
+
+  return {
+    notApplicableExplanation:
+      typeof record.notApplicableExplanation === 'string' ? record.notApplicableExplanation : null,
+    status: isVerificationStatus(status) ? status : null,
+  };
+}
+
+export async function updateProjectChecklistItemVerification(input: {
+  checklistId: string;
+  componentId: string;
+  itemId: string;
+  membership: OrganizationMembership;
+  projectSlug: string;
+  values: UpdateChecklistItemVerificationInput;
+}): Promise<ProjectChecklistResponse | null> {
+  if (!input.values.status) {
+    throw new ProjectChecklistInputError(
+      'Verification status must be checked, unchecked, or not applicable.',
+    );
+  }
+
+  const notApplicableExplanation = input.values.notApplicableExplanation?.trim() ?? '';
+
+  if (input.values.status === 'not-applicable' && !notApplicableExplanation) {
+    throw new ProjectChecklistInputError('Not applicable verification requires an explanation.');
+  }
+
+  const checklistItem = await db
+    .select({
+      componentArchivedAt: projectComponents.archivedAt,
+      controlVersionId: projectChecklistItems.controlVersionId,
+      itemId: projectChecklistItems.id,
+      projectArchivedAt: projects.archivedAt,
+      projectChecklistArchivedAt: projectChecklists.archivedAt,
+      verificationRecordId: projectChecklistItems.verificationRecordId,
+    })
+    .from(projectChecklistItems)
+    .innerJoin(
+      projectChecklists,
+      eq(projectChecklistItems.projectChecklistId, projectChecklists.id),
+    )
+    .innerJoin(projectComponents, eq(projectChecklists.componentId, projectComponents.id))
+    .innerJoin(projects, eq(projectComponents.projectId, projects.id))
+    .where(
+      and(
+        eq(projectChecklistItems.id, input.itemId),
+        eq(projectChecklistItems.projectChecklistId, input.checklistId),
+        eq(projectChecklists.componentId, input.componentId),
+        eq(projects.organizationId, input.membership.organizationId),
+        eq(projects.slug, input.projectSlug),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!checklistItem) {
+    return null;
+  }
+
+  if (
+    checklistItem.projectArchivedAt ||
+    checklistItem.componentArchivedAt ||
+    checklistItem.projectChecklistArchivedAt
+  ) {
+    throw new ProjectChecklistInputError('Archived Project Checklist containers are read-only.');
+  }
+
+  const now = new Date();
+  const storedExplanation =
+    input.values.status === 'not-applicable' ? notApplicableExplanation : null;
+
+  await db
+    .update(projectChecklistVerificationRecords)
+    .set({
+      notApplicableExplanation: storedExplanation,
+      status: input.values.status,
+      updatedAt: now,
+    })
+    .where(eq(projectChecklistVerificationRecords.id, checklistItem.verificationRecordId));
+
+  await db.insert(projectChecklistVerificationHistory).values({
+    actorMemberId: input.membership.id,
+    controlVersionId: checklistItem.controlVersionId,
+    createdAt: now,
+    id: crypto.randomUUID(),
+    notApplicableExplanation: storedExplanation,
+    projectChecklistItemId: checklistItem.itemId,
+    status: input.values.status,
+  });
+
+  return getProjectChecklistForMembership({
+    checklistId: input.checklistId,
+    componentId: input.componentId,
+    membership: input.membership,
+    projectSlug: input.projectSlug,
+  });
+}
+
 export async function getProjectChecklistForMembership(input: {
   checklistId: string;
   componentId?: string;
@@ -269,6 +396,7 @@ export async function getProjectChecklistForMembership(input: {
       sectionDisplayOrder: checklistTemplateSections.displayOrder,
       sectionId: checklistTemplateItems.sectionId,
       sectionName: checklistTemplateSections.name,
+      notApplicableExplanation: projectChecklistVerificationRecords.notApplicableExplanation,
       status: projectChecklistVerificationRecords.status,
       templateItemId: projectChecklistItems.templateItemId,
       title: controlVersions.title,
@@ -300,6 +428,32 @@ export async function getProjectChecklistForMembership(input: {
       asc(projectChecklistItems.createdAt),
     );
 
+  const histories = itemRows.length
+    ? await db
+        .select({
+          actorMemberId: projectChecklistVerificationHistory.actorMemberId,
+          controlVersionId: projectChecklistVerificationHistory.controlVersionId,
+          createdAt: projectChecklistVerificationHistory.createdAt,
+          id: projectChecklistVerificationHistory.id,
+          notApplicableExplanation: projectChecklistVerificationHistory.notApplicableExplanation,
+          projectChecklistItemId: projectChecklistVerificationHistory.projectChecklistItemId,
+          status: projectChecklistVerificationHistory.status,
+          versionNumber: controlVersions.versionNumber,
+        })
+        .from(projectChecklistVerificationHistory)
+        .innerJoin(
+          controlVersions,
+          eq(projectChecklistVerificationHistory.controlVersionId, controlVersions.id),
+        )
+        .where(
+          inArray(
+            projectChecklistVerificationHistory.projectChecklistItemId,
+            itemRows.map(({ id }) => id),
+          ),
+        )
+        .orderBy(desc(projectChecklistVerificationHistory.createdAt))
+    : [];
+
   const items = itemRows.map((item) => ({
     control: {
       controlCode: item.controlCode,
@@ -316,7 +470,21 @@ export async function getProjectChecklistForMembership(input: {
     sectionId: item.sectionId,
     templateItemId: item.templateItemId,
     verificationRecord: {
+      history: histories
+        .filter((history) => history.projectChecklistItemId === item.id)
+        .map((history) => ({
+          actorMemberId: history.actorMemberId,
+          controlVersion: {
+            id: history.controlVersionId,
+            versionNumber: history.versionNumber,
+          },
+          createdAt: history.createdAt.toISOString(),
+          id: history.id,
+          notApplicableExplanation: history.notApplicableExplanation,
+          status: history.status,
+        })),
       id: item.verificationRecordId,
+      notApplicableExplanation: item.notApplicableExplanation,
       status: item.status,
     },
   }));
@@ -366,6 +534,10 @@ export async function getProjectChecklistForMembership(input: {
 
 function isCompleteVerificationStatus(status: string): boolean {
   return status === 'checked' || status === 'not-applicable' || status === 'not_applicable';
+}
+
+function isVerificationStatus(status: string | null): status is VerificationStatus {
+  return status === 'checked' || status === 'unchecked' || status === 'not-applicable';
 }
 
 async function assertProjectChecklistIsUnique(input: {

--- a/apps/backend-hono/test/project-checklists.spec.ts
+++ b/apps/backend-hono/test/project-checklists.spec.ts
@@ -12,6 +12,7 @@ import {
   members,
   projectChecklistItems,
   projectChecklists,
+  projectChecklistVerificationHistory,
   projectChecklistVerificationRecords,
   projectComponents,
   projects,
@@ -324,6 +325,30 @@ async function openChecklist(input: {
   const response = await app.request(
     `http://example.com/api/organizations/${input.organizationSlug}/projects/${input.projectSlug}/components/${input.componentId}/checklists/${input.checklistId}`,
     { headers: input.headers },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function updateChecklistItemVerification(input: {
+  body: Record<string, unknown>;
+  checklistId: string;
+  componentId: string;
+  headers: Headers;
+  itemId: string;
+  organizationSlug: string;
+  projectSlug: string;
+}) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${input.organizationSlug}/projects/${input.projectSlug}/components/${input.componentId}/checklists/${input.checklistId}/items/${input.itemId}/verification`,
+    {
+      body: JSON.stringify(input.body),
+      headers: input.headers,
+      method: 'PATCH',
+    },
   );
 
   return {
@@ -815,6 +840,326 @@ describe('Project Checklists API', () => {
       archivedAt: expect.any(String),
       completion: { completedItems: 1, totalItems: 1 },
       items: [{ control: { controlCode: 'AUTH-748' }, verificationRecord: { status: 'checked' } }],
+    });
+  });
+
+  it('lets active Organization members change checklist item verification and inspect Control Version history', async () => {
+    const owner = await createSignedInOwner('project-checklist-verify-owner');
+    const member = await addMemberToOrganization(
+      owner.organization.id,
+      'project-checklist-verify-member',
+    );
+    const projectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'vendor-risk',
+    });
+    const componentId = await createComponent(projectId);
+    const control = await createActiveControl({
+      controlCode: 'AUTH-849',
+      organizationId: owner.organization.id,
+      title: 'Require MFA',
+    });
+    const templateId = await createTemplate({
+      controlIds: [control.controlId],
+      organizationId: owner.organization.id,
+    });
+    const applyResponse = await applyTemplate({
+      body: { templateId },
+      componentId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'vendor-risk',
+    });
+    const projectChecklist = applyResponse.body.projectChecklist as {
+      id: string;
+      items: [{ id: string }];
+    };
+    const itemId = projectChecklist.items[0].id;
+
+    await addLatestControlVersion(control.controlId, 'AUTH-849', 'Require phishing-resistant MFA');
+
+    await expect(
+      updateChecklistItemVerification({
+        body: {
+          status: 'not-applicable',
+          notApplicableExplanation: 'Compensating control applies.',
+        },
+        checklistId: projectChecklist.id,
+        componentId,
+        headers: member.headers,
+        itemId,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({
+      body: {
+        projectChecklist: {
+          completion: { completedItems: 1, totalItems: 1 },
+          items: [
+            {
+              controlVersion: { id: control.versionId, versionNumber: 1 },
+              verificationRecord: {
+                history: [
+                  {
+                    actorMemberId: member.memberId,
+                    controlVersion: { id: control.versionId, versionNumber: 1 },
+                    createdAt: expect.any(String),
+                    notApplicableExplanation: 'Compensating control applies.',
+                    status: 'not-applicable',
+                  },
+                ],
+                notApplicableExplanation: 'Compensating control applies.',
+                status: 'not-applicable',
+              },
+            },
+          ],
+        },
+      },
+      status: 200,
+    });
+    await expect(
+      updateChecklistItemVerification({
+        body: { status: 'checked' },
+        checklistId: projectChecklist.id,
+        componentId,
+        headers: member.headers,
+        itemId,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({
+      body: {
+        projectChecklist: {
+          items: [
+            {
+              verificationRecord: {
+                history: [
+                  { notApplicableExplanation: null, status: 'checked' },
+                  {
+                    notApplicableExplanation: 'Compensating control applies.',
+                    status: 'not-applicable',
+                  },
+                ],
+                notApplicableExplanation: null,
+                status: 'checked',
+              },
+            },
+          ],
+        },
+      },
+      status: 200,
+    });
+    await expect(
+      updateChecklistItemVerification({
+        body: { status: 'unchecked' },
+        checklistId: projectChecklist.id,
+        componentId,
+        headers: member.headers,
+        itemId,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({
+      body: {
+        projectChecklist: {
+          completion: { completedItems: 0, totalItems: 1 },
+          items: [{ verificationRecord: { notApplicableExplanation: null, status: 'unchecked' } }],
+        },
+      },
+      status: 200,
+    });
+
+    const historyRows = await db
+      .select()
+      .from(projectChecklistVerificationHistory)
+      .where(eq(projectChecklistVerificationHistory.projectChecklistItemId, itemId));
+
+    expect(historyRows).toHaveLength(3);
+    expect(historyRows.map(({ controlVersionId }) => controlVersionId)).toEqual([
+      control.versionId,
+      control.versionId,
+      control.versionId,
+    ]);
+  });
+
+  it('rejects missing not applicable explanations and keeps checked or unchecked evidence-free', async () => {
+    const owner = await createSignedInOwner('project-checklist-verify-validation');
+    const projectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'vendor-risk',
+    });
+    const componentId = await createComponent(projectId);
+    const control = await createActiveControl({
+      controlCode: 'AUTH-949',
+      organizationId: owner.organization.id,
+      title: 'Require MFA',
+    });
+    const templateId = await createTemplate({
+      controlIds: [control.controlId],
+      organizationId: owner.organization.id,
+    });
+    const applyResponse = await applyTemplate({
+      body: { templateId },
+      componentId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'vendor-risk',
+    });
+    const projectChecklist = applyResponse.body.projectChecklist as {
+      id: string;
+      items: [{ id: string }];
+    };
+
+    await expect(
+      updateChecklistItemVerification({
+        body: { status: 'not-applicable', notApplicableExplanation: '   ' },
+        checklistId: projectChecklist.id,
+        componentId,
+        headers: owner.headers,
+        itemId: projectChecklist.items[0].id,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Not applicable verification requires an explanation.' },
+      status: 400,
+    });
+    await expect(
+      updateChecklistItemVerification({
+        body: { status: 'checked' },
+        checklistId: projectChecklist.id,
+        componentId,
+        headers: owner.headers,
+        itemId: projectChecklist.items[0].id,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({ status: 200 });
+    await expect(
+      updateChecklistItemVerification({
+        body: { status: 'unchecked' },
+        checklistId: projectChecklist.id,
+        componentId,
+        headers: owner.headers,
+        itemId: projectChecklist.items[0].id,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({ status: 200 });
+  });
+
+  it('keeps archived Projects, Project Components, and Project Checklists read-only for verification', async () => {
+    const owner = await createSignedInOwner('project-checklist-verify-archived');
+    const projectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'vendor-risk',
+    });
+    const checklistArchivedComponentId = await createComponent(projectId, 'Checklist Archived');
+    const componentArchivedComponentId = await createComponent(projectId, 'Component Archived');
+    const projectArchivedComponentId = await createComponent(projectId, 'Project Archived');
+    const control = await createActiveControl({
+      controlCode: 'AUTH-1049',
+      organizationId: owner.organization.id,
+      title: 'Require MFA',
+    });
+    const checklistArchivedTemplateId = await createTemplate({
+      controlIds: [control.controlId],
+      name: 'Checklist Archived Readiness',
+      organizationId: owner.organization.id,
+    });
+    const componentArchivedTemplateId = await createTemplate({
+      controlIds: [control.controlId],
+      name: 'Component Archived Readiness',
+      organizationId: owner.organization.id,
+    });
+    const projectArchivedTemplateId = await createTemplate({
+      controlIds: [control.controlId],
+      name: 'Project Archived Readiness',
+      organizationId: owner.organization.id,
+    });
+    const checklistArchivedChecklist = (
+      await applyTemplate({
+        body: { templateId: checklistArchivedTemplateId },
+        componentId: checklistArchivedComponentId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      })
+    ).body.projectChecklist as { id: string; items: [{ id: string }] };
+    const componentArchivedChecklist = (
+      await applyTemplate({
+        body: { templateId: componentArchivedTemplateId },
+        componentId: componentArchivedComponentId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      })
+    ).body.projectChecklist as { id: string; items: [{ id: string }] };
+    const projectArchivedChecklist = (
+      await applyTemplate({
+        body: { templateId: projectArchivedTemplateId },
+        componentId: projectArchivedComponentId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      })
+    ).body.projectChecklist as { id: string; items: [{ id: string }] };
+
+    await db
+      .update(projectChecklists)
+      .set({ archivedAt: new Date() })
+      .where(eq(projectChecklists.id, checklistArchivedChecklist.id));
+    await db
+      .update(projectComponents)
+      .set({ archivedAt: new Date() })
+      .where(eq(projectComponents.id, componentArchivedComponentId));
+
+    await expect(
+      updateChecklistItemVerification({
+        body: { status: 'checked' },
+        checklistId: checklistArchivedChecklist.id,
+        componentId: checklistArchivedComponentId,
+        headers: owner.headers,
+        itemId: checklistArchivedChecklist.items[0].id,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Archived Project Checklist containers are read-only.' },
+      status: 400,
+    });
+    await expect(
+      updateChecklistItemVerification({
+        body: { status: 'checked' },
+        checklistId: componentArchivedChecklist.id,
+        componentId: componentArchivedComponentId,
+        headers: owner.headers,
+        itemId: componentArchivedChecklist.items[0].id,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Archived Project Checklist containers are read-only.' },
+      status: 400,
+    });
+    await db.update(projects).set({ archivedAt: new Date() }).where(eq(projects.id, projectId));
+
+    await expect(
+      updateChecklistItemVerification({
+        body: { status: 'checked' },
+        checklistId: projectArchivedChecklist.id,
+        componentId: projectArchivedComponentId,
+        headers: owner.headers,
+        itemId: projectArchivedChecklist.items[0].id,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Archived Project Checklist containers are read-only.' },
+      status: 400,
     });
   });
 

--- a/apps/backend-hono/test/project-checklists.spec.ts
+++ b/apps/backend-hono/test/project-checklists.spec.ts
@@ -1,0 +1,620 @@
+import { and, eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import app from '../src/index';
+import { db } from '../src/db/client';
+import {
+  checklistTemplateItems,
+  checklistTemplates,
+  controlVersions,
+  controls,
+  members,
+  projectChecklistItems,
+  projectChecklists,
+  projectChecklistVerificationRecords,
+  projectComponents,
+  projects,
+  users,
+} from '../src/db/schema';
+import { auth } from '../src/lib/auth';
+
+const authHeaders = {
+  origin: 'http://localhost:5173',
+  host: 'localhost:8787',
+};
+const verificationCallbackURL = 'http://localhost:8787/sign-in';
+const mailpitSendUrl = 'http://127.0.0.1:8025/api/v1/send';
+
+function createCredentials(prefix: string) {
+  const token = crypto.randomUUID();
+
+  return {
+    name: `${prefix} user`,
+    email: `${prefix}-${token}@example.com`,
+    password: `Password-${token}`,
+  };
+}
+
+async function signUpUser(credentials: ReturnType<typeof createCredentials>) {
+  await auth.api.signUpEmail({
+    body: {
+      ...credentials,
+      callbackURL: verificationCallbackURL,
+    },
+    headers: authHeaders,
+  });
+
+  await db.update(users).set({ emailVerified: true }).where(eq(users.email, credentials.email));
+}
+
+async function signInUser(credentials: ReturnType<typeof createCredentials>) {
+  const result = await auth.api.signInEmail({
+    body: {
+      email: credentials.email,
+      password: credentials.password,
+    },
+    headers: authHeaders,
+    returnHeaders: true,
+  });
+
+  const sessionCookie = result.headers.get('set-cookie');
+
+  expect(sessionCookie).toBeTruthy();
+
+  if (!sessionCookie) {
+    throw new Error('Expected Better Auth to return a session cookie.');
+  }
+
+  return new Headers({
+    ...authHeaders,
+    cookie: sessionCookie.split(';', 1)[0] ?? sessionCookie,
+  });
+}
+
+async function getUserByEmail(email: string) {
+  const user = await db
+    .select()
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  expect(user).toBeTruthy();
+
+  if (!user) {
+    throw new Error('Expected user to exist.');
+  }
+
+  return user;
+}
+
+async function getMember(organizationId: string, userId: string) {
+  const member = await db
+    .select()
+    .from(members)
+    .where(and(eq(members.organizationId, organizationId), eq(members.userId, userId)))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  expect(member).toBeTruthy();
+
+  if (!member) {
+    throw new Error('Expected organization member to exist.');
+  }
+
+  return member;
+}
+
+async function createSignedInOwner(prefix: string) {
+  const credentials = createCredentials(prefix);
+  await signUpUser(credentials);
+  const headers = await signInUser(credentials);
+  const organization = (await auth.api.listOrganizations({ headers }))[0];
+  const user = await getUserByEmail(credentials.email);
+
+  expect(organization).toBeTruthy();
+
+  if (!organization) {
+    throw new Error('Expected default organization to exist.');
+  }
+
+  return {
+    headers,
+    member: await getMember(organization.id, user.id),
+    organization,
+  };
+}
+
+async function addMemberToOrganization(
+  organizationId: string,
+  prefix: string,
+  role: 'admin' | 'member' = 'member',
+) {
+  const credentials = createCredentials(prefix);
+  await signUpUser(credentials);
+  const user = await getUserByEmail(credentials.email);
+  const memberId = crypto.randomUUID();
+
+  await db.insert(members).values({
+    id: memberId,
+    organizationId,
+    role,
+    userId: user.id,
+  });
+
+  return {
+    headers: await signInUser(credentials),
+    memberId,
+  };
+}
+
+async function createProject(input: {
+  archived?: boolean;
+  organizationId: string;
+  projectOwnerMemberId: string | null;
+  slug: string;
+}) {
+  const now = new Date();
+  const id = crypto.randomUUID();
+
+  await db.insert(projects).values({
+    archivedAt: input.archived ? now : null,
+    createdAt: now,
+    description: 'Governance work for reviewing critical vendor risk.',
+    id,
+    name: 'Vendor Risk Review',
+    organizationId: input.organizationId,
+    projectOwnerMemberId: input.projectOwnerMemberId,
+    slug: input.slug,
+    updatedAt: now,
+  });
+
+  return id;
+}
+
+async function createComponent(projectId: string, name = 'Payments Platform', archived = false) {
+  const now = new Date();
+  const id = crypto.randomUUID();
+
+  await db.insert(projectComponents).values({
+    archivedAt: archived ? now : null,
+    createdAt: now,
+    description: null,
+    id,
+    name,
+    projectId,
+    updatedAt: now,
+  });
+
+  return id;
+}
+
+async function createActiveControl(input: {
+  controlCode: string;
+  organizationId: string;
+  title: string;
+}) {
+  const controlId = crypto.randomUUID();
+  const versionId = crypto.randomUUID();
+  const now = new Date();
+
+  await db.insert(controls).values({
+    archivedAt: null,
+    archivedByMemberId: null,
+    archiveReason: null,
+    createdAt: now,
+    currentControlCode: input.controlCode,
+    currentVersionId: versionId,
+    id: controlId,
+    organizationId: input.organizationId,
+    updatedAt: now,
+  });
+  await db.insert(controlVersions).values({
+    acceptedEvidenceTypes: JSON.stringify(['document']),
+    applicabilityConditions: 'Applies to this component.',
+    businessMeaning: 'Required release assurance.',
+    controlCode: input.controlCode,
+    controlId,
+    createdAt: now,
+    externalStandardsMappings: JSON.stringify([]),
+    id: versionId,
+    releaseImpact: 'blocking',
+    title: input.title,
+    verificationMethod: 'Review evidence.',
+    versionNumber: 1,
+  });
+
+  return { controlId, versionId };
+}
+
+async function addLatestControlVersion(controlId: string, controlCode: string, title: string) {
+  const versionId = crypto.randomUUID();
+
+  await db.insert(controlVersions).values({
+    acceptedEvidenceTypes: JSON.stringify(['document']),
+    applicabilityConditions: 'Applies to this component.',
+    businessMeaning: 'Updated release assurance.',
+    controlCode,
+    controlId,
+    createdAt: new Date(),
+    externalStandardsMappings: JSON.stringify([]),
+    id: versionId,
+    releaseImpact: 'needs review',
+    title,
+    verificationMethod: 'Review updated evidence.',
+    versionNumber: 2,
+  });
+  await db.update(controls).set({ currentVersionId: versionId }).where(eq(controls.id, controlId));
+
+  return versionId;
+}
+
+async function createTemplate(input: {
+  controlIds: string[];
+  name?: string;
+  organizationId: string;
+  status?: 'active' | 'archived' | 'draft';
+}) {
+  const now = new Date();
+  const templateId = crypto.randomUUID();
+
+  await db.insert(checklistTemplates).values({
+    authorMemberId: (
+      await db
+        .select()
+        .from(members)
+        .where(eq(members.organizationId, input.organizationId))
+        .limit(1)
+    )[0]!.id,
+    createdAt: now,
+    id: templateId,
+    name: input.name ?? 'Release Readiness',
+    normalizedName: (input.name ?? 'Release Readiness').toLowerCase(),
+    organizationId: input.organizationId,
+    publishedAt: input.status === 'active' ? now : null,
+    status: input.status ?? 'active',
+    updatedAt: now,
+  });
+
+  for (const [displayOrder, controlId] of input.controlIds.entries()) {
+    await db.insert(checklistTemplateItems).values({
+      controlId,
+      createdAt: now,
+      displayOrder,
+      id: crypto.randomUUID(),
+      sectionId: null,
+      templateId,
+    });
+  }
+
+  return templateId;
+}
+
+async function applyTemplate(input: {
+  body: Record<string, unknown>;
+  componentId: string;
+  headers: Headers;
+  organizationSlug: string;
+  projectSlug: string;
+}) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${input.organizationSlug}/projects/${input.projectSlug}/components/${input.componentId}/checklists`,
+    {
+      body: JSON.stringify(input.body),
+      headers: input.headers,
+      method: 'POST',
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+beforeEach(() => {
+  const originalFetch = globalThis.fetch;
+
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+    if (url === mailpitSendUrl) {
+      return new Response(null, { status: 200 });
+    }
+
+    return originalFetch(input, init);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Project Checklists API', () => {
+  it('lets Organization owners, admins, and the Project Owner apply active Checklist Templates', async () => {
+    const owner = await createSignedInOwner('project-checklist-owner');
+    const admin = await addMemberToOrganization(
+      owner.organization.id,
+      'project-checklist-admin',
+      'admin',
+    );
+    const projectOwner = await addMemberToOrganization(
+      owner.organization.id,
+      'project-checklist-project-owner',
+    );
+    const member = await addMemberToOrganization(owner.organization.id, 'project-checklist-member');
+    const projectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: projectOwner.memberId,
+      slug: 'vendor-risk',
+    });
+    const ownerComponentId = await createComponent(projectId, 'Owner Component');
+    const adminComponentId = await createComponent(projectId, 'Admin Component');
+    const projectOwnerComponentId = await createComponent(projectId, 'Project Owner Component');
+    const memberComponentId = await createComponent(projectId, 'Member Component');
+    const control = await createActiveControl({
+      controlCode: 'AUTH-147',
+      organizationId: owner.organization.id,
+      title: 'Require MFA',
+    });
+    const templateId = await createTemplate({
+      controlIds: [control.controlId],
+      organizationId: owner.organization.id,
+    });
+
+    await expect(
+      applyTemplate({
+        body: { displayName: 'Owner Checklist', templateId },
+        componentId: ownerComponentId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({ status: 201 });
+    await expect(
+      applyTemplate({
+        body: { displayName: 'Admin Checklist', templateId },
+        componentId: adminComponentId,
+        headers: admin.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({ status: 201 });
+    await expect(
+      applyTemplate({
+        body: { displayName: 'Project Owner Checklist', templateId },
+        componentId: projectOwnerComponentId,
+        headers: projectOwner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({ status: 201 });
+    await expect(
+      applyTemplate({
+        body: { displayName: 'Member Checklist', templateId },
+        componentId: memberComponentId,
+        headers: member.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({ status: 403 });
+  });
+
+  it('creates a Project Checklist, generated items, and unchecked verification records using latest Control Versions', async () => {
+    const owner = await createSignedInOwner('project-checklist-side-effects');
+    const projectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'vendor-risk',
+    });
+    const componentId = await createComponent(projectId);
+    const firstControl = await createActiveControl({
+      controlCode: 'AUTH-247',
+      organizationId: owner.organization.id,
+      title: 'Require MFA',
+    });
+    const secondControl = await createActiveControl({
+      controlCode: 'LOG-247',
+      organizationId: owner.organization.id,
+      title: 'Require logging',
+    });
+    const latestVersionId = await addLatestControlVersion(
+      firstControl.controlId,
+      'AUTH-247',
+      'Require phishing-resistant MFA',
+    );
+    const templateId = await createTemplate({
+      controlIds: [firstControl.controlId, secondControl.controlId],
+      name: 'Production Readiness',
+      organizationId: owner.organization.id,
+    });
+
+    const response = await applyTemplate({
+      body: { templateId },
+      componentId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'vendor-risk',
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.projectChecklist).toMatchObject({
+      componentId,
+      displayName: 'Production Readiness',
+      items: [
+        {
+          control: { controlCode: 'AUTH-247', id: firstControl.controlId },
+          controlVersion: { id: latestVersionId, versionNumber: 2 },
+          displayOrder: 0,
+          verificationRecord: { status: 'unchecked' },
+        },
+        {
+          control: { controlCode: 'LOG-247', id: secondControl.controlId },
+          controlVersion: { id: secondControl.versionId, versionNumber: 1 },
+          displayOrder: 1,
+          verificationRecord: { status: 'unchecked' },
+        },
+      ],
+      templateId,
+    });
+
+    const checklists = await db
+      .select()
+      .from(projectChecklists)
+      .where(eq(projectChecklists.componentId, componentId));
+    const items = await db.select().from(projectChecklistItems);
+    const verificationRecords = await db.select().from(projectChecklistVerificationRecords);
+
+    expect(checklists).toHaveLength(1);
+    expect(items).toHaveLength(2);
+    expect(verificationRecords).toHaveLength(2);
+    expect(items.map(({ templateItemId }) => templateItemId).sort()).toEqual(
+      (await db.select({ id: checklistTemplateItems.id }).from(checklistTemplateItems))
+        .map(({ id }) => id)
+        .sort(),
+    );
+  });
+
+  it('enforces one active Project Checklist per template and unique display names per component', async () => {
+    const owner = await createSignedInOwner('project-checklist-unique');
+    const projectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'vendor-risk',
+    });
+    const componentId = await createComponent(projectId);
+    const control = await createActiveControl({
+      controlCode: 'AUTH-347',
+      organizationId: owner.organization.id,
+      title: 'Require MFA',
+    });
+    const firstTemplateId = await createTemplate({
+      controlIds: [control.controlId],
+      name: 'Release Readiness',
+      organizationId: owner.organization.id,
+    });
+    const secondTemplateId = await createTemplate({
+      controlIds: [control.controlId],
+      name: 'Operational Readiness',
+      organizationId: owner.organization.id,
+    });
+
+    await applyTemplate({
+      body: { displayName: 'Custom Checklist', templateId: firstTemplateId },
+      componentId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'vendor-risk',
+    });
+
+    await expect(
+      applyTemplate({
+        body: { displayName: 'Another Checklist', templateId: firstTemplateId },
+        componentId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({
+      body: {
+        error:
+          'Project Component already has an active Project Checklist for this Checklist Template.',
+      },
+      status: 400,
+    });
+    await expect(
+      applyTemplate({
+        body: { displayName: ' custom   checklist ', templateId: secondTemplateId },
+        componentId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Project Checklist display name is already used for this Project Component.' },
+      status: 400,
+    });
+  });
+
+  it('rejects inactive templates, archived Projects, archived Project Components, and archived Controls', async () => {
+    const owner = await createSignedInOwner('project-checklist-inactive');
+    const activeProjectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'vendor-risk',
+    });
+    const archivedProjectId = await createProject({
+      archived: true,
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'legacy-risk',
+    });
+    const activeComponentId = await createComponent(activeProjectId, 'Active Component');
+    const archivedComponentId = await createComponent(activeProjectId, 'Archived Component', true);
+    const archivedProjectComponentId = await createComponent(archivedProjectId, 'Legacy Component');
+    const control = await createActiveControl({
+      controlCode: 'AUTH-447',
+      organizationId: owner.organization.id,
+      title: 'Require MFA',
+    });
+    const inactiveTemplateId = await createTemplate({
+      controlIds: [control.controlId],
+      organizationId: owner.organization.id,
+      status: 'draft',
+    });
+    const archivedControlTemplateId = await createTemplate({
+      controlIds: [control.controlId],
+      name: 'Archived Control Template',
+      organizationId: owner.organization.id,
+    });
+
+    await db
+      .update(controls)
+      .set({ archivedAt: new Date() })
+      .where(eq(controls.id, control.controlId));
+
+    await expect(
+      applyTemplate({
+        body: { templateId: inactiveTemplateId },
+        componentId: activeComponentId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Only active Checklist Templates can be applied.' },
+      status: 400,
+    });
+    await expect(
+      applyTemplate({
+        body: { templateId: archivedControlTemplateId },
+        componentId: activeComponentId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Checklist Template contains Controls that are no longer active.' },
+      status: 400,
+    });
+    await expect(
+      applyTemplate({
+        body: { templateId: archivedControlTemplateId },
+        componentId: archivedComponentId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({ status: 404 });
+    await expect(
+      applyTemplate({
+        body: { templateId: archivedControlTemplateId },
+        componentId: archivedProjectComponentId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'legacy-risk',
+      }),
+    ).resolves.toMatchObject({ status: 404 });
+  });
+});

--- a/apps/backend-hono/test/project-checklists.spec.ts
+++ b/apps/backend-hono/test/project-checklists.spec.ts
@@ -5,6 +5,7 @@ import app from '../src/index';
 import { db } from '../src/db/client';
 import {
   checklistTemplateItems,
+  checklistTemplateSections,
   checklistTemplates,
   controlVersions,
   controls,
@@ -192,6 +193,7 @@ async function createComponent(projectId: string, name = 'Payments Platform', ar
 async function createActiveControl(input: {
   controlCode: string;
   organizationId: string;
+  releaseImpact?: string;
   title: string;
 }) {
   const controlId = crypto.randomUUID();
@@ -218,7 +220,7 @@ async function createActiveControl(input: {
     createdAt: now,
     externalStandardsMappings: JSON.stringify([]),
     id: versionId,
-    releaseImpact: 'blocking',
+    releaseImpact: input.releaseImpact ?? 'blocking',
     title: input.title,
     verificationMethod: 'Review evidence.',
     versionNumber: 1,
@@ -304,6 +306,24 @@ async function applyTemplate(input: {
       headers: input.headers,
       method: 'POST',
     },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function openChecklist(input: {
+  checklistId: string;
+  componentId: string;
+  headers: Headers;
+  organizationSlug: string;
+  projectSlug: string;
+}) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${input.organizationSlug}/projects/${input.projectSlug}/components/${input.componentId}/checklists/${input.checklistId}`,
+    { headers: input.headers },
   );
 
   return {
@@ -474,6 +494,328 @@ describe('Project Checklists API', () => {
         .map(({ id }) => id)
         .sort(),
     );
+  });
+
+  it('lets Organization members open Project Checklists with Control Versions, Release Impact, grouping, and completion', async () => {
+    const owner = await createSignedInOwner('project-checklist-read-owner');
+    const member = await addMemberToOrganization(owner.organization.id, 'project-checklist-reader');
+    const outsider = await createSignedInOwner('project-checklist-outsider');
+    const projectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'vendor-risk',
+    });
+    const componentId = await createComponent(projectId);
+    const accessControl = await createActiveControl({
+      controlCode: 'AUTH-548',
+      organizationId: owner.organization.id,
+      releaseImpact: 'blocking',
+      title: 'Require MFA',
+    });
+    const loggingControl = await createActiveControl({
+      controlCode: 'LOG-548',
+      organizationId: owner.organization.id,
+      releaseImpact: 'needs review',
+      title: 'Require logging',
+    });
+    const advisoryControl = await createActiveControl({
+      controlCode: 'DOC-548',
+      organizationId: owner.organization.id,
+      releaseImpact: 'advisory',
+      title: 'Document runbooks',
+    });
+    const latestAccessVersionId = await addLatestControlVersion(
+      accessControl.controlId,
+      'AUTH-548',
+      'Require phishing-resistant MFA',
+    );
+    const templateId = await createTemplate({
+      controlIds: [accessControl.controlId, loggingControl.controlId, advisoryControl.controlId],
+      organizationId: owner.organization.id,
+    });
+    const now = new Date();
+    const accessSectionId = crypto.randomUUID();
+    const operationsSectionId = crypto.randomUUID();
+
+    await db.insert(checklistTemplateSections).values([
+      {
+        createdAt: now,
+        displayOrder: 1,
+        id: operationsSectionId,
+        name: 'Operations',
+        normalizedName: 'operations',
+        templateId,
+        updatedAt: now,
+      },
+      {
+        createdAt: now,
+        displayOrder: 0,
+        id: accessSectionId,
+        name: 'Access',
+        normalizedName: 'access',
+        templateId,
+        updatedAt: now,
+      },
+    ]);
+    await db
+      .update(checklistTemplateItems)
+      .set({ displayOrder: 0, sectionId: accessSectionId })
+      .where(
+        and(
+          eq(checklistTemplateItems.templateId, templateId),
+          eq(checklistTemplateItems.controlId, accessControl.controlId),
+        ),
+      );
+    await db
+      .update(checklistTemplateItems)
+      .set({ displayOrder: 0, sectionId: operationsSectionId })
+      .where(
+        and(
+          eq(checklistTemplateItems.templateId, templateId),
+          eq(checklistTemplateItems.controlId, loggingControl.controlId),
+        ),
+      );
+
+    const applyResponse = await applyTemplate({
+      body: { templateId },
+      componentId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'vendor-risk',
+    });
+    const projectChecklist = applyResponse.body.projectChecklist as { id: string };
+    const records = await db
+      .select({
+        controlId: projectChecklistItems.controlId,
+        id: projectChecklistVerificationRecords.id,
+      })
+      .from(projectChecklistItems)
+      .innerJoin(
+        projectChecklistVerificationRecords,
+        eq(projectChecklistItems.verificationRecordId, projectChecklistVerificationRecords.id),
+      )
+      .where(eq(projectChecklistItems.projectChecklistId, projectChecklist.id));
+
+    await db
+      .update(projectChecklistVerificationRecords)
+      .set({ status: 'checked' })
+      .where(
+        eq(
+          projectChecklistVerificationRecords.id,
+          records.find(({ controlId }) => controlId === accessControl.controlId)!.id,
+        ),
+      );
+    await db
+      .update(projectChecklistVerificationRecords)
+      .set({ status: 'not-applicable' })
+      .where(
+        eq(
+          projectChecklistVerificationRecords.id,
+          records.find(({ controlId }) => controlId === loggingControl.controlId)!.id,
+        ),
+      );
+
+    const response = await openChecklist({
+      checklistId: projectChecklist.id,
+      componentId,
+      headers: member.headers,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'vendor-risk',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.projectChecklist).toMatchObject({
+      completion: { completedItems: 2, totalItems: 3 },
+      items: [
+        {
+          control: { controlCode: 'DOC-548', releaseImpact: 'advisory' },
+          sectionId: null,
+          verificationRecord: { status: 'unchecked' },
+        },
+        {
+          control: { controlCode: 'AUTH-548', releaseImpact: 'needs review' },
+          controlVersion: { id: latestAccessVersionId, versionNumber: 2 },
+          sectionId: accessSectionId,
+          verificationRecord: { status: 'checked' },
+        },
+        {
+          control: { controlCode: 'LOG-548', releaseImpact: 'needs review' },
+          controlVersion: { id: loggingControl.versionId, versionNumber: 1 },
+          sectionId: operationsSectionId,
+          verificationRecord: { status: 'not-applicable' },
+        },
+      ],
+      sections: [
+        {
+          displayOrder: 0,
+          id: accessSectionId,
+          items: [{ control: { controlCode: 'AUTH-548' } }],
+          name: 'Access',
+        },
+        {
+          displayOrder: 1,
+          id: operationsSectionId,
+          items: [{ control: { controlCode: 'LOG-548' } }],
+          name: 'Operations',
+        },
+      ],
+      unsectionedItems: [{ control: { controlCode: 'DOC-548' } }],
+    });
+    await expect(
+      openChecklist({
+        checklistId: projectChecklist.id,
+        componentId,
+        headers: outsider.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      }),
+    ).resolves.toMatchObject({ status: 404 });
+  });
+
+  it('hides removed-from-template items by default and excludes them from completion', async () => {
+    const owner = await createSignedInOwner('project-checklist-removed');
+    const projectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'vendor-risk',
+    });
+    const componentId = await createComponent(projectId);
+    const visibleControl = await createActiveControl({
+      controlCode: 'AUTH-648',
+      organizationId: owner.organization.id,
+      title: 'Require MFA',
+    });
+    const removedControl = await createActiveControl({
+      controlCode: 'LOG-648',
+      organizationId: owner.organization.id,
+      title: 'Require logging',
+    });
+    const otherControl = await createActiveControl({
+      controlCode: 'NET-648',
+      organizationId: owner.organization.id,
+      title: 'Segment networks',
+    });
+    const templateId = await createTemplate({
+      controlIds: [visibleControl.controlId, removedControl.controlId],
+      organizationId: owner.organization.id,
+    });
+    const otherTemplateId = await createTemplate({
+      controlIds: [otherControl.controlId],
+      name: 'Other Readiness',
+      organizationId: owner.organization.id,
+    });
+
+    const applyResponse = await applyTemplate({
+      body: { templateId },
+      componentId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'vendor-risk',
+    });
+    const projectChecklist = applyResponse.body.projectChecklist as { id: string };
+    const removedTemplateItem = await db
+      .select({ id: checklistTemplateItems.id })
+      .from(checklistTemplateItems)
+      .where(
+        and(
+          eq(checklistTemplateItems.templateId, templateId),
+          eq(checklistTemplateItems.controlId, removedControl.controlId),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0]!);
+    const replacementTemplateItem = await db
+      .select({ id: checklistTemplateItems.id })
+      .from(checklistTemplateItems)
+      .where(eq(checklistTemplateItems.templateId, otherTemplateId))
+      .limit(1)
+      .then((rows) => rows[0]!);
+    const removedChecklistItem = await db
+      .select({ verificationRecordId: projectChecklistItems.verificationRecordId })
+      .from(projectChecklistItems)
+      .where(eq(projectChecklistItems.templateItemId, removedTemplateItem.id))
+      .limit(1)
+      .then((rows) => rows[0]!);
+
+    await db
+      .update(projectChecklistItems)
+      .set({ templateItemId: replacementTemplateItem.id })
+      .where(eq(projectChecklistItems.templateItemId, removedTemplateItem.id));
+    await db
+      .update(projectChecklistVerificationRecords)
+      .set({ status: 'checked' })
+      .where(eq(projectChecklistVerificationRecords.id, removedChecklistItem.verificationRecordId));
+
+    const response = await openChecklist({
+      checklistId: projectChecklist.id,
+      componentId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'vendor-risk',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.projectChecklist).toMatchObject({
+      completion: { completedItems: 0, totalItems: 1 },
+      items: [{ control: { controlCode: 'AUTH-648' } }],
+    });
+  });
+
+  it('keeps archived Project Checklist completion readable with current non-removed items', async () => {
+    const owner = await createSignedInOwner('project-checklist-archived-read');
+    const projectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'vendor-risk',
+    });
+    const componentId = await createComponent(projectId);
+    const control = await createActiveControl({
+      controlCode: 'AUTH-748',
+      organizationId: owner.organization.id,
+      title: 'Require MFA',
+    });
+    const templateId = await createTemplate({
+      controlIds: [control.controlId],
+      organizationId: owner.organization.id,
+    });
+    const applyResponse = await applyTemplate({
+      body: { templateId },
+      componentId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'vendor-risk',
+    });
+    const projectChecklist = applyResponse.body.projectChecklist as { id: string };
+    const checklistItem = await db
+      .select({ verificationRecordId: projectChecklistItems.verificationRecordId })
+      .from(projectChecklistItems)
+      .where(eq(projectChecklistItems.projectChecklistId, projectChecklist.id))
+      .limit(1)
+      .then((rows) => rows[0]!);
+
+    await db
+      .update(projectChecklistVerificationRecords)
+      .set({ status: 'checked' })
+      .where(eq(projectChecklistVerificationRecords.id, checklistItem.verificationRecordId));
+    await db
+      .update(projectChecklists)
+      .set({ archivedAt: new Date() })
+      .where(eq(projectChecklists.id, projectChecklist.id));
+
+    const response = await openChecklist({
+      checklistId: projectChecklist.id,
+      componentId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'vendor-risk',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.projectChecklist).toMatchObject({
+      archivedAt: expect.any(String),
+      completion: { completedItems: 1, totalItems: 1 },
+      items: [{ control: { controlCode: 'AUTH-748' }, verificationRecord: { status: 'checked' } }],
+    });
   });
 
   it('enforces one active Project Checklist per template and unique display names per component', async () => {


### PR DESCRIPTION
## Summary
- Add checklist item verification updates for checked, unchecked, and not applicable states.
- Persist current not-applicable explanations and immutable Control Version verification history with actor and timestamp.
- Keep archived Project, Project Component, and Project Checklist containers read-only for verification changes.

## Tests
- pnpm lint
- pnpm format:check
- pnpm check-types
- pnpm test
- pnpm build

Closes #49