### PR TITLE
Catch up restored active-work containers

### DIFF
--- a/apps/backend-hono/src/lib/project-checklist-catch-up.ts
+++ b/apps/backend-hono/src/lib/project-checklist-catch-up.ts
@@ -1,0 +1,141 @@
+import { and, eq, isNull } from 'drizzle-orm';
+import { db } from '../db/client';
+import {
+  checklistTemplateItems,
+  controls,
+  projectChecklistItems,
+  projectChecklists,
+  projectChecklistVerificationRecords,
+  projectComponents,
+  projects,
+} from '../db/schema';
+
+type CatchUpProjectChecklistsInput = {
+  checklistId?: string;
+  componentId?: string;
+  projectId?: string;
+};
+
+export async function catchUpActiveProjectChecklists(input: CatchUpProjectChecklistsInput) {
+  const checklists = await db
+    .select({ id: projectChecklists.id, templateId: projectChecklists.templateId })
+    .from(projectChecklists)
+    .innerJoin(projectComponents, eq(projectChecklists.componentId, projectComponents.id))
+    .innerJoin(projects, eq(projectComponents.projectId, projects.id))
+    .where(
+      and(
+        input.checklistId ? eq(projectChecklists.id, input.checklistId) : undefined,
+        input.componentId ? eq(projectComponents.id, input.componentId) : undefined,
+        input.projectId ? eq(projects.id, input.projectId) : undefined,
+        isNull(projectChecklists.archivedAt),
+        isNull(projectComponents.archivedAt),
+        isNull(projects.archivedAt),
+      ),
+    );
+
+  for (const checklist of checklists) {
+    await catchUpActiveProjectChecklist(checklist);
+  }
+}
+
+async function catchUpActiveProjectChecklist(checklist: { id: string; templateId: string }) {
+  const activeTemplateItems = await db
+    .select({
+      controlId: checklistTemplateItems.controlId,
+      controlVersionId: controls.currentVersionId,
+      displayOrder: checklistTemplateItems.displayOrder,
+      templateItemId: checklistTemplateItems.id,
+    })
+    .from(checklistTemplateItems)
+    .innerJoin(controls, eq(checklistTemplateItems.controlId, controls.id))
+    .where(
+      and(
+        eq(checklistTemplateItems.templateId, checklist.templateId),
+        isNull(checklistTemplateItems.removedAt),
+        isNull(controls.archivedAt),
+      ),
+    );
+  const existingItems = await db
+    .select({
+      controlVersionId: projectChecklistItems.controlVersionId,
+      id: projectChecklistItems.id,
+      removedFromTemplateAt: projectChecklistItems.removedFromTemplateAt,
+      templateItemId: projectChecklistItems.templateItemId,
+    })
+    .from(projectChecklistItems)
+    .where(eq(projectChecklistItems.projectChecklistId, checklist.id));
+  const activeTemplateItemIds = new Set(
+    activeTemplateItems.map(({ templateItemId }) => templateItemId),
+  );
+  const now = new Date();
+
+  for (const item of existingItems) {
+    if (!activeTemplateItemIds.has(item.templateItemId) && !item.removedFromTemplateAt) {
+      await db
+        .update(projectChecklistItems)
+        .set({ removedFromTemplateAt: now })
+        .where(eq(projectChecklistItems.id, item.id));
+    }
+  }
+
+  for (const templateItem of activeTemplateItems) {
+    if (!templateItem.controlVersionId) {
+      continue;
+    }
+
+    const existingItem = existingItems.find(
+      (item) => item.templateItemId === templateItem.templateItemId,
+    );
+
+    if (!existingItem) {
+      const verificationRecordId = crypto.randomUUID();
+
+      await db.insert(projectChecklistVerificationRecords).values({
+        controlVersionId: templateItem.controlVersionId,
+        createdAt: now,
+        id: verificationRecordId,
+        status: 'unchecked',
+        updatedAt: now,
+      });
+      await db.insert(projectChecklistItems).values({
+        controlId: templateItem.controlId,
+        controlVersionId: templateItem.controlVersionId,
+        createdAt: now,
+        displayOrder: templateItem.displayOrder,
+        id: crypto.randomUUID(),
+        projectChecklistId: checklist.id,
+        removedFromTemplateAt: null,
+        templateItemId: templateItem.templateItemId,
+        verificationRecordId,
+      });
+      continue;
+    }
+
+    if (existingItem.controlVersionId === templateItem.controlVersionId) {
+      await db
+        .update(projectChecklistItems)
+        .set({ displayOrder: templateItem.displayOrder, removedFromTemplateAt: null })
+        .where(eq(projectChecklistItems.id, existingItem.id));
+      continue;
+    }
+
+    const verificationRecordId = crypto.randomUUID();
+
+    await db.insert(projectChecklistVerificationRecords).values({
+      controlVersionId: templateItem.controlVersionId,
+      createdAt: now,
+      id: verificationRecordId,
+      status: 'unchecked',
+      updatedAt: now,
+    });
+    await db
+      .update(projectChecklistItems)
+      .set({
+        controlVersionId: templateItem.controlVersionId,
+        displayOrder: templateItem.displayOrder,
+        removedFromTemplateAt: null,
+        verificationRecordId,
+      })
+      .where(eq(projectChecklistItems.id, existingItem.id));
+  }
+}

--- a/apps/backend-hono/src/lib/project-checklists.ts
+++ b/apps/backend-hono/src/lib/project-checklists.ts
@@ -14,6 +14,7 @@ import {
   projects,
 } from '../db/schema';
 import { canManageProjects, type OrganizationMembership } from './projects';
+import { catchUpActiveProjectChecklists } from './project-checklist-catch-up';
 
 export type ProjectChecklistResponse = {
   archivedAt: string | null;
@@ -417,6 +418,10 @@ export async function setProjectChecklistArchivedForMembership(input: {
       updatedAt: new Date(),
     })
     .where(eq(projectChecklists.id, checklist.id));
+
+  if (!input.archived) {
+    await catchUpActiveProjectChecklists({ checklistId: checklist.id });
+  }
 
   return getProjectChecklistForMembership({
     checklistId: checklist.id,

--- a/apps/backend-hono/src/lib/projects.ts
+++ b/apps/backend-hono/src/lib/projects.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, isNotNull, isNull, ne } from 'drizzle-orm';
 import { db } from '../db/client';
 import { members, organizations, projectComponents, projects, users } from '../db/schema';
+import { catchUpActiveProjectChecklists } from './project-checklist-catch-up';
 
 export type ProjectListItem = {
   archivedAt: string | null;
@@ -315,6 +316,10 @@ export async function setProjectArchivedForMembership(input: {
     })
     .where(eq(projects.id, existingProject.id));
 
+  if (!input.archived) {
+    await catchUpActiveProjectChecklists({ projectId: existingProject.id });
+  }
+
   return getProjectDetailForMembership(input.membership, input.projectSlug);
 }
 
@@ -489,6 +494,10 @@ export async function setProjectComponentArchivedForMembership(input: {
       updatedAt: new Date(),
     })
     .where(eq(projectComponents.id, component.id));
+
+  if (!input.archived) {
+    await catchUpActiveProjectChecklists({ componentId: component.id });
+  }
 
   return getProjectComponent(project.id, component.id).then((row) =>
     row ? formatProjectComponent(row) : null,

--- a/apps/backend-hono/test/project-checklists.spec.ts
+++ b/apps/backend-hono/test/project-checklists.spec.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import app from '../src/index';
@@ -451,6 +451,47 @@ async function setChecklistArchived(input: {
 }) {
   const response = await app.request(
     `http://example.com/api/organizations/${input.organizationSlug}/projects/${input.projectSlug}/components/${input.componentId}/checklists/${input.checklistId}/${input.archived ? 'archive' : 'restore'}`,
+    {
+      headers: input.headers,
+      method: 'PATCH',
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function setComponentArchived(input: {
+  archived: boolean;
+  componentId: string;
+  headers: Headers;
+  organizationSlug: string;
+  projectSlug: string;
+}) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${input.organizationSlug}/projects/${input.projectSlug}/components/${input.componentId}/${input.archived ? 'archive' : 'restore'}`,
+    {
+      headers: input.headers,
+      method: 'PATCH',
+    },
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
+async function setProjectArchived(input: {
+  archived: boolean;
+  headers: Headers;
+  organizationSlug: string;
+  projectSlug: string;
+}) {
+  const response = await app.request(
+    `http://example.com/api/organizations/${input.organizationSlug}/projects/${input.projectSlug}/${input.archived ? 'archive' : 'restore'}`,
     {
       headers: input.headers,
       method: 'PATCH',
@@ -1576,6 +1617,305 @@ describe('Project Checklists API', () => {
                 ],
                 status: 'unchecked',
               },
+            },
+          ],
+        },
+      },
+      status: 200,
+    });
+  });
+
+  it('catches up restored active-work containers without duplicating verification records', async () => {
+    const owner = await createSignedInOwner('project-checklist-restore-catch-up');
+    const staleControl = await createActiveControl({
+      controlCode: 'AUTH-853',
+      organizationId: owner.organization.id,
+      title: 'Require MFA before restore',
+    });
+    const missedControl = await createActiveControl({
+      controlCode: 'LOG-853',
+      organizationId: owner.organization.id,
+      title: 'Require logging before restore',
+    });
+    const templateId = await createTemplate({
+      controlIds: [staleControl.controlId],
+      organizationId: owner.organization.id,
+    });
+    const projectArchivedProjectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'restore-project-risk',
+    });
+    const componentArchivedProjectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'restore-component-risk',
+    });
+    const checklistArchivedProjectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'restore-checklist-risk',
+    });
+    const projectArchivedComponentId = await createComponent(
+      projectArchivedProjectId,
+      'Project Archived Component',
+    );
+    const componentArchivedComponentId = await createComponent(
+      componentArchivedProjectId,
+      'Component Archived Component',
+    );
+    const checklistArchivedComponentId = await createComponent(
+      checklistArchivedProjectId,
+      'Checklist Archived Component',
+    );
+    const projectArchivedApplyResponse = await applyTemplate({
+      body: { templateId },
+      componentId: projectArchivedComponentId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'restore-project-risk',
+    });
+    const componentArchivedApplyResponse = await applyTemplate({
+      body: { templateId },
+      componentId: componentArchivedComponentId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'restore-component-risk',
+    });
+    const checklistArchivedApplyResponse = await applyTemplate({
+      body: { templateId },
+      componentId: checklistArchivedComponentId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'restore-checklist-risk',
+    });
+    const projectArchivedChecklist = projectArchivedApplyResponse.body.projectChecklist as {
+      id: string;
+      items: [{ id: string; verificationRecord: { id: string } }];
+    };
+    const componentArchivedChecklist = componentArchivedApplyResponse.body.projectChecklist as {
+      id: string;
+      items: [{ id: string; verificationRecord: { id: string } }];
+    };
+    const checklistArchivedChecklist = checklistArchivedApplyResponse.body.projectChecklist as {
+      id: string;
+      items: [{ id: string; verificationRecord: { id: string } }];
+    };
+    const originalRecordIds = [
+      projectArchivedChecklist.items[0].verificationRecord.id,
+      componentArchivedChecklist.items[0].verificationRecord.id,
+      checklistArchivedChecklist.items[0].verificationRecord.id,
+    ];
+
+    await updateChecklistItemVerification({
+      body: { status: 'checked' },
+      checklistId: projectArchivedChecklist.id,
+      componentId: projectArchivedComponentId,
+      headers: owner.headers,
+      itemId: projectArchivedChecklist.items[0].id,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'restore-project-risk',
+    });
+    await expect(
+      setProjectArchived({
+        archived: true,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'restore-project-risk',
+      }),
+    ).resolves.toMatchObject({ status: 200 });
+    await expect(
+      setComponentArchived({
+        archived: true,
+        componentId: componentArchivedComponentId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'restore-component-risk',
+      }),
+    ).resolves.toMatchObject({ status: 200 });
+    await expect(
+      setChecklistArchived({
+        archived: true,
+        checklistId: checklistArchivedChecklist.id,
+        componentId: checklistArchivedComponentId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'restore-checklist-risk',
+      }),
+    ).resolves.toMatchObject({ status: 200 });
+
+    await expect(
+      addChecklistTemplateItem({
+        controlId: missedControl.controlId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        templateId,
+      }),
+    ).resolves.toMatchObject({ status: 201 });
+
+    const proposedResponse = await createControlProposedUpdate({
+      body: {
+        acceptedEvidenceTypes: ['document'],
+        applicabilityConditions: 'Applies after restore.',
+        businessMeaning: 'Restored work must use current assurance requirements.',
+        controlCode: 'AUTH-853',
+        externalStandardsMappings: [],
+        releaseImpact: 'blocking',
+        title: 'Require MFA after restore',
+        verificationMethod: 'Review restored evidence.',
+      },
+      controlId: staleControl.controlId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+    });
+    const proposedUpdate = proposedResponse.body.proposedUpdate as { id: string };
+    const publishResponse = await publishControlProposedUpdate({
+      controlId: staleControl.controlId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      proposedUpdateId: proposedUpdate.id,
+    });
+    const publishedControl = publishResponse.body.control as {
+      currentVersion: { id: string; versionNumber: number };
+    };
+
+    expect(publishResponse.status).toBe(201);
+
+    const inactiveItems = await db
+      .select()
+      .from(projectChecklistItems)
+      .where(
+        inArray(projectChecklistItems.projectChecklistId, [
+          projectArchivedChecklist.id,
+          componentArchivedChecklist.id,
+          checklistArchivedChecklist.id,
+        ]),
+      );
+
+    expect(inactiveItems).toHaveLength(3);
+    expect(inactiveItems.map(({ controlVersionId }) => controlVersionId)).toEqual([
+      staleControl.versionId,
+      staleControl.versionId,
+      staleControl.versionId,
+    ]);
+
+    await expect(
+      setProjectArchived({
+        archived: false,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'restore-project-risk',
+      }),
+    ).resolves.toMatchObject({ status: 200 });
+    await expect(
+      setComponentArchived({
+        archived: false,
+        componentId: componentArchivedComponentId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'restore-component-risk',
+      }),
+    ).resolves.toMatchObject({ status: 200 });
+    await expect(
+      setChecklistArchived({
+        archived: false,
+        checklistId: checklistArchivedChecklist.id,
+        componentId: checklistArchivedComponentId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'restore-checklist-risk',
+      }),
+    ).resolves.toMatchObject({ status: 200 });
+
+    await setProjectArchived({
+      archived: false,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'restore-project-risk',
+    });
+    await setComponentArchived({
+      archived: false,
+      componentId: componentArchivedComponentId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'restore-component-risk',
+    });
+    await setChecklistArchived({
+      archived: false,
+      checklistId: checklistArchivedChecklist.id,
+      componentId: checklistArchivedComponentId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'restore-checklist-risk',
+    });
+
+    const restoredItems = await db
+      .select()
+      .from(projectChecklistItems)
+      .where(
+        inArray(projectChecklistItems.projectChecklistId, [
+          projectArchivedChecklist.id,
+          componentArchivedChecklist.id,
+          checklistArchivedChecklist.id,
+        ]),
+      );
+    const restoredRecords = await db
+      .select()
+      .from(projectChecklistVerificationRecords)
+      .where(
+        inArray(
+          projectChecklistVerificationRecords.id,
+          restoredItems.map(({ verificationRecordId }) => verificationRecordId),
+        ),
+      );
+    const preservedRecords = await db
+      .select()
+      .from(projectChecklistVerificationRecords)
+      .where(inArray(projectChecklistVerificationRecords.id, originalRecordIds));
+
+    expect(restoredItems).toHaveLength(6);
+    expect(restoredRecords).toHaveLength(6);
+    expect(preservedRecords).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          controlVersionId: staleControl.versionId,
+          id: originalRecordIds[0],
+          status: 'checked',
+        }),
+      ]),
+    );
+    expect(restoredItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ controlVersionId: publishedControl.currentVersion.id }),
+        expect.objectContaining({ controlVersionId: missedControl.versionId }),
+      ]),
+    );
+
+    await expect(
+      openChecklist({
+        checklistId: projectArchivedChecklist.id,
+        componentId: projectArchivedComponentId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'restore-project-risk',
+      }),
+    ).resolves.toMatchObject({
+      body: {
+        projectChecklist: {
+          completion: { completedItems: 0, totalItems: 2 },
+          items: [
+            {
+              control: { controlCode: 'AUTH-853' },
+              controlVersion: { id: publishedControl.currentVersion.id, versionNumber: 2 },
+              verificationRecord: {
+                history: [{ controlVersion: { id: staleControl.versionId }, status: 'checked' }],
+                status: 'unchecked',
+              },
+            },
+            {
+              control: { controlCode: 'LOG-853' },
+              controlVersion: { id: missedControl.versionId, versionNumber: 1 },
+              verificationRecord: { status: 'unchecked' },
             },
           ],
         },


### PR DESCRIPTION
## Summary
- Add restore-time catch-up for active Project Checklists under restored Projects, Project Components, and Project Checklists.
- Reconcile missed active template items and current Control Versions without duplicating existing verification records.
- Preserve old verification records/history while restored work gets new unchecked records for current requirements.

## Tests
- pnpm format:check
- pnpm lint
- pnpm check-types
- pnpm test
- pnpm build

Closes #53