### PR TITLE
Report unchecked current requirements

### DIFF
--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -86,6 +86,7 @@ import {
   applyChecklistTemplateToProjectComponent,
   canApplyProjectChecklists,
   getProjectChecklistForMembership,
+  listUncheckedCurrentRequirementsForMembership,
   normalizeApplyChecklistTemplateBody,
   normalizeChecklistItemVerificationBody,
   ProjectChecklistInputError,
@@ -249,6 +250,32 @@ app.get('/api/organizations/:organizationSlug/projects', async (c) => {
 
   return c.json({ projects: await listProjects(membership.organizationId, status) });
 });
+
+app.get(
+  '/api/organizations/:organizationSlug/reports/unchecked-current-requirements',
+  async (c) => {
+    const session = await auth.api.getSession({
+      headers: c.req.raw.headers,
+    });
+
+    if (!session) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    const membership = await getOrganizationMembership(
+      c.req.param('organizationSlug'),
+      session.user.id,
+    );
+
+    if (!membership) {
+      return c.json({ error: 'Organization not found' }, 404);
+    }
+
+    return c.json({
+      uncheckedCurrentRequirements: await listUncheckedCurrentRequirementsForMembership(membership),
+    });
+  },
+);
 
 app.get('/api/organizations/:organizationSlug/checklist-templates', async (c) => {
   const session = await auth.api.getSession({

--- a/apps/backend-hono/src/lib/project-checklists.ts
+++ b/apps/backend-hono/src/lib/project-checklists.ts
@@ -76,6 +76,40 @@ export type ProjectChecklistSectionResponse = {
   name: string;
 };
 
+export type UncheckedCurrentRequirementReportItem = {
+  control: {
+    controlCode: string;
+    id: string;
+    releaseImpact: string;
+    title: string;
+  };
+  controlVersion: {
+    id: string;
+    versionNumber: number;
+  };
+  project: {
+    id: string;
+    name: string;
+    slug: string;
+  };
+  projectChecklist: {
+    displayName: string;
+    id: string;
+  };
+  projectChecklistItem: {
+    id: string;
+  };
+  projectComponent: {
+    id: string;
+    name: string;
+  };
+  uncheckedReason: 'new-control-version' | 'never-verified';
+  verificationRecord: {
+    id: string;
+    status: string;
+  };
+};
+
 type ApplyChecklistTemplateInput = {
   displayName: string | null;
   templateId: string;
@@ -619,6 +653,125 @@ export async function getProjectChecklistForMembership(input: {
     unsectionedItems: items.filter(({ sectionId }) => !sectionId),
     updatedAt: checklist.updatedAt.toISOString(),
   };
+}
+
+export async function listUncheckedCurrentRequirementsForMembership(
+  membership: OrganizationMembership,
+): Promise<UncheckedCurrentRequirementReportItem[]> {
+  const rows = await db
+    .select({
+      componentId: projectComponents.id,
+      componentName: projectComponents.name,
+      controlCode: controlVersions.controlCode,
+      controlId: projectChecklistItems.controlId,
+      controlVersionId: projectChecklistItems.controlVersionId,
+      displayOrder: projectChecklistItems.displayOrder,
+      itemId: projectChecklistItems.id,
+      projectChecklistDisplayName: projectChecklists.displayName,
+      projectChecklistId: projectChecklists.id,
+      projectId: projects.id,
+      projectName: projects.name,
+      projectSlug: projects.slug,
+      releaseImpact: controlVersions.releaseImpact,
+      title: controlVersions.title,
+      verificationRecordId: projectChecklistVerificationRecords.id,
+      verificationStatus: projectChecklistVerificationRecords.status,
+      versionNumber: controlVersions.versionNumber,
+    })
+    .from(projectChecklistItems)
+    .innerJoin(
+      projectChecklists,
+      eq(projectChecklistItems.projectChecklistId, projectChecklists.id),
+    )
+    .innerJoin(projectComponents, eq(projectChecklists.componentId, projectComponents.id))
+    .innerJoin(projects, eq(projectComponents.projectId, projects.id))
+    .innerJoin(controls, eq(projectChecklistItems.controlId, controls.id))
+    .innerJoin(controlVersions, eq(projectChecklistItems.controlVersionId, controlVersions.id))
+    .innerJoin(
+      projectChecklistVerificationRecords,
+      eq(projectChecklistItems.verificationRecordId, projectChecklistVerificationRecords.id),
+    )
+    .where(
+      and(
+        eq(projects.organizationId, membership.organizationId),
+        isNull(projects.archivedAt),
+        isNull(projectComponents.archivedAt),
+        isNull(projectChecklists.archivedAt),
+        isNull(projectChecklistItems.removedFromTemplateAt),
+        isNull(controls.archivedAt),
+        eq(projectChecklistItems.controlVersionId, controls.currentVersionId),
+        eq(projectChecklistVerificationRecords.status, 'unchecked'),
+      ),
+    )
+    .orderBy(
+      asc(projects.name),
+      asc(projectComponents.name),
+      asc(projectChecklists.displayName),
+      asc(projectChecklistItems.displayOrder),
+      asc(controlVersions.controlCode),
+    );
+
+  const histories = rows.length
+    ? await db
+        .select({
+          controlVersionId: projectChecklistVerificationHistory.controlVersionId,
+          projectChecklistItemId: projectChecklistVerificationHistory.projectChecklistItemId,
+        })
+        .from(projectChecklistVerificationHistory)
+        .where(
+          inArray(
+            projectChecklistVerificationHistory.projectChecklistItemId,
+            rows.map(({ itemId }) => itemId),
+          ),
+        )
+    : [];
+  const currentVersionByItemId = new Map(
+    rows.map(({ controlVersionId, itemId }) => [itemId, controlVersionId]),
+  );
+  const itemsWithPriorVersionHistory = new Set(
+    histories
+      .filter(
+        ({ controlVersionId, projectChecklistItemId }) =>
+          currentVersionByItemId.get(projectChecklistItemId) !== controlVersionId,
+      )
+      .map(({ projectChecklistItemId }) => projectChecklistItemId),
+  );
+
+  return rows.map((row) => ({
+    control: {
+      controlCode: row.controlCode,
+      id: row.controlId,
+      releaseImpact: row.releaseImpact,
+      title: row.title,
+    },
+    controlVersion: {
+      id: row.controlVersionId,
+      versionNumber: row.versionNumber,
+    },
+    project: {
+      id: row.projectId,
+      name: row.projectName,
+      slug: row.projectSlug,
+    },
+    projectChecklist: {
+      displayName: row.projectChecklistDisplayName,
+      id: row.projectChecklistId,
+    },
+    projectChecklistItem: {
+      id: row.itemId,
+    },
+    projectComponent: {
+      id: row.componentId,
+      name: row.componentName,
+    },
+    uncheckedReason: itemsWithPriorVersionHistory.has(row.itemId)
+      ? 'new-control-version'
+      : 'never-verified',
+    verificationRecord: {
+      id: row.verificationRecordId,
+      status: row.verificationStatus,
+    },
+  }));
 }
 
 function isCompleteVerificationStatus(status: string): boolean {

--- a/apps/backend-hono/test/project-checklists.spec.ts
+++ b/apps/backend-hono/test/project-checklists.spec.ts
@@ -463,6 +463,21 @@ async function setChecklistArchived(input: {
   };
 }
 
+async function getUncheckedCurrentRequirementsReport(input: {
+  headers?: Headers;
+  organizationSlug: string;
+}) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${input.organizationSlug}/reports/unchecked-current-requirements`,
+    input.headers ? { headers: input.headers } : undefined,
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
 beforeEach(() => {
   const originalFetch = globalThis.fetch;
 
@@ -483,6 +498,227 @@ afterEach(() => {
 });
 
 describe('Project Checklists API', () => {
+  it('reports unchecked current requirements to Organization members only', async () => {
+    const owner = await createSignedInOwner('unchecked-report-owner');
+    const member = await addMemberToOrganization(owner.organization.id, 'unchecked-report-member');
+    const outsider = await createSignedInOwner('unchecked-report-outsider');
+    const projectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'vendor-risk',
+    });
+    const componentId = await createComponent(projectId, 'Active Component');
+    const neverVerifiedControl = await createActiveControl({
+      controlCode: 'AUTH-055',
+      organizationId: owner.organization.id,
+      title: 'Require MFA enrollment',
+    });
+    const notApplicableControl = await createActiveControl({
+      controlCode: 'LOG-055',
+      organizationId: owner.organization.id,
+      title: 'Require centralized logs',
+    });
+    const removedControl = await createActiveControl({
+      controlCode: 'NET-055',
+      organizationId: owner.organization.id,
+      title: 'Require network review',
+    });
+    const staleControl = await createActiveControl({
+      controlCode: 'OPS-055',
+      organizationId: owner.organization.id,
+      title: 'Require operational readiness',
+    });
+    const updatedControl = await createActiveControl({
+      controlCode: 'SEC-055',
+      organizationId: owner.organization.id,
+      title: 'Require security approval',
+    });
+    const templateId = await createTemplate({
+      controlIds: [
+        neverVerifiedControl.controlId,
+        notApplicableControl.controlId,
+        removedControl.controlId,
+        staleControl.controlId,
+        updatedControl.controlId,
+      ],
+      organizationId: owner.organization.id,
+    });
+    const checklist = (
+      await applyTemplate({
+        body: { templateId },
+        componentId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'vendor-risk',
+      })
+    ).body.projectChecklist as {
+      id: string;
+      items: Array<{ control: { id: string }; id: string }>;
+    };
+    const itemByControlId = new Map(checklist.items.map((item) => [item.control.id, item]));
+
+    await updateChecklistItemVerification({
+      body: {
+        notApplicableExplanation: 'This Project Component does not process audit logs.',
+        status: 'not-applicable',
+      },
+      checklistId: checklist.id,
+      componentId,
+      headers: owner.headers,
+      itemId: itemByControlId.get(notApplicableControl.controlId)!.id,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'vendor-risk',
+    });
+    await updateChecklistItemVerification({
+      body: { status: 'checked' },
+      checklistId: checklist.id,
+      componentId,
+      headers: owner.headers,
+      itemId: itemByControlId.get(updatedControl.controlId)!.id,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'vendor-risk',
+    });
+
+    const removedTemplateItem = await db
+      .select({ id: checklistTemplateItems.id })
+      .from(checklistTemplateItems)
+      .where(
+        and(
+          eq(checklistTemplateItems.templateId, templateId),
+          eq(checklistTemplateItems.controlId, removedControl.controlId),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0]!);
+
+    await removeChecklistTemplateItem({
+      headers: owner.headers,
+      itemId: removedTemplateItem.id,
+      organizationSlug: owner.organization.slug,
+      templateId,
+    });
+    await addLatestControlVersion(staleControl.controlId, 'OPS-055', 'Require current operations');
+
+    const proposedResponse = await createControlProposedUpdate({
+      body: {
+        acceptedEvidenceTypes: ['document'],
+        applicabilityConditions: 'Applies to active Project Checklist Items.',
+        businessMeaning: 'Updated security approval requires fresh verification.',
+        controlCode: 'SEC-055',
+        externalStandardsMappings: [],
+        releaseImpact: 'blocking',
+        title: 'Require refreshed security approval',
+        verificationMethod: 'Review updated approval evidence.',
+      },
+      controlId: updatedControl.controlId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+    });
+    await publishControlProposedUpdate({
+      controlId: updatedControl.controlId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      proposedUpdateId: (proposedResponse.body.proposedUpdate as { id: string }).id,
+    });
+
+    const archivedProjectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'archived-report-project',
+    });
+    const archivedProjectComponentId = await createComponent(archivedProjectId, 'Archived Project');
+    const archivedComponentProjectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'archived-report-component',
+    });
+    const archivedComponentId = await createComponent(
+      archivedComponentProjectId,
+      'Archived Component',
+    );
+    const archivedChecklistProjectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'archived-report-checklist',
+    });
+    const archivedChecklistComponentId = await createComponent(
+      archivedChecklistProjectId,
+      'Archived Checklist',
+    );
+
+    for (const [slug, archivedComponent] of [
+      ['archived-report-project', archivedProjectComponentId],
+      ['archived-report-component', archivedComponentId],
+      ['archived-report-checklist', archivedChecklistComponentId],
+    ] as const) {
+      await applyTemplate({
+        body: { templateId },
+        componentId: archivedComponent,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: slug,
+      });
+    }
+    await db
+      .update(projects)
+      .set({ archivedAt: new Date() })
+      .where(eq(projects.id, archivedProjectId));
+    await db
+      .update(projectComponents)
+      .set({ archivedAt: new Date() })
+      .where(eq(projectComponents.id, archivedComponentId));
+    await db
+      .update(projectChecklists)
+      .set({ archivedAt: new Date() })
+      .where(eq(projectChecklists.componentId, archivedChecklistComponentId));
+
+    await expect(
+      getUncheckedCurrentRequirementsReport({ organizationSlug: owner.organization.slug }),
+    ).resolves.toMatchObject({ body: { error: 'Unauthorized' }, status: 401 });
+    await expect(
+      getUncheckedCurrentRequirementsReport({
+        headers: outsider.headers,
+        organizationSlug: owner.organization.slug,
+      }),
+    ).resolves.toMatchObject({ body: { error: 'Organization not found' }, status: 404 });
+
+    const reportResponse = await getUncheckedCurrentRequirementsReport({
+      headers: member.headers,
+      organizationSlug: owner.organization.slug,
+    });
+    const requirements = reportResponse.body.uncheckedCurrentRequirements as Array<{
+      control: { controlCode: string; title: string };
+      controlVersion: { versionNumber: number };
+      project: { slug: string };
+      projectChecklistItem: { id: string };
+      uncheckedReason: string;
+      verificationRecord: { status: string };
+    }>;
+
+    expect(reportResponse.status).toBe(200);
+    expect(requirements).toHaveLength(2);
+    expect(requirements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          control: expect.objectContaining({ controlCode: 'AUTH-055' }),
+          controlVersion: expect.objectContaining({ versionNumber: 1 }),
+          project: expect.objectContaining({ slug: 'vendor-risk' }),
+          projectChecklistItem: { id: itemByControlId.get(neverVerifiedControl.controlId)!.id },
+          uncheckedReason: 'never-verified',
+          verificationRecord: expect.objectContaining({ status: 'unchecked' }),
+        }),
+        expect.objectContaining({
+          control: expect.objectContaining({ controlCode: 'SEC-055' }),
+          controlVersion: expect.objectContaining({ versionNumber: 2 }),
+          project: expect.objectContaining({ slug: 'vendor-risk' }),
+          projectChecklistItem: { id: itemByControlId.get(updatedControl.controlId)!.id },
+          uncheckedReason: 'new-control-version',
+          verificationRecord: expect.objectContaining({ status: 'unchecked' }),
+        }),
+      ]),
+    );
+  });
+
   it('lets Organization owners, admins, and the Project Owner apply active Checklist Templates', async () => {
     const owner = await createSignedInOwner('project-checklist-owner');
     const admin = await addMemberToOrganization(


### PR DESCRIPTION
## Summary
- Add an Organization-wide unchecked current requirements report endpoint for active Projects, Project Components, Project Checklists, and current Control Versions.
- Exclude not-applicable, checked, removed-from-template, archived-work, archived-Control, and stale-Control-Version items.
- Distinguish never-verified unchecked items from items reset by a new Control Version.

## Tests
- pnpm format:check
- pnpm lint
- pnpm check-types
- pnpm test
- pnpm build

Closes #55