### PR TITLE
Report outdated Control Versions

### DIFF
--- a/apps/backend-hono/src/index.ts
+++ b/apps/backend-hono/src/index.ts
@@ -86,6 +86,7 @@ import {
   applyChecklistTemplateToProjectComponent,
   canApplyProjectChecklists,
   getProjectChecklistForMembership,
+  listOutdatedControlVersionsForMembership,
   listUncheckedCurrentRequirementsForMembership,
   normalizeApplyChecklistTemplateBody,
   normalizeChecklistItemVerificationBody,
@@ -276,6 +277,41 @@ app.get(
     });
   },
 );
+
+app.get('/api/organizations/:organizationSlug/reports/outdated-control-versions', async (c) => {
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  });
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const membership = await getOrganizationMembership(
+    c.req.param('organizationSlug'),
+    session.user.id,
+  );
+
+  if (!membership) {
+    return c.json({ error: 'Organization not found' }, 404);
+  }
+
+  const includeArchived = c.req.query('includeArchived') === 'true';
+
+  if (includeArchived && !canManageProjects(membership.role)) {
+    return c.json(
+      { error: 'Archived work history is restricted to Organization owners and admins.' },
+      403,
+    );
+  }
+
+  return c.json({
+    outdatedControlVersions: await listOutdatedControlVersionsForMembership({
+      includeArchived,
+      membership,
+    }),
+  });
+});
 
 app.get('/api/organizations/:organizationSlug/checklist-templates', async (c) => {
   const session = await auth.api.getSession({

--- a/apps/backend-hono/src/lib/project-checklists.ts
+++ b/apps/backend-hono/src/lib/project-checklists.ts
@@ -111,6 +111,46 @@ export type UncheckedCurrentRequirementReportItem = {
   };
 };
 
+export type OutdatedControlVersionReportItem = {
+  control: {
+    controlCode: string;
+    id: string;
+    releaseImpact: string;
+    title: string;
+  };
+  latestControlVersion: {
+    id: string;
+    versionNumber: number;
+  };
+  pinnedControlVersion: {
+    id: string;
+    versionNumber: number;
+  };
+  project: {
+    archivedAt: string | null;
+    id: string;
+    name: string;
+    slug: string;
+  };
+  projectChecklist: {
+    archivedAt: string | null;
+    displayName: string;
+    id: string;
+  };
+  projectChecklistItem: {
+    id: string;
+  };
+  projectComponent: {
+    archivedAt: string | null;
+    id: string;
+    name: string;
+  };
+  verificationRecord: {
+    id: string;
+    status: string;
+  };
+};
+
 type ApplyChecklistTemplateInput = {
   displayName: string | null;
   templateId: string;
@@ -777,6 +817,135 @@ export async function listUncheckedCurrentRequirementsForMembership(
       status: row.verificationStatus,
     },
   }));
+}
+
+export async function listOutdatedControlVersionsForMembership(input: {
+  includeArchived: boolean;
+  membership: OrganizationMembership;
+}): Promise<OutdatedControlVersionReportItem[]> {
+  const rows = await db
+    .select({
+      componentArchivedAt: projectComponents.archivedAt,
+      componentId: projectComponents.id,
+      componentName: projectComponents.name,
+      controlCode: controlVersions.controlCode,
+      controlId: projectChecklistItems.controlId,
+      displayOrder: projectChecklistItems.displayOrder,
+      itemId: projectChecklistItems.id,
+      latestControlVersionId: controls.currentVersionId,
+      pinnedControlVersionId: projectChecklistItems.controlVersionId,
+      pinnedVersionNumber: controlVersions.versionNumber,
+      projectArchivedAt: projects.archivedAt,
+      projectChecklistArchivedAt: projectChecklists.archivedAt,
+      projectChecklistDisplayName: projectChecklists.displayName,
+      projectChecklistId: projectChecklists.id,
+      projectId: projects.id,
+      projectName: projects.name,
+      projectSlug: projects.slug,
+      releaseImpact: controlVersions.releaseImpact,
+      title: controlVersions.title,
+      verificationRecordId: projectChecklistVerificationRecords.id,
+      verificationStatus: projectChecklistVerificationRecords.status,
+    })
+    .from(projectChecklistItems)
+    .innerJoin(
+      projectChecklists,
+      eq(projectChecklistItems.projectChecklistId, projectChecklists.id),
+    )
+    .innerJoin(projectComponents, eq(projectChecklists.componentId, projectComponents.id))
+    .innerJoin(projects, eq(projectComponents.projectId, projects.id))
+    .innerJoin(controls, eq(projectChecklistItems.controlId, controls.id))
+    .innerJoin(controlVersions, eq(projectChecklistItems.controlVersionId, controlVersions.id))
+    .innerJoin(
+      projectChecklistVerificationRecords,
+      eq(projectChecklistItems.verificationRecordId, projectChecklistVerificationRecords.id),
+    )
+    .where(
+      and(
+        eq(projects.organizationId, input.membership.organizationId),
+        input.includeArchived ? undefined : isNull(projects.archivedAt),
+        input.includeArchived ? undefined : isNull(projectComponents.archivedAt),
+        input.includeArchived ? undefined : isNull(projectChecklists.archivedAt),
+        isNull(projectChecklistItems.removedFromTemplateAt),
+        isNull(controls.archivedAt),
+        ne(projectChecklistItems.controlVersionId, controls.currentVersionId),
+      ),
+    )
+    .orderBy(
+      asc(projects.name),
+      asc(projectComponents.name),
+      asc(projectChecklists.displayName),
+      asc(projectChecklistItems.displayOrder),
+      asc(controlVersions.controlCode),
+    );
+
+  const latestControlVersionIds = rows
+    .map(({ latestControlVersionId }) => latestControlVersionId)
+    .filter((latestControlVersionId): latestControlVersionId is string => !!latestControlVersionId);
+  const latestVersions = latestControlVersionIds.length
+    ? await db
+        .select({
+          id: controlVersions.id,
+          versionNumber: controlVersions.versionNumber,
+        })
+        .from(controlVersions)
+        .where(inArray(controlVersions.id, latestControlVersionIds))
+    : [];
+  const latestVersionById = new Map(latestVersions.map((version) => [version.id, version]));
+
+  return rows.flatMap((row) => {
+    if (!row.latestControlVersionId) {
+      return [];
+    }
+
+    const latestControlVersion = latestVersionById.get(row.latestControlVersionId);
+
+    if (!latestControlVersion) {
+      return [];
+    }
+
+    return [
+      {
+        control: {
+          controlCode: row.controlCode,
+          id: row.controlId,
+          releaseImpact: row.releaseImpact,
+          title: row.title,
+        },
+        latestControlVersion: {
+          id: latestControlVersion.id,
+          versionNumber: latestControlVersion.versionNumber,
+        },
+        pinnedControlVersion: {
+          id: row.pinnedControlVersionId,
+          versionNumber: row.pinnedVersionNumber,
+        },
+        project: {
+          archivedAt: row.projectArchivedAt?.toISOString() ?? null,
+          id: row.projectId,
+          name: row.projectName,
+          slug: row.projectSlug,
+        },
+        projectChecklist: {
+          archivedAt: row.projectChecklistArchivedAt?.toISOString() ?? null,
+          displayName: row.projectChecklistDisplayName,
+          id: row.projectChecklistId,
+        },
+        projectChecklistItem: {
+          id: row.itemId,
+        },
+        projectComponent: {
+          archivedAt: row.componentArchivedAt?.toISOString() ?? null,
+          id: row.componentId,
+          name: row.componentName,
+        },
+        verificationRecord: {
+          id: row.verificationRecordId,
+          status: row.verificationStatus,
+        },
+      },
+    ];
+  });
 }
 
 function isCompleteVerificationStatus(status: string): boolean {

--- a/apps/backend-hono/test/project-checklists.spec.ts
+++ b/apps/backend-hono/test/project-checklists.spec.ts
@@ -478,6 +478,23 @@ async function getUncheckedCurrentRequirementsReport(input: {
   };
 }
 
+async function getOutdatedControlVersionsReport(input: {
+  headers?: Headers;
+  includeArchived?: boolean;
+  organizationSlug: string;
+}) {
+  const query = input.includeArchived ? '?includeArchived=true' : '';
+  const response = await app.request(
+    `http://example.com/api/organizations/${input.organizationSlug}/reports/outdated-control-versions${query}`,
+    input.headers ? { headers: input.headers } : undefined,
+  );
+
+  return {
+    body: (await response.json()) as Record<string, unknown>,
+    status: response.status,
+  };
+}
+
 async function setComponentArchived(input: {
   archived: boolean;
   componentId: string;
@@ -755,6 +772,243 @@ describe('Project Checklists API', () => {
           projectChecklistItem: { id: itemByControlId.get(updatedControl.controlId)!.id },
           uncheckedReason: 'new-control-version',
           verificationRecord: expect.objectContaining({ status: 'unchecked' }),
+        }),
+      ]),
+    );
+  });
+
+  it('reports outdated Control Versions with active-work defaults and archived-work access control', async () => {
+    const owner = await createSignedInOwner('outdated-report-owner');
+    const admin = await addMemberToOrganization(
+      owner.organization.id,
+      'outdated-report-admin',
+      'admin',
+    );
+    const member = await addMemberToOrganization(owner.organization.id, 'outdated-report-member');
+    const outsider = await createSignedInOwner('outdated-report-outsider');
+    const projectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'outdated-active-work',
+    });
+    const componentId = await createComponent(projectId, 'Active Outdated Component');
+    const outdatedControl = await createActiveControl({
+      controlCode: 'AUTH-054',
+      organizationId: owner.organization.id,
+      title: 'Require access review',
+    });
+    const neverVerifiedControl = await createActiveControl({
+      controlCode: 'LOG-054',
+      organizationId: owner.organization.id,
+      title: 'Require log review',
+    });
+    const refreshedControl = await createActiveControl({
+      controlCode: 'SEC-054',
+      organizationId: owner.organization.id,
+      title: 'Require security review',
+    });
+    const templateId = await createTemplate({
+      controlIds: [
+        outdatedControl.controlId,
+        neverVerifiedControl.controlId,
+        refreshedControl.controlId,
+      ],
+      organizationId: owner.organization.id,
+    });
+    const activeChecklist = (
+      await applyTemplate({
+        body: { templateId },
+        componentId,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: 'outdated-active-work',
+      })
+    ).body.projectChecklist as {
+      id: string;
+      items: Array<{ control: { id: string }; id: string }>;
+    };
+    const activeItemByControlId = new Map(
+      activeChecklist.items.map((item) => [item.control.id, item]),
+    );
+
+    await updateChecklistItemVerification({
+      body: { status: 'checked' },
+      checklistId: activeChecklist.id,
+      componentId,
+      headers: owner.headers,
+      itemId: activeItemByControlId.get(outdatedControl.controlId)!.id,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'outdated-active-work',
+    });
+    await updateChecklistItemVerification({
+      body: { status: 'checked' },
+      checklistId: activeChecklist.id,
+      componentId,
+      headers: owner.headers,
+      itemId: activeItemByControlId.get(refreshedControl.controlId)!.id,
+      organizationSlug: owner.organization.slug,
+      projectSlug: 'outdated-active-work',
+    });
+
+    const archivedProjectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'outdated-archived-project',
+    });
+    const archivedProjectComponentId = await createComponent(
+      archivedProjectId,
+      'Outdated Archived Project Component',
+    );
+    const archivedComponentProjectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'outdated-archived-component',
+    });
+    const archivedComponentId = await createComponent(
+      archivedComponentProjectId,
+      'Outdated Archived Component',
+    );
+    const archivedChecklistProjectId = await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'outdated-archived-checklist',
+    });
+    const archivedChecklistComponentId = await createComponent(
+      archivedChecklistProjectId,
+      'Outdated Archived Checklist Component',
+    );
+
+    for (const [slug, archivedComponent] of [
+      ['outdated-archived-project', archivedProjectComponentId],
+      ['outdated-archived-component', archivedComponentId],
+      ['outdated-archived-checklist', archivedChecklistComponentId],
+    ] as const) {
+      await applyTemplate({
+        body: { templateId },
+        componentId: archivedComponent,
+        headers: owner.headers,
+        organizationSlug: owner.organization.slug,
+        projectSlug: slug,
+      });
+    }
+
+    const proposedResponse = await createControlProposedUpdate({
+      body: {
+        acceptedEvidenceTypes: ['document'],
+        applicabilityConditions: 'Applies to active Project Checklist Items.',
+        businessMeaning: 'Updated security review requires fresh verification.',
+        controlCode: 'SEC-054',
+        externalStandardsMappings: [],
+        releaseImpact: 'blocking',
+        title: 'Require refreshed security review',
+        verificationMethod: 'Review updated security evidence.',
+      },
+      controlId: refreshedControl.controlId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+    });
+    await publishControlProposedUpdate({
+      controlId: refreshedControl.controlId,
+      headers: owner.headers,
+      organizationSlug: owner.organization.slug,
+      proposedUpdateId: (proposedResponse.body.proposedUpdate as { id: string }).id,
+    });
+    const latestOutdatedVersionId = await addLatestControlVersion(
+      outdatedControl.controlId,
+      'AUTH-054',
+      'Require refreshed access review',
+    );
+
+    await db
+      .update(projects)
+      .set({ archivedAt: new Date() })
+      .where(eq(projects.id, archivedProjectId));
+    await db
+      .update(projectComponents)
+      .set({ archivedAt: new Date() })
+      .where(eq(projectComponents.id, archivedComponentId));
+    await db
+      .update(projectChecklists)
+      .set({ archivedAt: new Date() })
+      .where(eq(projectChecklists.componentId, archivedChecklistComponentId));
+
+    await expect(
+      getOutdatedControlVersionsReport({ organizationSlug: owner.organization.slug }),
+    ).resolves.toMatchObject({ body: { error: 'Unauthorized' }, status: 401 });
+    await expect(
+      getOutdatedControlVersionsReport({
+        headers: outsider.headers,
+        organizationSlug: owner.organization.slug,
+      }),
+    ).resolves.toMatchObject({ body: { error: 'Organization not found' }, status: 404 });
+    await expect(
+      getOutdatedControlVersionsReport({
+        headers: member.headers,
+        includeArchived: true,
+        organizationSlug: owner.organization.slug,
+      }),
+    ).resolves.toMatchObject({ status: 403 });
+
+    const activeReportResponse = await getOutdatedControlVersionsReport({
+      headers: member.headers,
+      organizationSlug: owner.organization.slug,
+    });
+    const activeOutdatedItems = activeReportResponse.body.outdatedControlVersions as Array<{
+      control: { controlCode: string };
+      latestControlVersion: { id: string; versionNumber: number };
+      pinnedControlVersion: { id: string; versionNumber: number };
+      project: { archivedAt: string | null; slug: string };
+      projectChecklist: { archivedAt: string | null; displayName: string };
+      projectChecklistItem: { id: string };
+      projectComponent: { archivedAt: string | null; name: string };
+      verificationRecord: { status: string };
+    }>;
+
+    expect(activeReportResponse.status).toBe(200);
+    expect(activeOutdatedItems).toEqual([
+      expect.objectContaining({
+        control: expect.objectContaining({ controlCode: 'AUTH-054' }),
+        latestControlVersion: { id: latestOutdatedVersionId, versionNumber: 2 },
+        pinnedControlVersion: {
+          id: outdatedControl.versionId,
+          versionNumber: 1,
+        },
+        project: expect.objectContaining({ archivedAt: null, slug: 'outdated-active-work' }),
+        projectChecklist: expect.objectContaining({ archivedAt: null }),
+        projectChecklistItem: { id: activeItemByControlId.get(outdatedControl.controlId)!.id },
+        projectComponent: expect.objectContaining({
+          archivedAt: null,
+          name: 'Active Outdated Component',
+        }),
+        verificationRecord: expect.objectContaining({ status: 'checked' }),
+      }),
+    ]);
+    expect(activeOutdatedItems.map((item) => item.control.controlCode)).not.toContain('LOG-054');
+    expect(activeOutdatedItems.map((item) => item.control.controlCode)).not.toContain('SEC-054');
+
+    const archivedReportResponse = await getOutdatedControlVersionsReport({
+      headers: admin.headers,
+      includeArchived: true,
+      organizationSlug: owner.organization.slug,
+    });
+    const archivedOutdatedItems = archivedReportResponse.body.outdatedControlVersions as Array<{
+      project: { archivedAt: string | null; slug: string };
+      projectChecklist: { archivedAt: string | null };
+      projectComponent: { archivedAt: string | null };
+    }>;
+
+    expect(archivedReportResponse.status).toBe(200);
+    expect(archivedOutdatedItems).toHaveLength(4);
+    expect(archivedOutdatedItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          project: expect.objectContaining({ archivedAt: expect.any(String) }),
+        }),
+        expect.objectContaining({
+          projectComponent: expect.objectContaining({ archivedAt: expect.any(String) }),
+        }),
+        expect.objectContaining({
+          projectChecklist: expect.objectContaining({ archivedAt: expect.any(String) }),
         }),
       ]),
     );


### PR DESCRIPTION
## Summary
- Add an Organization report endpoint for outdated Control Versions, returning Project, Project Component, Project Checklist, Control, pinned Control Version, latest Control Version, and verification status.
- Keep active-work defaults excluding archived Projects, Project Components, and Project Checklists.
- Restrict `includeArchived=true` archived-work history to Organization owners/admins.

## Tests
- `pnpm format:check`
- `pnpm lint`
- `pnpm check-types`
- `pnpm test`
- `pnpm build`

Closes #54