### PR TITLE
feat(checklists): add project checklist workflows

### DIFF
--- a/apps/backend-hono/drizzle/migrations/0008_checklists.sql
+++ b/apps/backend-hono/drizzle/migrations/0008_checklists.sql
@@ -1,0 +1,60 @@
+CREATE TABLE `checklist_templates` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`name` text NOT NULL,
+	`archived_at` integer,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `checklist_template_organization_id_idx` ON `checklist_templates` (`organization_id`);--> statement-breakpoint
+CREATE INDEX `checklist_template_archived_at_idx` ON `checklist_templates` (`archived_at`);--> statement-breakpoint
+CREATE UNIQUE INDEX `checklist_template_active_name_unique` ON `checklist_templates` (`organization_id`,`name`) WHERE `archived_at` is null;--> statement-breakpoint
+CREATE TABLE `checklist_template_controls` (
+	`id` text PRIMARY KEY NOT NULL,
+	`checklist_template_id` text NOT NULL,
+	`control_id` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`checklist_template_id`) REFERENCES `checklist_templates`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`control_id`) REFERENCES `controls`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `checklist_template_control_template_id_idx` ON `checklist_template_controls` (`checklist_template_id`);--> statement-breakpoint
+CREATE INDEX `checklist_template_control_control_id_idx` ON `checklist_template_controls` (`control_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `checklist_template_control_unique` ON `checklist_template_controls` (`checklist_template_id`,`control_id`);--> statement-breakpoint
+CREATE TABLE `project_checklists` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`source_checklist_template_id` text,
+	`name` text NOT NULL,
+	`archived_at` integer,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`source_checklist_template_id`) REFERENCES `checklist_templates`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `project_checklist_project_id_idx` ON `project_checklists` (`project_id`);--> statement-breakpoint
+CREATE INDEX `project_checklist_source_template_id_idx` ON `project_checklists` (`source_checklist_template_id`);--> statement-breakpoint
+CREATE INDEX `project_checklist_archived_at_idx` ON `project_checklists` (`archived_at`);--> statement-breakpoint
+CREATE UNIQUE INDEX `project_checklist_active_name_unique` ON `project_checklists` (`project_id`,`name`) WHERE `archived_at` is null;--> statement-breakpoint
+CREATE TABLE `checklist_items` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_checklist_id` text NOT NULL,
+	`control_id` text NOT NULL,
+	`control_version_id` text NOT NULL,
+	`checked` integer DEFAULT false NOT NULL,
+	`status` text DEFAULT 'active' NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`project_checklist_id`) REFERENCES `project_checklists`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`control_id`) REFERENCES `controls`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`control_version_id`) REFERENCES `control_versions`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `checklist_item_project_checklist_id_idx` ON `checklist_items` (`project_checklist_id`);--> statement-breakpoint
+CREATE INDEX `checklist_item_control_id_idx` ON `checklist_items` (`control_id`);--> statement-breakpoint
+CREATE INDEX `checklist_item_control_version_id_idx` ON `checklist_items` (`control_version_id`);--> statement-breakpoint
+CREATE INDEX `checklist_item_status_idx` ON `checklist_items` (`status`);--> statement-breakpoint
+CREATE UNIQUE INDEX `checklist_item_active_control_unique` ON `checklist_items` (`project_checklist_id`,`control_id`) WHERE `status` = 'active';

--- a/apps/backend-hono/drizzle/migrations/0008_checklists.sql
+++ b/apps/backend-hono/drizzle/migrations/0008_checklists.sql
@@ -39,6 +39,7 @@ CREATE INDEX `project_checklist_project_id_idx` ON `project_checklists` (`projec
 CREATE INDEX `project_checklist_source_template_id_idx` ON `project_checklists` (`source_checklist_template_id`);--> statement-breakpoint
 CREATE INDEX `project_checklist_archived_at_idx` ON `project_checklists` (`archived_at`);--> statement-breakpoint
 CREATE UNIQUE INDEX `project_checklist_active_name_unique` ON `project_checklists` (`project_id`,`name`) WHERE `archived_at` is null;--> statement-breakpoint
+CREATE UNIQUE INDEX `control_version_control_id_id_unique` ON `control_versions` (`control_id`,`id`);--> statement-breakpoint
 CREATE TABLE `checklist_items` (
 	`id` text PRIMARY KEY NOT NULL,
 	`project_checklist_id` text NOT NULL,
@@ -50,7 +51,8 @@ CREATE TABLE `checklist_items` (
 	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
 	FOREIGN KEY (`project_checklist_id`) REFERENCES `project_checklists`(`id`) ON UPDATE no action ON DELETE cascade,
 	FOREIGN KEY (`control_id`) REFERENCES `controls`(`id`) ON UPDATE no action ON DELETE cascade,
-	FOREIGN KEY (`control_version_id`) REFERENCES `control_versions`(`id`) ON UPDATE no action ON DELETE cascade
+	FOREIGN KEY (`control_version_id`) REFERENCES `control_versions`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`control_id`,`control_version_id`) REFERENCES `control_versions`(`control_id`,`id`) ON UPDATE no action ON DELETE cascade
 );
 --> statement-breakpoint
 CREATE INDEX `checklist_item_project_checklist_id_idx` ON `checklist_items` (`project_checklist_id`);--> statement-breakpoint

--- a/apps/backend-hono/src/contexts/checklists/checklists-router.ts
+++ b/apps/backend-hono/src/contexts/checklists/checklists-router.ts
@@ -1,0 +1,381 @@
+import { TRPCError } from '@trpc/server';
+import {
+  authorizeOrganizationAction,
+  OrganizationAuthorizationError,
+} from '../identity-organization/organization-authorization';
+import {
+  checklistAuthorizationActions,
+  ChecklistInputError,
+  ChecklistPermissionError,
+  addChecklistItemForMember,
+  archiveChecklistTemplateForMember,
+  archiveProjectChecklistForMember,
+  createChecklistTemplateForMember,
+  createProjectChecklistForMember,
+  enforceArchivedControlForMember,
+  listChecklistTemplatesForMember,
+  listProjectChecklistsForMember,
+  refreshChecklistItemForMember,
+  removeChecklistItemForMember,
+  renameChecklistTemplateForMember,
+  renameProjectChecklistForMember,
+  restoreChecklistTemplateForMember,
+  restoreProjectChecklistForMember,
+  setChecklistItemCheckedForMember,
+} from './checklists';
+import {
+  checklistControlInput,
+  checklistItemIdentityInput,
+  checklistTemplateIdentityInput,
+  checklistTemplateListInput,
+  createChecklistTemplateInput,
+  createProjectChecklistInput,
+  projectChecklistIdentityInput,
+  projectChecklistListInput,
+  renameChecklistTemplateInput,
+  renameProjectChecklistInput,
+  setChecklistItemCheckedInput,
+} from './checklists-schemas';
+import { protectedProcedure, router } from '../../trpc/core';
+
+function throwKnownChecklistError(caughtError: unknown): never {
+  if (caughtError instanceof OrganizationAuthorizationError) {
+    throw new TRPCError({
+      code: caughtError.reason === 'not-found' ? 'NOT_FOUND' : 'FORBIDDEN',
+      message: caughtError.message,
+    });
+  }
+
+  if (caughtError instanceof ChecklistInputError) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: caughtError.message });
+  }
+
+  if (caughtError instanceof ChecklistPermissionError) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: caughtError.message });
+  }
+
+  throw caughtError;
+}
+
+export const checklistsRouter = router({
+  createTemplate: protectedProcedure
+    .input(createChecklistTemplateInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: checklistAuthorizationActions.createTemplate,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+
+        return {
+          checklistTemplate: await createChecklistTemplateForMember(membership, input),
+        };
+      } catch (caughtError) {
+        throwKnownChecklistError(caughtError);
+      }
+    }),
+
+  listTemplates: protectedProcedure
+    .input(checklistTemplateListInput)
+    .query(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: checklistAuthorizationActions.listTemplates,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+
+        return {
+          checklistTemplates: await listChecklistTemplatesForMember(membership, input.status),
+        };
+      } catch (caughtError) {
+        throwKnownChecklistError(caughtError);
+      }
+    }),
+
+  renameTemplate: protectedProcedure
+    .input(renameChecklistTemplateInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: checklistAuthorizationActions.renameTemplate,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const checklistTemplate = await renameChecklistTemplateForMember(membership, input);
+
+        if (!checklistTemplate) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Checklist Template unavailable' });
+        }
+
+        return { checklistTemplate };
+      } catch (caughtError) {
+        throwKnownChecklistError(caughtError);
+      }
+    }),
+
+  archiveTemplate: protectedProcedure
+    .input(checklistTemplateIdentityInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: checklistAuthorizationActions.archiveTemplate,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const checklistTemplate = await archiveChecklistTemplateForMember(
+          membership,
+          input.checklistTemplateId,
+        );
+
+        if (!checklistTemplate) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Checklist Template unavailable' });
+        }
+
+        return { checklistTemplate };
+      } catch (caughtError) {
+        throwKnownChecklistError(caughtError);
+      }
+    }),
+
+  restoreTemplate: protectedProcedure
+    .input(checklistTemplateIdentityInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: checklistAuthorizationActions.restoreTemplate,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const checklistTemplate = await restoreChecklistTemplateForMember(
+          membership,
+          input.checklistTemplateId,
+        );
+
+        if (!checklistTemplate) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Checklist Template unavailable' });
+        }
+
+        return { checklistTemplate };
+      } catch (caughtError) {
+        throwKnownChecklistError(caughtError);
+      }
+    }),
+
+  createProjectChecklist: protectedProcedure
+    .input(createProjectChecklistInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: checklistAuthorizationActions.createProjectChecklist,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const projectChecklist = await createProjectChecklistForMember(membership, input);
+
+        if (!projectChecklist) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Project unavailable' });
+        }
+
+        return { projectChecklist };
+      } catch (caughtError) {
+        throwKnownChecklistError(caughtError);
+      }
+    }),
+
+  listProjectChecklists: protectedProcedure
+    .input(projectChecklistListInput)
+    .query(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: checklistAuthorizationActions.listProjectChecklists,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const projectChecklists = await listProjectChecklistsForMember(membership, input);
+
+        if (!projectChecklists) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Project unavailable' });
+        }
+
+        return { projectChecklists };
+      } catch (caughtError) {
+        throwKnownChecklistError(caughtError);
+      }
+    }),
+
+  renameProjectChecklist: protectedProcedure
+    .input(renameProjectChecklistInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: checklistAuthorizationActions.renameProjectChecklist,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const projectChecklist = await renameProjectChecklistForMember(membership, input);
+
+        if (!projectChecklist) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Project Checklist unavailable' });
+        }
+
+        return { projectChecklist };
+      } catch (caughtError) {
+        throwKnownChecklistError(caughtError);
+      }
+    }),
+
+  archiveProjectChecklist: protectedProcedure
+    .input(projectChecklistIdentityInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: checklistAuthorizationActions.archiveProjectChecklist,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const projectChecklist = await archiveProjectChecklistForMember(
+          membership,
+          input.projectChecklistId,
+        );
+
+        if (!projectChecklist) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Project Checklist unavailable' });
+        }
+
+        return { projectChecklist };
+      } catch (caughtError) {
+        throwKnownChecklistError(caughtError);
+      }
+    }),
+
+  restoreProjectChecklist: protectedProcedure
+    .input(projectChecklistIdentityInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: checklistAuthorizationActions.restoreProjectChecklist,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const projectChecklist = await restoreProjectChecklistForMember(
+          membership,
+          input.projectChecklistId,
+        );
+
+        if (!projectChecklist) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Project Checklist unavailable' });
+        }
+
+        return { projectChecklist };
+      } catch (caughtError) {
+        throwKnownChecklistError(caughtError);
+      }
+    }),
+
+  addChecklistItem: protectedProcedure
+    .input(checklistControlInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: checklistAuthorizationActions.addChecklistItem,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const projectChecklist = await addChecklistItemForMember(membership, input);
+
+        if (!projectChecklist) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Project Checklist unavailable' });
+        }
+
+        return { projectChecklist };
+      } catch (caughtError) {
+        throwKnownChecklistError(caughtError);
+      }
+    }),
+
+  enforceArchivedControl: protectedProcedure
+    .input(checklistControlInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: checklistAuthorizationActions.enforceArchivedControl,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const projectChecklist = await enforceArchivedControlForMember(membership, input);
+
+        if (!projectChecklist) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Project Checklist unavailable' });
+        }
+
+        return { projectChecklist };
+      } catch (caughtError) {
+        throwKnownChecklistError(caughtError);
+      }
+    }),
+
+  setChecklistItemChecked: protectedProcedure
+    .input(setChecklistItemCheckedInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: checklistAuthorizationActions.setChecklistItemChecked,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const projectChecklist = await setChecklistItemCheckedForMember(membership, input);
+
+        if (!projectChecklist) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Checklist Item unavailable' });
+        }
+
+        return { projectChecklist };
+      } catch (caughtError) {
+        throwKnownChecklistError(caughtError);
+      }
+    }),
+
+  refreshChecklistItem: protectedProcedure
+    .input(checklistItemIdentityInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: checklistAuthorizationActions.refreshChecklistItem,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const projectChecklist = await refreshChecklistItemForMember(membership, input);
+
+        if (!projectChecklist) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Checklist Item unavailable' });
+        }
+
+        return { projectChecklist };
+      } catch (caughtError) {
+        throwKnownChecklistError(caughtError);
+      }
+    }),
+
+  removeChecklistItem: protectedProcedure
+    .input(checklistItemIdentityInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: checklistAuthorizationActions.removeChecklistItem,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const projectChecklist = await removeChecklistItemForMember(membership, input);
+
+        if (!projectChecklist) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Checklist Item unavailable' });
+        }
+
+        return { projectChecklist };
+      } catch (caughtError) {
+        throwKnownChecklistError(caughtError);
+      }
+    }),
+});

--- a/apps/backend-hono/src/contexts/checklists/checklists-schemas.ts
+++ b/apps/backend-hono/src/contexts/checklists/checklists-schemas.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import { organizationSlugInput } from '../identity-organization/organization-schemas';
+
+export const createProjectChecklistInput = organizationSlugInput.extend({
+  checklistTemplateId: z.string().min(1).optional(),
+  controlIds: z.array(z.string().min(1)).optional(),
+  name: z.string(),
+  projectSlug: z.string().min(1),
+});
+
+export const projectChecklistListInput = organizationSlugInput.extend({
+  projectSlug: z.string().min(1),
+  status: z.enum(['active', 'archived']).default('active'),
+});
+
+export const projectChecklistIdentityInput = organizationSlugInput.extend({
+  projectChecklistId: z.string().min(1),
+});
+
+export const checklistControlInput = projectChecklistIdentityInput.extend({
+  controlId: z.string().min(1),
+});
+
+export const renameProjectChecklistInput = projectChecklistIdentityInput.extend({
+  name: z.string(),
+});
+
+export const createChecklistTemplateInput = organizationSlugInput.extend({
+  controlIds: z.array(z.string().min(1)).min(1),
+  name: z.string(),
+});
+
+export const checklistTemplateListInput = organizationSlugInput.extend({
+  status: z.enum(['active', 'archived']).default('active'),
+});
+
+export const checklistTemplateIdentityInput = organizationSlugInput.extend({
+  checklistTemplateId: z.string().min(1),
+});
+
+export const renameChecklistTemplateInput = checklistTemplateIdentityInput.extend({
+  name: z.string(),
+});
+
+export const setChecklistItemCheckedInput = organizationSlugInput.extend({
+  checked: z.boolean(),
+  checklistItemId: z.string().min(1),
+});
+
+export const checklistItemIdentityInput = organizationSlugInput.extend({
+  checklistItemId: z.string().min(1),
+});

--- a/apps/backend-hono/src/contexts/checklists/checklists.ts
+++ b/apps/backend-hono/src/contexts/checklists/checklists.ts
@@ -101,6 +101,7 @@ export async function createChecklistTemplateForMember(
   const body = normalizeCreateChecklistTemplateBody(input);
 
   validateChecklistTemplateName(body.name);
+  validateChecklistTemplateControlIds(body.controlIds);
   validateUniqueControlIds(
     body.controlIds,
     'A Control can appear only once in a Checklist Template.',
@@ -1158,6 +1159,12 @@ function validateProjectChecklistName(name: string) {
 function validateChecklistTemplateName(name: string) {
   if (!name.trim()) {
     throw new ChecklistInputError('Checklist Template name is required.');
+  }
+}
+
+function validateChecklistTemplateControlIds(controlIds: string[]) {
+  if (controlIds.length === 0) {
+    throw new ChecklistInputError('Checklist Template needs at least one selected Control.');
   }
 }
 

--- a/apps/backend-hono/src/contexts/checklists/checklists.ts
+++ b/apps/backend-hono/src/contexts/checklists/checklists.ts
@@ -1,0 +1,1170 @@
+import { and, asc, eq, inArray, isNotNull, isNull, ne } from 'drizzle-orm';
+import { db } from '../../db/client';
+import {
+  checklistItems,
+  checklistTemplateControls,
+  checklistTemplates,
+  controls,
+  controlVersions,
+  projectChecklists,
+  projects,
+} from '../../db/schema';
+import type { AuthorizedOrganizationMember } from '../../types/organization-types';
+import type { OrganizationAuthorizationPolicy } from '../identity-organization/organization-authorization';
+
+type CreateProjectChecklistInput = {
+  checklistTemplateId?: string;
+  controlIds?: string[];
+  name: string;
+  projectSlug: string;
+};
+
+type CreateChecklistTemplateInput = {
+  controlIds: string[];
+  name: string;
+};
+
+export type ChecklistArchiveStatus = 'active' | 'archived';
+
+const checklistManagerRoles = ['owner', 'admin'] as const;
+
+export const checklistAuthorizationActions = {
+  createTemplate: {
+    allowedRoles: checklistManagerRoles,
+    deniedMessage: 'Only Organization owners and admins can create Checklist Templates.',
+  },
+  createProjectChecklist: {
+    allowedRoles: checklistManagerRoles,
+    deniedMessage: 'Only Organization owners and admins can create Project Checklists.',
+  },
+  listProjectChecklists: {
+    allowedRoles: 'any-member',
+    deniedMessage: 'Only Organization members can view Project Checklists.',
+  },
+  listTemplates: {
+    allowedRoles: checklistManagerRoles,
+    deniedMessage: 'Only Organization owners and admins can view Checklist Templates.',
+  },
+  renameTemplate: {
+    allowedRoles: checklistManagerRoles,
+    deniedMessage: 'Only Organization owners and admins can rename Checklist Templates.',
+  },
+  archiveTemplate: {
+    allowedRoles: checklistManagerRoles,
+    deniedMessage: 'Only Organization owners and admins can archive Checklist Templates.',
+  },
+  restoreTemplate: {
+    allowedRoles: checklistManagerRoles,
+    deniedMessage: 'Only Organization owners and admins can restore Checklist Templates.',
+  },
+  refreshChecklistItem: {
+    allowedRoles: checklistManagerRoles,
+    deniedMessage: 'Only Organization owners and admins can refresh Checklist Items.',
+  },
+  removeChecklistItem: {
+    allowedRoles: checklistManagerRoles,
+    deniedMessage: 'Only Organization owners and admins can remove Checklist Items.',
+  },
+  addChecklistItem: {
+    allowedRoles: checklistManagerRoles,
+    deniedMessage: 'Only Organization owners and admins can add Checklist Items.',
+  },
+  enforceArchivedControl: {
+    allowedRoles: checklistManagerRoles,
+    deniedMessage: 'Only Organization owners and admins can enforce Archived Controls.',
+  },
+  renameProjectChecklist: {
+    allowedRoles: checklistManagerRoles,
+    deniedMessage: 'Only Organization owners and admins can rename Project Checklists.',
+  },
+  archiveProjectChecklist: {
+    allowedRoles: checklistManagerRoles,
+    deniedMessage: 'Only Organization owners and admins can archive Project Checklists.',
+  },
+  restoreProjectChecklist: {
+    allowedRoles: checklistManagerRoles,
+    deniedMessage: 'Only Organization owners and admins can restore Project Checklists.',
+  },
+  setChecklistItemChecked: {
+    allowedRoles: 'any-member',
+    deniedMessage: 'Only Organization members can update Checklist Items.',
+  },
+} satisfies Record<string, OrganizationAuthorizationPolicy>;
+
+export class ChecklistInputError extends Error {}
+export class ChecklistPermissionError extends Error {}
+
+export async function createChecklistTemplateForMember(
+  membership: AuthorizedOrganizationMember,
+  input: CreateChecklistTemplateInput,
+) {
+  const body = normalizeCreateChecklistTemplateBody(input);
+
+  validateChecklistTemplateName(body.name);
+  validateUniqueControlIds(
+    body.controlIds,
+    'A Control can appear only once in a Checklist Template.',
+  );
+
+  const existingTemplate = await db
+    .select({ id: checklistTemplates.id })
+    .from(checklistTemplates)
+    .where(
+      and(
+        eq(checklistTemplates.organizationId, membership.organizationId),
+        eq(checklistTemplates.name, body.name.trim()),
+        isNull(checklistTemplates.archivedAt),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existingTemplate) {
+    throw new ChecklistInputError('Checklist Template name is already used in this Organization.');
+  }
+
+  const selectedControls = await getLatestActiveControlVersions(
+    membership.organizationId,
+    body.controlIds,
+  );
+
+  if (selectedControls.length !== body.controlIds.length) {
+    throw new ChecklistInputError('Checklist Templates can use only active Controls.');
+  }
+
+  const now = new Date();
+  const checklistTemplateId = crypto.randomUUID();
+
+  await db.insert(checklistTemplates).values({
+    createdAt: now,
+    id: checklistTemplateId,
+    name: body.name.trim(),
+    organizationId: membership.organizationId,
+    updatedAt: now,
+  });
+
+  await db.insert(checklistTemplateControls).values(
+    selectedControls.map((control) => ({
+      checklistTemplateId,
+      controlId: control.controlId,
+      createdAt: now,
+      id: crypto.randomUUID(),
+    })),
+  );
+
+  const checklistTemplate = await getChecklistTemplateDetail(membership, checklistTemplateId);
+
+  if (!checklistTemplate) {
+    throw new ChecklistInputError('Checklist Template unavailable.');
+  }
+
+  return checklistTemplate;
+}
+
+export async function listChecklistTemplatesForMember(
+  membership: AuthorizedOrganizationMember,
+  status: ChecklistArchiveStatus,
+) {
+  const rows = await db
+    .select({ id: checklistTemplates.id })
+    .from(checklistTemplates)
+    .where(
+      and(
+        eq(checklistTemplates.organizationId, membership.organizationId),
+        status === 'archived'
+          ? isNotNull(checklistTemplates.archivedAt)
+          : isNull(checklistTemplates.archivedAt),
+      ),
+    )
+    .orderBy(asc(checklistTemplates.createdAt), asc(checklistTemplates.name));
+
+  const templates = await Promise.all(
+    rows.map((row) => getChecklistTemplateDetail(membership, row.id)),
+  );
+
+  return templates.filter((template) => template !== null);
+}
+
+export async function renameChecklistTemplateForMember(
+  membership: AuthorizedOrganizationMember,
+  input: { checklistTemplateId: string; name: string },
+) {
+  validateChecklistTemplateName(input.name);
+
+  const template = await getChecklistTemplateForManagement(membership, input.checklistTemplateId);
+
+  if (!template) {
+    return null;
+  }
+
+  if (template.archivedAt) {
+    throw new ChecklistInputError('Only active Checklist Templates can be renamed.');
+  }
+
+  await ensureChecklistTemplateNameAvailable({
+    excludeChecklistTemplateId: template.id,
+    name: input.name,
+    organizationId: membership.organizationId,
+  });
+
+  await db
+    .update(checklistTemplates)
+    .set({ name: input.name.trim(), updatedAt: new Date() })
+    .where(eq(checklistTemplates.id, template.id));
+
+  return getChecklistTemplateDetail(membership, template.id);
+}
+
+export async function archiveChecklistTemplateForMember(
+  membership: AuthorizedOrganizationMember,
+  checklistTemplateId: string,
+) {
+  return setChecklistTemplateArchivedForMember({
+    archived: true,
+    checklistTemplateId,
+    membership,
+  });
+}
+
+export async function restoreChecklistTemplateForMember(
+  membership: AuthorizedOrganizationMember,
+  checklistTemplateId: string,
+) {
+  return setChecklistTemplateArchivedForMember({
+    archived: false,
+    checklistTemplateId,
+    membership,
+  });
+}
+
+export async function createProjectChecklistForMember(
+  membership: AuthorizedOrganizationMember,
+  input: CreateProjectChecklistInput,
+) {
+  const body = normalizeCreateProjectChecklistBody(input);
+
+  validateProjectChecklistName(body.name);
+
+  const controlSource = await resolveProjectChecklistControlSource(membership, body);
+  const uniqueControlIds = Array.from(new Set(controlSource.controlIds));
+
+  validateUniqueControlIds(
+    controlSource.controlIds,
+    'A Control can appear only once in a Project Checklist.',
+  );
+
+  const project = await db
+    .select({
+      id: projects.id,
+      slug: projects.slug,
+    })
+    .from(projects)
+    .where(
+      and(
+        eq(projects.organizationId, membership.organizationId),
+        eq(projects.slug, body.projectSlug),
+        isNull(projects.archivedAt),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!project) {
+    return null;
+  }
+
+  const existingChecklist = await db
+    .select({ id: projectChecklists.id })
+    .from(projectChecklists)
+    .where(
+      and(
+        eq(projectChecklists.projectId, project.id),
+        eq(projectChecklists.name, body.name.trim()),
+        isNull(projectChecklists.archivedAt),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existingChecklist) {
+    throw new ChecklistInputError('Project Checklist name is already used on this Project.');
+  }
+
+  const selectedControls = await getLatestActiveControlVersions(
+    membership.organizationId,
+    uniqueControlIds,
+  );
+
+  if (selectedControls.length !== uniqueControlIds.length) {
+    throw new ChecklistInputError('Project Checklists can use only active Controls.');
+  }
+
+  const now = new Date();
+  const projectChecklistId = crypto.randomUUID();
+
+  await db.insert(projectChecklists).values({
+    createdAt: now,
+    id: projectChecklistId,
+    name: body.name.trim(),
+    projectId: project.id,
+    sourceChecklistTemplateId: controlSource.checklistTemplateId,
+    updatedAt: now,
+  });
+
+  await db.insert(checklistItems).values(
+    selectedControls.map((control) => ({
+      checked: false,
+      controlId: control.controlId,
+      controlVersionId: control.controlVersionId,
+      createdAt: now,
+      id: crypto.randomUUID(),
+      projectChecklistId,
+      status: 'active',
+      updatedAt: now,
+    })),
+  );
+
+  return getProjectChecklistDetail({
+    membership,
+    projectChecklistId,
+    projectSlug: project.slug,
+  });
+}
+
+export async function listProjectChecklistsForMember(
+  membership: AuthorizedOrganizationMember,
+  input: { projectSlug: string; status: ChecklistArchiveStatus },
+) {
+  const project = await getProjectForChecklistAction(membership, input.projectSlug, {
+    allowArchivedProject: true,
+  });
+
+  if (!project) {
+    return null;
+  }
+
+  const rows = await db
+    .select({ id: projectChecklists.id })
+    .from(projectChecklists)
+    .where(
+      and(
+        eq(projectChecklists.projectId, project.id),
+        input.status === 'archived'
+          ? isNotNull(projectChecklists.archivedAt)
+          : isNull(projectChecklists.archivedAt),
+      ),
+    )
+    .orderBy(asc(projectChecklists.createdAt), asc(projectChecklists.name));
+
+  return Promise.all(
+    rows.map((row) =>
+      getProjectChecklistDetail({
+        membership,
+        projectChecklistId: row.id,
+        projectSlug: project.slug,
+      }),
+    ),
+  );
+}
+
+export async function renameProjectChecklistForMember(
+  membership: AuthorizedOrganizationMember,
+  input: { name: string; projectChecklistId: string },
+) {
+  validateProjectChecklistName(input.name);
+
+  const projectChecklist = await getProjectChecklistForManagement(
+    membership,
+    input.projectChecklistId,
+  );
+
+  if (!projectChecklist) {
+    return null;
+  }
+
+  if (projectChecklist.projectArchivedAt || projectChecklist.archivedAt) {
+    throw new ChecklistInputError('Only active Project Checklists can be renamed.');
+  }
+
+  await ensureProjectChecklistNameAvailable({
+    excludeProjectChecklistId: projectChecklist.id,
+    name: input.name,
+    projectId: projectChecklist.projectId,
+  });
+
+  await db
+    .update(projectChecklists)
+    .set({ name: input.name.trim(), updatedAt: new Date() })
+    .where(eq(projectChecklists.id, projectChecklist.id));
+
+  return getProjectChecklistDetail({
+    membership,
+    projectChecklistId: projectChecklist.id,
+    projectSlug: projectChecklist.projectSlug,
+  });
+}
+
+export async function archiveProjectChecklistForMember(
+  membership: AuthorizedOrganizationMember,
+  projectChecklistId: string,
+) {
+  return setProjectChecklistArchivedForMember({
+    archived: true,
+    membership,
+    projectChecklistId,
+  });
+}
+
+export async function restoreProjectChecklistForMember(
+  membership: AuthorizedOrganizationMember,
+  projectChecklistId: string,
+) {
+  return setProjectChecklistArchivedForMember({
+    archived: false,
+    membership,
+    projectChecklistId,
+  });
+}
+
+async function getChecklistTemplateDetail(
+  membership: AuthorizedOrganizationMember,
+  checklistTemplateId: string,
+) {
+  const template = await db
+    .select({
+      archivedAt: checklistTemplates.archivedAt,
+      createdAt: checklistTemplates.createdAt,
+      id: checklistTemplates.id,
+      name: checklistTemplates.name,
+    })
+    .from(checklistTemplates)
+    .where(
+      and(
+        eq(checklistTemplates.id, checklistTemplateId),
+        eq(checklistTemplates.organizationId, membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!template) {
+    return null;
+  }
+
+  const templateControls = await db
+    .select({
+      controlCode: controlVersions.controlCode,
+      controlId: controls.id,
+      controlTitle: controlVersions.title,
+      currentVersionId: controlVersions.id,
+      currentVersionNumber: controlVersions.versionNumber,
+    })
+    .from(checklistTemplateControls)
+    .innerJoin(controls, eq(checklistTemplateControls.controlId, controls.id))
+    .innerJoin(controlVersions, eq(controls.currentVersionId, controlVersions.id))
+    .where(eq(checklistTemplateControls.checklistTemplateId, template.id))
+    .orderBy(asc(checklistTemplateControls.createdAt), asc(controlVersions.controlCode));
+
+  return {
+    archivedAt: template.archivedAt?.toISOString() ?? null,
+    controls: templateControls,
+    createdAt: template.createdAt.toISOString(),
+    id: template.id,
+    name: template.name,
+    status: template.archivedAt ? ('archived' as const) : ('active' as const),
+  };
+}
+
+async function getChecklistTemplateForManagement(
+  membership: AuthorizedOrganizationMember,
+  checklistTemplateId: string,
+) {
+  return db
+    .select({
+      archivedAt: checklistTemplates.archivedAt,
+      id: checklistTemplates.id,
+      name: checklistTemplates.name,
+    })
+    .from(checklistTemplates)
+    .where(
+      and(
+        eq(checklistTemplates.id, checklistTemplateId),
+        eq(checklistTemplates.organizationId, membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+}
+
+async function ensureChecklistTemplateNameAvailable(input: {
+  excludeChecklistTemplateId?: string;
+  name: string;
+  organizationId: string;
+}) {
+  const existingTemplate = await db
+    .select({ id: checklistTemplates.id })
+    .from(checklistTemplates)
+    .where(
+      and(
+        eq(checklistTemplates.organizationId, input.organizationId),
+        eq(checklistTemplates.name, input.name.trim()),
+        isNull(checklistTemplates.archivedAt),
+        input.excludeChecklistTemplateId
+          ? ne(checklistTemplates.id, input.excludeChecklistTemplateId)
+          : undefined,
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existingTemplate) {
+    throw new ChecklistInputError('Checklist Template name is already used in this Organization.');
+  }
+}
+
+async function setChecklistTemplateArchivedForMember(input: {
+  archived: boolean;
+  checklistTemplateId: string;
+  membership: AuthorizedOrganizationMember;
+}) {
+  const template = await getChecklistTemplateForManagement(
+    input.membership,
+    input.checklistTemplateId,
+  );
+
+  if (!template) {
+    return null;
+  }
+
+  if (!input.archived) {
+    await ensureChecklistTemplateNameAvailable({
+      excludeChecklistTemplateId: template.id,
+      name: template.name,
+      organizationId: input.membership.organizationId,
+    });
+  }
+
+  await db
+    .update(checklistTemplates)
+    .set({
+      archivedAt: input.archived ? new Date() : null,
+      updatedAt: new Date(),
+    })
+    .where(eq(checklistTemplates.id, template.id));
+
+  return getChecklistTemplateDetail(input.membership, template.id);
+}
+
+async function getProjectForChecklistAction(
+  membership: AuthorizedOrganizationMember,
+  projectSlug: string,
+  options: { allowArchivedProject: boolean },
+) {
+  return db
+    .select({
+      archivedAt: projects.archivedAt,
+      id: projects.id,
+      slug: projects.slug,
+    })
+    .from(projects)
+    .where(
+      and(
+        eq(projects.organizationId, membership.organizationId),
+        eq(projects.slug, projectSlug),
+        options.allowArchivedProject ? undefined : isNull(projects.archivedAt),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+}
+
+async function getProjectChecklistForManagement(
+  membership: AuthorizedOrganizationMember,
+  projectChecklistId: string,
+) {
+  return db
+    .select({
+      archivedAt: projectChecklists.archivedAt,
+      id: projectChecklists.id,
+      projectArchivedAt: projects.archivedAt,
+      projectId: projects.id,
+      projectSlug: projects.slug,
+    })
+    .from(projectChecklists)
+    .innerJoin(projects, eq(projectChecklists.projectId, projects.id))
+    .where(
+      and(
+        eq(projectChecklists.id, projectChecklistId),
+        eq(projects.organizationId, membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+}
+
+async function ensureProjectChecklistNameAvailable(input: {
+  excludeProjectChecklistId?: string;
+  name: string;
+  projectId: string;
+}) {
+  const existingChecklist = await db
+    .select({ id: projectChecklists.id })
+    .from(projectChecklists)
+    .where(
+      and(
+        eq(projectChecklists.projectId, input.projectId),
+        eq(projectChecklists.name, input.name.trim()),
+        isNull(projectChecklists.archivedAt),
+        input.excludeProjectChecklistId
+          ? ne(projectChecklists.id, input.excludeProjectChecklistId)
+          : undefined,
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existingChecklist) {
+    throw new ChecklistInputError('Project Checklist name is already used on this Project.');
+  }
+}
+
+async function setProjectChecklistArchivedForMember(input: {
+  archived: boolean;
+  membership: AuthorizedOrganizationMember;
+  projectChecklistId: string;
+}) {
+  const projectChecklist = await getProjectChecklistForManagement(
+    input.membership,
+    input.projectChecklistId,
+  );
+
+  if (!projectChecklist) {
+    return null;
+  }
+
+  if (projectChecklist.projectArchivedAt) {
+    throw new ChecklistInputError('Project Checklists on Archived Projects are read-only.');
+  }
+
+  if (!input.archived) {
+    await ensureProjectChecklistNameAvailable({
+      excludeProjectChecklistId: projectChecklist.id,
+      name: await db
+        .select({ name: projectChecklists.name })
+        .from(projectChecklists)
+        .where(eq(projectChecklists.id, projectChecklist.id))
+        .limit(1)
+        .then((rows) => rows[0]?.name ?? ''),
+      projectId: projectChecklist.projectId,
+    });
+  }
+
+  await db
+    .update(projectChecklists)
+    .set({
+      archivedAt: input.archived ? new Date() : null,
+      updatedAt: new Date(),
+    })
+    .where(eq(projectChecklists.id, projectChecklist.id));
+
+  return getProjectChecklistDetail({
+    membership: input.membership,
+    projectChecklistId: projectChecklist.id,
+    projectSlug: projectChecklist.projectSlug,
+  });
+}
+
+async function resolveProjectChecklistControlSource(
+  membership: AuthorizedOrganizationMember,
+  input: Required<Pick<CreateProjectChecklistInput, 'name' | 'projectSlug'>> &
+    Pick<CreateProjectChecklistInput, 'checklistTemplateId' | 'controlIds'>,
+) {
+  if (input.checklistTemplateId && input.controlIds?.length) {
+    throw new ChecklistInputError(
+      'Create a Project Checklist from a Checklist Template or selected Controls, not both.',
+    );
+  }
+
+  if (input.checklistTemplateId) {
+    const template = await db
+      .select({ id: checklistTemplates.id })
+      .from(checklistTemplates)
+      .where(
+        and(
+          eq(checklistTemplates.id, input.checklistTemplateId),
+          eq(checklistTemplates.organizationId, membership.organizationId),
+          isNull(checklistTemplates.archivedAt),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+
+    if (!template) {
+      throw new ChecklistInputError('Checklist Template unavailable.');
+    }
+
+    const templateControls = await db
+      .select({ controlId: checklistTemplateControls.controlId })
+      .from(checklistTemplateControls)
+      .where(eq(checklistTemplateControls.checklistTemplateId, template.id));
+
+    return {
+      checklistTemplateId: template.id,
+      controlIds: templateControls.map((control) => control.controlId),
+    };
+  }
+
+  if (!input.controlIds?.length) {
+    throw new ChecklistInputError('Project Checklist needs at least one selected Control.');
+  }
+
+  return {
+    checklistTemplateId: null,
+    controlIds: input.controlIds,
+  };
+}
+
+export async function setChecklistItemCheckedForMember(
+  membership: AuthorizedOrganizationMember,
+  input: { checked: boolean; checklistItemId: string },
+) {
+  const checklistItem = await db
+    .select({
+      archivedAt: projectChecklists.archivedAt,
+      itemStatus: checklistItems.status,
+      projectArchivedAt: projects.archivedAt,
+      projectChecklistId: projectChecklists.id,
+      projectOwnerMemberId: projects.projectOwnerMemberId,
+      projectSlug: projects.slug,
+    })
+    .from(checklistItems)
+    .innerJoin(projectChecklists, eq(checklistItems.projectChecklistId, projectChecklists.id))
+    .innerJoin(projects, eq(projectChecklists.projectId, projects.id))
+    .where(
+      and(
+        eq(checklistItems.id, input.checklistItemId),
+        eq(projects.organizationId, membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!checklistItem) {
+    return null;
+  }
+
+  if (checklistItem.projectOwnerMemberId !== membership.id) {
+    throw new ChecklistPermissionError('Only the Project Owner can check Checklist Items.');
+  }
+
+  if (
+    checklistItem.projectArchivedAt ||
+    checklistItem.archivedAt ||
+    checklistItem.itemStatus !== 'active'
+  ) {
+    throw new ChecklistInputError('Only active Checklist Items can be checked or unchecked.');
+  }
+
+  await db
+    .update(checklistItems)
+    .set({
+      checked: input.checked,
+      updatedAt: new Date(),
+    })
+    .where(eq(checklistItems.id, input.checklistItemId));
+
+  return getProjectChecklistDetail({
+    membership,
+    projectChecklistId: checklistItem.projectChecklistId,
+    projectSlug: checklistItem.projectSlug,
+  });
+}
+
+export async function removeChecklistItemForMember(
+  membership: AuthorizedOrganizationMember,
+  input: { checklistItemId: string },
+) {
+  const checklistItem = await db
+    .select({
+      archivedAt: projectChecklists.archivedAt,
+      itemStatus: checklistItems.status,
+      projectArchivedAt: projects.archivedAt,
+      projectChecklistId: projectChecklists.id,
+      projectSlug: projects.slug,
+    })
+    .from(checklistItems)
+    .innerJoin(projectChecklists, eq(checklistItems.projectChecklistId, projectChecklists.id))
+    .innerJoin(projects, eq(projectChecklists.projectId, projects.id))
+    .where(
+      and(
+        eq(checklistItems.id, input.checklistItemId),
+        eq(projects.organizationId, membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!checklistItem) {
+    return null;
+  }
+
+  if (
+    checklistItem.projectArchivedAt ||
+    checklistItem.archivedAt ||
+    checklistItem.itemStatus !== 'active'
+  ) {
+    throw new ChecklistInputError('Only active Checklist Items can be removed.');
+  }
+
+  await db
+    .update(checklistItems)
+    .set({
+      status: 'removed',
+      updatedAt: new Date(),
+    })
+    .where(eq(checklistItems.id, input.checklistItemId));
+
+  return getProjectChecklistDetail({
+    membership,
+    projectChecklistId: checklistItem.projectChecklistId,
+    projectSlug: checklistItem.projectSlug,
+  });
+}
+
+export async function addChecklistItemForMember(
+  membership: AuthorizedOrganizationMember,
+  input: { controlId: string; projectChecklistId: string },
+) {
+  const projectChecklist = await getProjectChecklistForManagement(
+    membership,
+    input.projectChecklistId,
+  );
+
+  if (!projectChecklist) {
+    return null;
+  }
+
+  if (projectChecklist.projectArchivedAt || projectChecklist.archivedAt) {
+    throw new ChecklistInputError(
+      'Only active Project Checklists can receive new Checklist Items.',
+    );
+  }
+
+  const activeExistingItem = await db
+    .select({ id: checklistItems.id })
+    .from(checklistItems)
+    .where(
+      and(
+        eq(checklistItems.projectChecklistId, projectChecklist.id),
+        eq(checklistItems.controlId, input.controlId),
+        eq(checklistItems.status, 'active'),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (activeExistingItem) {
+    throw new ChecklistInputError('A Control can appear only once in a Project Checklist.');
+  }
+
+  const selectedControl = await getLatestActiveControlVersions(membership.organizationId, [
+    input.controlId,
+  ]).then((rows) => rows[0] ?? null);
+
+  if (!selectedControl) {
+    throw new ChecklistInputError('Project Checklists can use only active Controls.');
+  }
+
+  const now = new Date();
+
+  await db.insert(checklistItems).values({
+    checked: false,
+    controlId: selectedControl.controlId,
+    controlVersionId: selectedControl.controlVersionId,
+    createdAt: now,
+    id: crypto.randomUUID(),
+    projectChecklistId: projectChecklist.id,
+    status: 'active',
+    updatedAt: now,
+  });
+
+  return getProjectChecklistDetail({
+    membership,
+    projectChecklistId: projectChecklist.id,
+    projectSlug: projectChecklist.projectSlug,
+  });
+}
+
+export async function enforceArchivedControlForMember(
+  membership: AuthorizedOrganizationMember,
+  input: { controlId: string; projectChecklistId: string },
+) {
+  const projectChecklist = await getProjectChecklistForManagement(
+    membership,
+    input.projectChecklistId,
+  );
+
+  if (!projectChecklist) {
+    return null;
+  }
+
+  if (projectChecklist.projectArchivedAt || projectChecklist.archivedAt) {
+    throw new ChecklistInputError('Only active Project Checklists can enforce Archived Controls.');
+  }
+
+  const archivedControl = await db
+    .select({ id: controls.id })
+    .from(controls)
+    .where(
+      and(
+        eq(controls.id, input.controlId),
+        eq(controls.organizationId, membership.organizationId),
+        isNotNull(controls.archivedAt),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!archivedControl) {
+    throw new ChecklistInputError('Archived Control unavailable.');
+  }
+
+  await db
+    .update(checklistItems)
+    .set({ status: 'removed', updatedAt: new Date() })
+    .where(
+      and(
+        eq(checklistItems.projectChecklistId, projectChecklist.id),
+        eq(checklistItems.controlId, archivedControl.id),
+        eq(checklistItems.status, 'active'),
+      ),
+    );
+
+  return getProjectChecklistDetail({
+    membership,
+    projectChecklistId: projectChecklist.id,
+    projectSlug: projectChecklist.projectSlug,
+  });
+}
+
+export async function refreshChecklistItemForMember(
+  membership: AuthorizedOrganizationMember,
+  input: { checklistItemId: string },
+) {
+  const checklistItem = await db
+    .select({
+      archivedAt: projectChecklists.archivedAt,
+      controlId: checklistItems.controlId,
+      controlVersionId: checklistItems.controlVersionId,
+      itemStatus: checklistItems.status,
+      projectArchivedAt: projects.archivedAt,
+      projectChecklistId: projectChecklists.id,
+      projectSlug: projects.slug,
+    })
+    .from(checklistItems)
+    .innerJoin(projectChecklists, eq(checklistItems.projectChecklistId, projectChecklists.id))
+    .innerJoin(projects, eq(projectChecklists.projectId, projects.id))
+    .where(
+      and(
+        eq(checklistItems.id, input.checklistItemId),
+        eq(projects.organizationId, membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!checklistItem) {
+    return null;
+  }
+
+  if (
+    checklistItem.projectArchivedAt ||
+    checklistItem.archivedAt ||
+    checklistItem.itemStatus !== 'active'
+  ) {
+    throw new ChecklistInputError('Only active Checklist Items can be refreshed.');
+  }
+
+  const latestControlVersion = await db
+    .select({
+      controlVersionId: controlVersions.id,
+    })
+    .from(controls)
+    .innerJoin(controlVersions, eq(controls.currentVersionId, controlVersions.id))
+    .where(
+      and(
+        eq(controls.id, checklistItem.controlId),
+        eq(controls.organizationId, membership.organizationId),
+        isNull(controls.archivedAt),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!latestControlVersion) {
+    throw new ChecklistInputError('Checklist Items can be refreshed only from active Controls.');
+  }
+
+  if (latestControlVersion.controlVersionId === checklistItem.controlVersionId) {
+    throw new ChecklistInputError('Checklist Item already uses the latest Control Version.');
+  }
+
+  const now = new Date();
+
+  await db
+    .update(checklistItems)
+    .set({
+      status: 'superseded',
+      updatedAt: now,
+    })
+    .where(eq(checklistItems.id, input.checklistItemId));
+
+  await db.insert(checklistItems).values({
+    checked: false,
+    controlId: checklistItem.controlId,
+    controlVersionId: latestControlVersion.controlVersionId,
+    createdAt: now,
+    id: crypto.randomUUID(),
+    projectChecklistId: checklistItem.projectChecklistId,
+    status: 'active',
+    updatedAt: now,
+  });
+
+  return getProjectChecklistDetail({
+    membership,
+    projectChecklistId: checklistItem.projectChecklistId,
+    projectSlug: checklistItem.projectSlug,
+  });
+}
+
+async function getProjectChecklistDetail(input: {
+  membership: AuthorizedOrganizationMember;
+  projectChecklistId: string;
+  projectSlug: string;
+}) {
+  const projectChecklist = await db
+    .select({
+      archivedAt: projectChecklists.archivedAt,
+      createdAt: projectChecklists.createdAt,
+      id: projectChecklists.id,
+      name: projectChecklists.name,
+      sourceChecklistTemplateId: projectChecklists.sourceChecklistTemplateId,
+    })
+    .from(projectChecklists)
+    .innerJoin(projects, eq(projectChecklists.projectId, projects.id))
+    .where(
+      and(
+        eq(projectChecklists.id, input.projectChecklistId),
+        eq(projects.organizationId, input.membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!projectChecklist) {
+    return null;
+  }
+
+  const items = await getProjectChecklistItems(projectChecklist.id);
+  const activeItems = items.filter((item) => item.itemStatus === 'active');
+
+  return {
+    archivedAt: projectChecklist.archivedAt?.toISOString() ?? null,
+    createdAt: projectChecklist.createdAt.toISOString(),
+    id: projectChecklist.id,
+    isComplete: activeItems.length > 0 && activeItems.every((item) => item.checked),
+    items,
+    name: projectChecklist.name,
+    projectSlug: input.projectSlug,
+    sourceChecklistTemplateId: projectChecklist.sourceChecklistTemplateId,
+    status: projectChecklist.archivedAt ? ('archived' as const) : ('active' as const),
+  };
+}
+
+async function getProjectChecklistItems(projectChecklistId: string) {
+  const rows = await db
+    .select({
+      checked: checklistItems.checked,
+      controlCode: controlVersions.controlCode,
+      controlId: checklistItems.controlId,
+      controlTitle: controlVersions.title,
+      controlVersionId: checklistItems.controlVersionId,
+      controlVersionNumber: controlVersions.versionNumber,
+      createdAt: checklistItems.createdAt,
+      id: checklistItems.id,
+      status: checklistItems.status,
+    })
+    .from(checklistItems)
+    .innerJoin(controlVersions, eq(checklistItems.controlVersionId, controlVersions.id))
+    .where(eq(checklistItems.projectChecklistId, projectChecklistId))
+    .orderBy(asc(checklistItems.createdAt), asc(controlVersions.controlCode));
+
+  return rows.map((row) => ({
+    checked: row.checked,
+    controlCode: row.controlCode,
+    controlId: row.controlId,
+    controlTitle: row.controlTitle,
+    controlVersionId: row.controlVersionId,
+    controlVersionNumber: row.controlVersionNumber,
+    createdAt: row.createdAt.toISOString(),
+    id: row.id,
+    itemStatus: row.status,
+  }));
+}
+
+async function getLatestActiveControlVersions(organizationId: string, controlIds: string[]) {
+  if (controlIds.length === 0) {
+    return [];
+  }
+
+  return db
+    .select({
+      controlId: controls.id,
+      controlVersionId: controlVersions.id,
+    })
+    .from(controls)
+    .innerJoin(controlVersions, eq(controls.currentVersionId, controlVersions.id))
+    .where(
+      and(
+        eq(controls.organizationId, organizationId),
+        isNull(controls.archivedAt),
+        inArray(controls.id, controlIds),
+      ),
+    );
+}
+
+function normalizeCreateProjectChecklistBody(body: CreateProjectChecklistInput) {
+  return {
+    checklistTemplateId: body.checklistTemplateId,
+    controlIds: body.controlIds,
+    name: body.name,
+    projectSlug: body.projectSlug,
+  };
+}
+
+function normalizeCreateChecklistTemplateBody(body: CreateChecklistTemplateInput) {
+  return {
+    controlIds: body.controlIds,
+    name: body.name,
+  };
+}
+
+function validateProjectChecklistName(name: string) {
+  if (!name.trim()) {
+    throw new ChecklistInputError('Project Checklist name is required.');
+  }
+}
+
+function validateChecklistTemplateName(name: string) {
+  if (!name.trim()) {
+    throw new ChecklistInputError('Checklist Template name is required.');
+  }
+}
+
+function validateUniqueControlIds(controlIds: string[], message: string) {
+  const uniqueControlIds = new Set(controlIds);
+
+  if (uniqueControlIds.size !== controlIds.length) {
+    throw new ChecklistInputError(message);
+  }
+}

--- a/apps/backend-hono/src/contexts/control-library/controls-router.ts
+++ b/apps/backend-hono/src/contexts/control-library/controls-router.ts
@@ -31,6 +31,7 @@ import {
   publishControlProposedUpdate,
   publishControlPublishRequest,
   publishDraftControl,
+  rejectControlProposedUpdate,
   rejectControlPublishRequest,
   setControlArchivedForMembership,
   submitControlProposedUpdatePublishRequest,
@@ -371,6 +372,31 @@ export const controlsRouter = router({
         }
 
         return { publishRequest };
+      } catch (caughtError) {
+        throwKnownInputError(caughtError);
+      }
+    }),
+
+  rejectProposedUpdate: protectedProcedure
+    .input(proposedUpdateIdentityInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: controlLibraryAuthorizationActions.rejectProposedUpdate,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const rejected = await rejectControlProposedUpdate(
+          membership,
+          input.controlId,
+          input.proposedUpdateId,
+        );
+
+        if (!rejected) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Proposed update unavailable' });
+        }
+
+        return { rejected: true };
       } catch (caughtError) {
         throwKnownInputError(caughtError);
       }

--- a/apps/backend-hono/src/contexts/control-library/controls.ts
+++ b/apps/backend-hono/src/contexts/control-library/controls.ts
@@ -169,6 +169,10 @@ export const controlLibraryAuthorizationActions = {
     allowedRoles: controlPublisherRoles,
     deniedMessage: 'Only Organization owners and admins can reject Control Publish Requests.',
   },
+  rejectProposedUpdate: {
+    allowedRoles: controlPublisherRoles,
+    deniedMessage: 'Only Organization owners and admins can reject proposed Control updates.',
+  },
   restore: {
     allowedRoles: controlPublisherRoles,
     deniedMessage: 'Only Organization owners and admins can restore Controls.',
@@ -1026,6 +1030,33 @@ export async function publishControlProposedUpdate(
   await db.delete(controlProposedUpdates).where(eq(controlProposedUpdates.id, proposedUpdateId));
 
   return getControlDetail(membership, controlId);
+}
+
+export async function rejectControlProposedUpdate(
+  membership: AuthorizedOrganizationMember,
+  controlId: string,
+  proposedUpdateId: string,
+) {
+  const proposedUpdate = await db
+    .select({ id: controlProposedUpdates.id })
+    .from(controlProposedUpdates)
+    .where(
+      and(
+        eq(controlProposedUpdates.id, proposedUpdateId),
+        eq(controlProposedUpdates.controlId, controlId),
+        eq(controlProposedUpdates.organizationId, membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!proposedUpdate) {
+    return false;
+  }
+
+  await db.delete(controlProposedUpdates).where(eq(controlProposedUpdates.id, proposedUpdateId));
+
+  return true;
 }
 
 export function normalizeDraftControlCreateBody(body: unknown) {

--- a/apps/backend-hono/src/db/schema.ts
+++ b/apps/backend-hono/src/db/schema.ts
@@ -1,4 +1,11 @@
-import { index, integer, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core';
+import {
+  foreignKey,
+  index,
+  integer,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from 'drizzle-orm/sqlite-core';
 import { sql } from 'drizzle-orm';
 
 export const users = sqliteTable('users', {
@@ -292,6 +299,7 @@ export const controlVersions = sqliteTable(
   },
   (table) => [
     index('control_version_control_id_idx').on(table.controlId),
+    uniqueIndex('control_version_control_id_id_unique').on(table.controlId, table.id),
     uniqueIndex('control_version_number_unique').on(table.controlId, table.versionNumber),
   ],
 );
@@ -402,6 +410,11 @@ export const checklistItems = sqliteTable(
     index('checklist_item_control_id_idx').on(table.controlId),
     index('checklist_item_control_version_id_idx').on(table.controlVersionId),
     index('checklist_item_status_idx').on(table.status),
+    foreignKey({
+      columns: [table.controlId, table.controlVersionId],
+      foreignColumns: [controlVersions.controlId, controlVersions.id],
+      name: 'checklist_item_control_version_control_fk',
+    }).onDelete('cascade'),
     uniqueIndex('checklist_item_active_control_unique')
       .on(table.projectChecklistId, table.controlId)
       .where(sql`${table.status} = 'active'`),

--- a/apps/backend-hono/src/db/schema.ts
+++ b/apps/backend-hono/src/db/schema.ts
@@ -296,6 +296,118 @@ export const controlVersions = sqliteTable(
   ],
 );
 
+export const checklistTemplates = sqliteTable(
+  'checklist_templates',
+  {
+    id: text('id').primaryKey(),
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    archivedAt: integer('archived_at', { mode: 'timestamp_ms' }),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    index('checklist_template_organization_id_idx').on(table.organizationId),
+    index('checklist_template_archived_at_idx').on(table.archivedAt),
+    uniqueIndex('checklist_template_active_name_unique')
+      .on(table.organizationId, table.name)
+      .where(sql`${table.archivedAt} is null`),
+  ],
+);
+
+export const checklistTemplateControls = sqliteTable(
+  'checklist_template_controls',
+  {
+    id: text('id').primaryKey(),
+    checklistTemplateId: text('checklist_template_id')
+      .notNull()
+      .references(() => checklistTemplates.id, { onDelete: 'cascade' }),
+    controlId: text('control_id')
+      .notNull()
+      .references(() => controls.id, { onDelete: 'cascade' }),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+  },
+  (table) => [
+    index('checklist_template_control_template_id_idx').on(table.checklistTemplateId),
+    index('checklist_template_control_control_id_idx').on(table.controlId),
+    uniqueIndex('checklist_template_control_unique').on(table.checklistTemplateId, table.controlId),
+  ],
+);
+
+export const projectChecklists = sqliteTable(
+  'project_checklists',
+  {
+    id: text('id').primaryKey(),
+    projectId: text('project_id')
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    sourceChecklistTemplateId: text('source_checklist_template_id').references(
+      () => checklistTemplates.id,
+      { onDelete: 'set null' },
+    ),
+    name: text('name').notNull(),
+    archivedAt: integer('archived_at', { mode: 'timestamp_ms' }),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    index('project_checklist_project_id_idx').on(table.projectId),
+    index('project_checklist_source_template_id_idx').on(table.sourceChecklistTemplateId),
+    index('project_checklist_archived_at_idx').on(table.archivedAt),
+    uniqueIndex('project_checklist_active_name_unique')
+      .on(table.projectId, table.name)
+      .where(sql`${table.archivedAt} is null`),
+  ],
+);
+
+export const checklistItems = sqliteTable(
+  'checklist_items',
+  {
+    id: text('id').primaryKey(),
+    projectChecklistId: text('project_checklist_id')
+      .notNull()
+      .references(() => projectChecklists.id, { onDelete: 'cascade' }),
+    controlId: text('control_id')
+      .notNull()
+      .references(() => controls.id, { onDelete: 'cascade' }),
+    controlVersionId: text('control_version_id')
+      .notNull()
+      .references(() => controlVersions.id, { onDelete: 'cascade' }),
+    checked: integer('checked', { mode: 'boolean' }).default(false).notNull(),
+    status: text('status').default('active').notNull(),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    index('checklist_item_project_checklist_id_idx').on(table.projectChecklistId),
+    index('checklist_item_control_id_idx').on(table.controlId),
+    index('checklist_item_control_version_id_idx').on(table.controlVersionId),
+    index('checklist_item_status_idx').on(table.status),
+    uniqueIndex('checklist_item_active_control_unique')
+      .on(table.projectChecklistId, table.controlId)
+      .where(sql`${table.status} = 'active'`),
+  ],
+);
+
 export const controlProposedUpdates = sqliteTable(
   'control_proposed_updates',
   {

--- a/apps/backend-hono/src/trpc/router.ts
+++ b/apps/backend-hono/src/trpc/router.ts
@@ -1,9 +1,11 @@
 import { router } from './core';
+import { checklistsRouter } from '../contexts/checklists/checklists-router';
 import { controlsRouter } from '../contexts/control-library/controls-router';
 import { organizationsRouter } from '../contexts/identity-organization/organizations-router';
 import { projectsRouter } from '../contexts/projects/projects-router';
 
 export const appRouter = router({
+  checklists: checklistsRouter,
   controls: controlsRouter,
   organizations: organizationsRouter,
   projects: projectsRouter,

--- a/apps/backend-hono/test/checklists.spec.ts
+++ b/apps/backend-hono/test/checklists.spec.ts
@@ -2,7 +2,7 @@ import { and, eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { db } from '../src/db/client';
-import { members, users } from '../src/db/schema';
+import { checklistItems, members, users } from '../src/db/schema';
 import { auth } from '../src/lib/auth';
 import { callTRPC } from './trpc-test-utils';
 
@@ -543,6 +543,45 @@ describe('Project Checklists', () => {
         itemStatus: 'active',
       }),
     ]);
+  });
+
+  it('rejects Checklist Items whose Control Version belongs to another Control', async () => {
+    const { headers, organization } = await createSignedInOwner('checklist-version-link-owner');
+    const ownerMembership = await getFirstMembership(organization.id);
+    const project = await createProject({
+      headers,
+      organizationSlug: organization.slug,
+      projectOwnerMemberId: ownerMembership.id,
+    });
+    const firstControl = await createActiveControl({
+      headers,
+      organizationSlug: organization.slug,
+      title: 'Verify production access',
+    });
+    const secondControl = await createActiveControl({
+      headers,
+      organizationSlug: organization.slug,
+      title: 'Verify change approval',
+    });
+    const checklistResponse = await createProjectChecklist({
+      controlIds: [firstControl.id],
+      headers,
+      name: 'Version integrity',
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+    const projectChecklist = checklistResponse.body.projectChecklist;
+
+    await expect(
+      db.insert(checklistItems).values({
+        checked: false,
+        controlId: firstControl.id,
+        controlVersionId: secondControl.currentVersion.id,
+        id: crypto.randomUUID(),
+        projectChecklistId: projectChecklist.id,
+        status: 'removed',
+      }),
+    ).rejects.toThrow();
   });
 
   it('lets only the Project Owner check and uncheck Checklist Items', async () => {

--- a/apps/backend-hono/test/checklists.spec.ts
+++ b/apps/backend-hono/test/checklists.spec.ts
@@ -1,0 +1,1164 @@
+import { and, eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { db } from '../src/db/client';
+import { members, users } from '../src/db/schema';
+import { auth } from '../src/lib/auth';
+import { callTRPC } from './trpc-test-utils';
+
+const authHeaders = {
+  origin: 'http://localhost:5173',
+  host: 'localhost:8787',
+};
+const verificationCallbackURL = 'http://localhost:8787/sign-in';
+const mailpitSendUrl = 'http://127.0.0.1:8025/api/v1/send';
+
+function createCredentials(prefix: string) {
+  const token = crypto.randomUUID();
+
+  return {
+    name: `${prefix} user`,
+    email: `${prefix}-${token}@example.com`,
+    password: `Password-${token}`,
+  };
+}
+
+async function signUpUser(credentials: ReturnType<typeof createCredentials>) {
+  await auth.api.signUpEmail({
+    body: {
+      ...credentials,
+      callbackURL: verificationCallbackURL,
+    },
+    headers: authHeaders,
+  });
+
+  await db.update(users).set({ emailVerified: true }).where(eq(users.email, credentials.email));
+}
+
+async function signInUser(credentials: ReturnType<typeof createCredentials>) {
+  const result = await auth.api.signInEmail({
+    body: {
+      email: credentials.email,
+      password: credentials.password,
+    },
+    headers: authHeaders,
+    returnHeaders: true,
+  });
+
+  const sessionCookie = result.headers.get('set-cookie');
+
+  expect(sessionCookie).toBeTruthy();
+
+  if (!sessionCookie) {
+    throw new Error('Expected Better Auth to return a session cookie.');
+  }
+
+  const cookie = sessionCookie.split(';', 1)[0] ?? sessionCookie;
+
+  return new Headers({
+    ...authHeaders,
+    cookie,
+  });
+}
+
+async function createSignedInOwner(prefix: string) {
+  const credentials = createCredentials(prefix);
+
+  await signUpUser(credentials);
+
+  const headers = await signInUser(credentials);
+  const organization = (await auth.api.listOrganizations({ headers }))[0];
+
+  expect(organization?.id).toBeTruthy();
+
+  if (!organization?.id) {
+    throw new Error('Expected a default organization.');
+  }
+
+  return { headers, organization };
+}
+
+async function createSignedInMember(input: {
+  ownerHeaders: Headers;
+  organizationId: string;
+  prefix: string;
+  role: 'admin' | 'member';
+}) {
+  const credentials = createCredentials(input.prefix);
+
+  await signUpUser(credentials);
+
+  const invitation = await auth.api.createInvitation({
+    body: {
+      email: credentials.email,
+      organizationId: input.organizationId,
+      role: input.role,
+    },
+    headers: input.ownerHeaders,
+  });
+  const headers = await signInUser(credentials);
+
+  await auth.api.acceptInvitation({
+    body: { invitationId: invitation.id },
+    headers,
+  });
+
+  const membership = await db
+    .select({ id: members.id })
+    .from(members)
+    .innerJoin(users, eq(users.id, members.userId))
+    .where(
+      and(eq(members.organizationId, input.organizationId), eq(users.email, credentials.email)),
+    )
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  expect(membership?.id).toBeTruthy();
+
+  if (!membership?.id) {
+    throw new Error('Expected invited Organization membership.');
+  }
+
+  return { credentials, headers, membership };
+}
+
+async function getFirstMembership(organizationId: string) {
+  const membership = await db
+    .select({ id: members.id })
+    .from(members)
+    .where(eq(members.organizationId, organizationId))
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  expect(membership?.id).toBeTruthy();
+
+  if (!membership?.id) {
+    throw new Error('Expected an Organization membership.');
+  }
+
+  return membership;
+}
+
+async function createProject(input: {
+  headers: Headers;
+  organizationSlug: string;
+  projectOwnerMemberId: string;
+}) {
+  const projectToken = crypto.randomUUID().slice(0, 8);
+  const response = await callTRPC(
+    input.headers,
+    (caller) =>
+      caller.projects.create({
+        description: 'Checklist readiness work for this Organization.',
+        name: `Checklist Readiness ${projectToken}`,
+        organizationSlug: input.organizationSlug,
+        projectOwnerMemberId: input.projectOwnerMemberId,
+        slug: `checklist-readiness-${projectToken}`,
+      }),
+    201,
+  );
+
+  expect(response.status).toBe(201);
+
+  return response.body.project;
+}
+
+async function archiveProject(input: {
+  headers: Headers;
+  organizationSlug: string;
+  projectSlug: string;
+}) {
+  return callTRPC(input.headers, (caller) =>
+    caller.projects.archive({
+      organizationSlug: input.organizationSlug,
+      projectSlug: input.projectSlug,
+    }),
+  );
+}
+
+async function createActiveControl(input: {
+  headers: Headers;
+  organizationSlug: string;
+  title: string;
+}) {
+  const draftResponse = await callTRPC(
+    input.headers,
+    (caller) =>
+      caller.controls.createDraft({
+        organizationSlug: input.organizationSlug,
+        title: input.title,
+      }),
+    201,
+  );
+
+  expect(draftResponse.status).toBe(201);
+
+  const publishResponse = await callTRPC(
+    input.headers,
+    (caller) =>
+      caller.controls.publishDraft({
+        businessMeaning: 'Release teams must verify this requirement before completion.',
+        draftControlId: draftResponse.body.draftControl.id,
+        organizationSlug: input.organizationSlug,
+      }),
+    201,
+  );
+
+  expect(publishResponse.status).toBe(201);
+
+  return publishResponse.body.control;
+}
+
+async function publishControlUpdate(input: {
+  businessMeaning: string;
+  controlId: string;
+  headers: Headers;
+  organizationSlug: string;
+  title: string;
+}) {
+  const proposedUpdateResponse = await callTRPC(
+    input.headers,
+    (caller) =>
+      caller.controls.createProposedUpdate({
+        businessMeaning: input.businessMeaning,
+        controlId: input.controlId,
+        organizationSlug: input.organizationSlug,
+        title: input.title,
+      }),
+    201,
+  );
+
+  expect(proposedUpdateResponse.status).toBe(201);
+
+  const publishResponse = await callTRPC(
+    input.headers,
+    (caller) =>
+      caller.controls.publishProposedUpdate({
+        controlId: input.controlId,
+        organizationSlug: input.organizationSlug,
+        proposedUpdateId: proposedUpdateResponse.body.proposedUpdate.id,
+      }),
+    201,
+  );
+
+  expect(publishResponse.status).toBe(201);
+
+  return publishResponse.body.control;
+}
+
+async function archiveControl(input: {
+  controlId: string;
+  headers: Headers;
+  organizationSlug: string;
+}) {
+  return callTRPC(input.headers, (caller) =>
+    caller.controls.archive({
+      controlId: input.controlId,
+      organizationSlug: input.organizationSlug,
+    }),
+  );
+}
+
+async function createProjectChecklist(input: {
+  checklistTemplateId?: string;
+  controlIds?: string[];
+  headers: Headers;
+  name: string;
+  organizationSlug: string;
+  projectSlug: string;
+}) {
+  return callTRPC(
+    input.headers,
+    (caller) =>
+      caller.checklists.createProjectChecklist({
+        checklistTemplateId: input.checklistTemplateId,
+        controlIds: input.controlIds,
+        name: input.name,
+        organizationSlug: input.organizationSlug,
+        projectSlug: input.projectSlug,
+      } as never),
+    201,
+  );
+}
+
+async function listProjectChecklists(input: {
+  headers: Headers;
+  organizationSlug: string;
+  projectSlug: string;
+  status?: 'active' | 'archived';
+}) {
+  return callTRPC(input.headers, (caller) =>
+    caller.checklists.listProjectChecklists({
+      organizationSlug: input.organizationSlug,
+      projectSlug: input.projectSlug,
+      status: input.status,
+    } as never),
+  );
+}
+
+async function renameProjectChecklist(input: {
+  headers: Headers;
+  name: string;
+  organizationSlug: string;
+  projectChecklistId: string;
+}) {
+  return callTRPC(input.headers, (caller) =>
+    caller.checklists.renameProjectChecklist({
+      name: input.name,
+      organizationSlug: input.organizationSlug,
+      projectChecklistId: input.projectChecklistId,
+    }),
+  );
+}
+
+async function archiveProjectChecklist(input: {
+  headers: Headers;
+  organizationSlug: string;
+  projectChecklistId: string;
+}) {
+  return callTRPC(input.headers, (caller) =>
+    caller.checklists.archiveProjectChecklist({
+      organizationSlug: input.organizationSlug,
+      projectChecklistId: input.projectChecklistId,
+    }),
+  );
+}
+
+async function restoreProjectChecklist(input: {
+  headers: Headers;
+  organizationSlug: string;
+  projectChecklistId: string;
+}) {
+  return callTRPC(input.headers, (caller) =>
+    caller.checklists.restoreProjectChecklist({
+      organizationSlug: input.organizationSlug,
+      projectChecklistId: input.projectChecklistId,
+    }),
+  );
+}
+
+async function createChecklistTemplate(input: {
+  controlIds: string[];
+  headers: Headers;
+  name: string;
+  organizationSlug: string;
+}) {
+  return callTRPC(
+    input.headers,
+    (caller) =>
+      caller.checklists.createTemplate({
+        controlIds: input.controlIds,
+        name: input.name,
+        organizationSlug: input.organizationSlug,
+      }),
+    201,
+  );
+}
+
+async function listChecklistTemplates(input: {
+  headers: Headers;
+  organizationSlug: string;
+  status?: 'active' | 'archived';
+}) {
+  return callTRPC(input.headers, (caller) =>
+    caller.checklists.listTemplates({
+      organizationSlug: input.organizationSlug,
+      status: input.status,
+    } as never),
+  );
+}
+
+async function renameChecklistTemplate(input: {
+  checklistTemplateId: string;
+  headers: Headers;
+  name: string;
+  organizationSlug: string;
+}) {
+  return callTRPC(input.headers, (caller) =>
+    caller.checklists.renameTemplate({
+      checklistTemplateId: input.checklistTemplateId,
+      name: input.name,
+      organizationSlug: input.organizationSlug,
+    }),
+  );
+}
+
+async function archiveChecklistTemplate(input: {
+  checklistTemplateId: string;
+  headers: Headers;
+  organizationSlug: string;
+}) {
+  return callTRPC(input.headers, (caller) =>
+    caller.checklists.archiveTemplate({
+      checklistTemplateId: input.checklistTemplateId,
+      organizationSlug: input.organizationSlug,
+    }),
+  );
+}
+
+async function restoreChecklistTemplate(input: {
+  checklistTemplateId: string;
+  headers: Headers;
+  organizationSlug: string;
+}) {
+  return callTRPC(input.headers, (caller) =>
+    caller.checklists.restoreTemplate({
+      checklistTemplateId: input.checklistTemplateId,
+      organizationSlug: input.organizationSlug,
+    }),
+  );
+}
+
+async function setChecklistItemChecked(input: {
+  checked: boolean;
+  checklistItemId: string;
+  headers: Headers;
+  organizationSlug: string;
+}) {
+  return callTRPC(input.headers, (caller) =>
+    caller.checklists.setChecklistItemChecked({
+      checked: input.checked,
+      checklistItemId: input.checklistItemId,
+      organizationSlug: input.organizationSlug,
+    }),
+  );
+}
+
+async function refreshChecklistItem(input: {
+  checklistItemId: string;
+  headers: Headers;
+  organizationSlug: string;
+}) {
+  return callTRPC(input.headers, (caller) =>
+    caller.checklists.refreshChecklistItem({
+      checklistItemId: input.checklistItemId,
+      organizationSlug: input.organizationSlug,
+    }),
+  );
+}
+
+async function removeChecklistItem(input: {
+  checklistItemId: string;
+  headers: Headers;
+  organizationSlug: string;
+}) {
+  return callTRPC(input.headers, (caller) =>
+    caller.checklists.removeChecklistItem({
+      checklistItemId: input.checklistItemId,
+      organizationSlug: input.organizationSlug,
+    }),
+  );
+}
+
+async function addChecklistItem(input: {
+  controlId: string;
+  headers: Headers;
+  organizationSlug: string;
+  projectChecklistId: string;
+}) {
+  return callTRPC(
+    input.headers,
+    (caller) =>
+      caller.checklists.addChecklistItem({
+        controlId: input.controlId,
+        organizationSlug: input.organizationSlug,
+        projectChecklistId: input.projectChecklistId,
+      }),
+    201,
+  );
+}
+
+async function enforceArchivedControl(input: {
+  controlId: string;
+  headers: Headers;
+  organizationSlug: string;
+  projectChecklistId: string;
+}) {
+  return callTRPC(input.headers, (caller) =>
+    caller.checklists.enforceArchivedControl({
+      controlId: input.controlId,
+      organizationSlug: input.organizationSlug,
+      projectChecklistId: input.projectChecklistId,
+    }),
+  );
+}
+
+beforeEach(() => {
+  const originalFetch = globalThis.fetch;
+
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+    if (url === mailpitSendUrl) {
+      return new Response(null, { status: 200 });
+    }
+
+    return originalFetch(input, init);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Project Checklists', () => {
+  it('lets Organization owners create a Project Checklist from active Controls', async () => {
+    const { headers, organization } = await createSignedInOwner('checklist-owner');
+    const ownerMembership = await getFirstMembership(organization.id);
+    const project = await createProject({
+      headers,
+      organizationSlug: organization.slug,
+      projectOwnerMemberId: ownerMembership.id,
+    });
+    const control = await createActiveControl({
+      headers,
+      organizationSlug: organization.slug,
+      title: 'Verify access review',
+    });
+
+    const response = await createProjectChecklist({
+      controlIds: [control.id],
+      headers,
+      name: 'Release readiness',
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.projectChecklist).toMatchObject({
+      isComplete: false,
+      name: 'Release readiness',
+      projectSlug: project.slug,
+      status: 'active',
+    });
+    expect(response.body.projectChecklist.items).toEqual([
+      expect.objectContaining({
+        checked: false,
+        controlCode: control.controlCode,
+        controlId: control.id,
+        controlTitle: control.title,
+        controlVersionId: control.currentVersion.id,
+        controlVersionNumber: 1,
+        itemStatus: 'active',
+      }),
+    ]);
+  });
+
+  it('lets only the Project Owner check and uncheck Checklist Items', async () => {
+    const { headers: ownerHeaders, organization } =
+      await createSignedInOwner('checklist-state-owner');
+    const projectOwner = await createSignedInMember({
+      organizationId: organization.id,
+      ownerHeaders,
+      prefix: 'checklist-project-owner',
+      role: 'member',
+    });
+    const project = await createProject({
+      headers: ownerHeaders,
+      organizationSlug: organization.slug,
+      projectOwnerMemberId: projectOwner.membership.id,
+    });
+    const control = await createActiveControl({
+      headers: ownerHeaders,
+      organizationSlug: organization.slug,
+      title: 'Verify deployment approval',
+    });
+    const checklistResponse = await createProjectChecklist({
+      controlIds: [control.id],
+      headers: ownerHeaders,
+      name: 'Owner completion',
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+    const checklistItemId = checklistResponse.body.projectChecklist.items[0]?.id;
+
+    expect(checklistItemId).toBeTruthy();
+
+    if (!checklistItemId) {
+      throw new Error('Expected a Checklist Item.');
+    }
+
+    const forbiddenOwnerResponse = await setChecklistItemChecked({
+      checked: true,
+      checklistItemId,
+      headers: ownerHeaders,
+      organizationSlug: organization.slug,
+    });
+    const checkedResponse = await setChecklistItemChecked({
+      checked: true,
+      checklistItemId,
+      headers: projectOwner.headers,
+      organizationSlug: organization.slug,
+    });
+    const uncheckedResponse = await setChecklistItemChecked({
+      checked: false,
+      checklistItemId,
+      headers: projectOwner.headers,
+      organizationSlug: organization.slug,
+    });
+
+    expect(forbiddenOwnerResponse.status).toBe(403);
+    expect(checkedResponse.status).toBe(200);
+    expect(checkedResponse.body.projectChecklist).toMatchObject({
+      isComplete: true,
+      items: [expect.objectContaining({ checked: true, id: checklistItemId })],
+    });
+    expect(uncheckedResponse.status).toBe(200);
+    expect(uncheckedResponse.body.projectChecklist).toMatchObject({
+      isComplete: false,
+      items: [expect.objectContaining({ checked: false, id: checklistItemId })],
+    });
+  });
+
+  it('keeps Checklist Templates visible and manageable only by owners and admins', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'checklist-template-owner',
+    );
+    const member = await createSignedInMember({
+      organizationId: organization.id,
+      ownerHeaders,
+      prefix: 'checklist-template-member',
+      role: 'member',
+    });
+    const ownerMembership = await getFirstMembership(organization.id);
+    const project = await createProject({
+      headers: ownerHeaders,
+      organizationSlug: organization.slug,
+      projectOwnerMemberId: ownerMembership.id,
+    });
+    const control = await createActiveControl({
+      headers: ownerHeaders,
+      organizationSlug: organization.slug,
+      title: 'Verify template control',
+    });
+
+    const forbiddenCreateResponse = await createChecklistTemplate({
+      controlIds: [control.id],
+      headers: member.headers,
+      name: 'Member template',
+      organizationSlug: organization.slug,
+    });
+    const createTemplateResponse = await createChecklistTemplate({
+      controlIds: [control.id],
+      headers: ownerHeaders,
+      name: 'Release template',
+      organizationSlug: organization.slug,
+    });
+    const forbiddenListResponse = await listChecklistTemplates({
+      headers: member.headers,
+      organizationSlug: organization.slug,
+    });
+    const listResponse = await listChecklistTemplates({
+      headers: ownerHeaders,
+      organizationSlug: organization.slug,
+    });
+    const createChecklistResponse = await createProjectChecklist({
+      checklistTemplateId: createTemplateResponse.body.checklistTemplate.id,
+      headers: ownerHeaders,
+      name: 'Template-created checklist',
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+
+    expect(forbiddenCreateResponse.status).toBe(403);
+    expect(createTemplateResponse.status).toBe(201);
+    expect(createTemplateResponse.body.checklistTemplate).toMatchObject({
+      name: 'Release template',
+      status: 'active',
+      controls: [expect.objectContaining({ controlId: control.id })],
+    });
+    expect(forbiddenListResponse.status).toBe(403);
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.checklistTemplates).toEqual([
+      expect.objectContaining({
+        id: createTemplateResponse.body.checklistTemplate.id,
+        name: 'Release template',
+      }),
+    ]);
+    expect(createChecklistResponse.status).toBe(201);
+    expect(createChecklistResponse.body.projectChecklist).toMatchObject({
+      sourceChecklistTemplateId: createTemplateResponse.body.checklistTemplate.id,
+      items: [
+        expect.objectContaining({
+          controlId: control.id,
+          controlVersionId: control.currentVersion.id,
+        }),
+      ],
+    });
+  });
+
+  it('refreshes old-version Checklist Items into new unchecked active items', async () => {
+    const { headers, organization } = await createSignedInOwner('checklist-refresh-owner');
+    const ownerMembership = await getFirstMembership(organization.id);
+    const project = await createProject({
+      headers,
+      organizationSlug: organization.slug,
+      projectOwnerMemberId: ownerMembership.id,
+    });
+    const control = await createActiveControl({
+      headers,
+      organizationSlug: organization.slug,
+      title: 'Verify rollback plan',
+    });
+    const checklistResponse = await createProjectChecklist({
+      controlIds: [control.id],
+      headers,
+      name: 'Refresh checklist',
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+    const originalItemId = checklistResponse.body.projectChecklist.items[0]?.id;
+
+    expect(originalItemId).toBeTruthy();
+
+    if (!originalItemId) {
+      throw new Error('Expected a Checklist Item.');
+    }
+
+    const checkedResponse = await setChecklistItemChecked({
+      checked: true,
+      checklistItemId: originalItemId,
+      headers,
+      organizationSlug: organization.slug,
+    });
+    const updatedControl = await publishControlUpdate({
+      businessMeaning: 'Release teams must verify rollback ownership before completion.',
+      controlId: control.id,
+      headers,
+      organizationSlug: organization.slug,
+      title: 'Verify rollback ownership',
+    });
+    const refreshResponse = await refreshChecklistItem({
+      checklistItemId: originalItemId,
+      headers,
+      organizationSlug: organization.slug,
+    });
+
+    expect(checkedResponse.body.projectChecklist).toMatchObject({ isComplete: true });
+    expect(refreshResponse.status).toBe(200);
+    expect(refreshResponse.body.projectChecklist).toMatchObject({ isComplete: false });
+    expect(refreshResponse.body.projectChecklist.items).toEqual([
+      expect.objectContaining({
+        checked: true,
+        controlVersionId: control.currentVersion.id,
+        id: originalItemId,
+        itemStatus: 'superseded',
+      }),
+      expect.objectContaining({
+        checked: false,
+        controlTitle: 'Verify rollback ownership',
+        controlVersionId: updatedControl.currentVersion.id,
+        controlVersionNumber: 2,
+        itemStatus: 'active',
+      }),
+    ]);
+  });
+
+  it('retains removed Checklist Items and excludes them from completion', async () => {
+    const { headers, organization } = await createSignedInOwner('checklist-remove-owner');
+    const ownerMembership = await getFirstMembership(organization.id);
+    const project = await createProject({
+      headers,
+      organizationSlug: organization.slug,
+      projectOwnerMemberId: ownerMembership.id,
+    });
+    const checkedControl = await createActiveControl({
+      headers,
+      organizationSlug: organization.slug,
+      title: 'Verify checked requirement',
+    });
+    const removedControl = await createActiveControl({
+      headers,
+      organizationSlug: organization.slug,
+      title: 'Verify removed requirement',
+    });
+    const checklistResponse = await createProjectChecklist({
+      controlIds: [checkedControl.id, removedControl.id],
+      headers,
+      name: 'Removal checklist',
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+    const checkedItemId = checklistResponse.body.projectChecklist.items.find(
+      (item) => item.controlId === checkedControl.id,
+    )?.id;
+    const removedItemId = checklistResponse.body.projectChecklist.items.find(
+      (item) => item.controlId === removedControl.id,
+    )?.id;
+
+    expect(checkedItemId).toBeTruthy();
+    expect(removedItemId).toBeTruthy();
+
+    if (!checkedItemId || !removedItemId) {
+      throw new Error('Expected Checklist Items.');
+    }
+
+    await setChecklistItemChecked({
+      checked: true,
+      checklistItemId: checkedItemId,
+      headers,
+      organizationSlug: organization.slug,
+    });
+
+    const removeResponse = await removeChecklistItem({
+      checklistItemId: removedItemId,
+      headers,
+      organizationSlug: organization.slug,
+    });
+    const checkRemovedResponse = await setChecklistItemChecked({
+      checked: true,
+      checklistItemId: removedItemId,
+      headers,
+      organizationSlug: organization.slug,
+    });
+
+    expect(removeResponse.status).toBe(200);
+    expect(removeResponse.body.projectChecklist).toMatchObject({ isComplete: true });
+    expect(removeResponse.body.projectChecklist.items).toEqual([
+      expect.objectContaining({
+        checked: true,
+        controlId: checkedControl.id,
+        itemStatus: 'active',
+      }),
+      expect.objectContaining({
+        checked: false,
+        controlId: removedControl.id,
+        id: removedItemId,
+        itemStatus: 'removed',
+      }),
+    ]);
+    expect(checkRemovedResponse.status).toBe(400);
+  });
+
+  it('lists, renames, archives, and restores Project Checklists', async () => {
+    const { headers, organization } = await createSignedInOwner('checklist-lifecycle-owner');
+    const ownerMembership = await getFirstMembership(organization.id);
+    const project = await createProject({
+      headers,
+      organizationSlug: organization.slug,
+      projectOwnerMemberId: ownerMembership.id,
+    });
+    const control = await createActiveControl({
+      headers,
+      organizationSlug: organization.slug,
+      title: 'Verify lifecycle control',
+    });
+    const createResponse = await createProjectChecklist({
+      controlIds: [control.id],
+      headers,
+      name: 'Lifecycle checklist',
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+    const projectChecklistId = createResponse.body.projectChecklist.id;
+    const itemId = createResponse.body.projectChecklist.items[0]?.id;
+
+    expect(itemId).toBeTruthy();
+
+    if (!itemId) {
+      throw new Error('Expected a Checklist Item.');
+    }
+
+    const listResponse = await listProjectChecklists({
+      headers,
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+    const renameResponse = await renameProjectChecklist({
+      headers,
+      name: 'Renamed lifecycle checklist',
+      organizationSlug: organization.slug,
+      projectChecklistId,
+    });
+    const archiveResponse = await archiveProjectChecklist({
+      headers,
+      organizationSlug: organization.slug,
+      projectChecklistId,
+    });
+    const archivedListResponse = await listProjectChecklists({
+      headers,
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+      status: 'archived',
+    });
+    const checkedArchivedResponse = await setChecklistItemChecked({
+      checked: true,
+      checklistItemId: itemId,
+      headers,
+      organizationSlug: organization.slug,
+    });
+    const restoreResponse = await restoreProjectChecklist({
+      headers,
+      organizationSlug: organization.slug,
+      projectChecklistId,
+    });
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.projectChecklists).toEqual([
+      expect.objectContaining({
+        id: projectChecklistId,
+        name: 'Lifecycle checklist',
+        status: 'active',
+      }),
+    ]);
+    expect(renameResponse.status).toBe(200);
+    expect(renameResponse.body.projectChecklist).toMatchObject({
+      id: projectChecklistId,
+      name: 'Renamed lifecycle checklist',
+      status: 'active',
+    });
+    expect(archiveResponse.status).toBe(200);
+    expect(archiveResponse.body.projectChecklist).toMatchObject({
+      id: projectChecklistId,
+      status: 'archived',
+    });
+    expect(archivedListResponse.status).toBe(200);
+    expect(archivedListResponse.body.projectChecklists).toEqual([
+      expect.objectContaining({
+        id: projectChecklistId,
+        name: 'Renamed lifecycle checklist',
+        status: 'archived',
+      }),
+    ]);
+    expect(checkedArchivedResponse.status).toBe(400);
+    expect(restoreResponse.status).toBe(200);
+    expect(restoreResponse.body.projectChecklist).toMatchObject({
+      id: projectChecklistId,
+      status: 'active',
+    });
+  });
+
+  it('renames, archives, lists, and restores Checklist Templates', async () => {
+    const { headers, organization } = await createSignedInOwner('checklist-template-lifecycle');
+    const control = await createActiveControl({
+      headers,
+      organizationSlug: organization.slug,
+      title: 'Verify template lifecycle',
+    });
+    const createResponse = await createChecklistTemplate({
+      controlIds: [control.id],
+      headers,
+      name: 'Template lifecycle',
+      organizationSlug: organization.slug,
+    });
+    const checklistTemplateId = createResponse.body.checklistTemplate.id;
+
+    const renameResponse = await renameChecklistTemplate({
+      checklistTemplateId,
+      headers,
+      name: 'Renamed template lifecycle',
+      organizationSlug: organization.slug,
+    });
+    const archiveResponse = await archiveChecklistTemplate({
+      checklistTemplateId,
+      headers,
+      organizationSlug: organization.slug,
+    });
+    const archivedListResponse = await listChecklistTemplates({
+      headers,
+      organizationSlug: organization.slug,
+      status: 'archived',
+    });
+    const reusedNameResponse = await createChecklistTemplate({
+      controlIds: [control.id],
+      headers,
+      name: 'Renamed template lifecycle',
+      organizationSlug: organization.slug,
+    });
+    const conflictingRestoreResponse = await restoreChecklistTemplate({
+      checklistTemplateId,
+      headers,
+      organizationSlug: organization.slug,
+    });
+
+    expect(renameResponse.status).toBe(200);
+    expect(renameResponse.body.checklistTemplate).toMatchObject({
+      id: checklistTemplateId,
+      name: 'Renamed template lifecycle',
+      status: 'active',
+    });
+    expect(archiveResponse.status).toBe(200);
+    expect(archiveResponse.body.checklistTemplate).toMatchObject({
+      id: checklistTemplateId,
+      status: 'archived',
+    });
+    expect(archivedListResponse.status).toBe(200);
+    expect(archivedListResponse.body.checklistTemplates).toEqual([
+      expect.objectContaining({
+        id: checklistTemplateId,
+        name: 'Renamed template lifecycle',
+        status: 'archived',
+      }),
+    ]);
+    expect(reusedNameResponse.status).toBe(201);
+    expect(conflictingRestoreResponse.status).toBe(400);
+  });
+
+  it('adds active Controls and enforces Archived Control removal per Project Checklist', async () => {
+    const { headers, organization } = await createSignedInOwner('checklist-add-item-owner');
+    const ownerMembership = await getFirstMembership(organization.id);
+    const project = await createProject({
+      headers,
+      organizationSlug: organization.slug,
+      projectOwnerMemberId: ownerMembership.id,
+    });
+    const firstControl = await createActiveControl({
+      headers,
+      organizationSlug: organization.slug,
+      title: 'Verify first add item control',
+    });
+    const secondControl = await createActiveControl({
+      headers,
+      organizationSlug: organization.slug,
+      title: 'Verify second add item control',
+    });
+    const createResponse = await createProjectChecklist({
+      controlIds: [firstControl.id],
+      headers,
+      name: 'Add item checklist',
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+    const projectChecklistId = createResponse.body.projectChecklist.id;
+
+    const addResponse = await addChecklistItem({
+      controlId: secondControl.id,
+      headers,
+      organizationSlug: organization.slug,
+      projectChecklistId,
+    });
+    const duplicateAddResponse = await addChecklistItem({
+      controlId: secondControl.id,
+      headers,
+      organizationSlug: organization.slug,
+      projectChecklistId,
+    });
+    const archiveControlResponse = await archiveControl({
+      controlId: secondControl.id,
+      headers,
+      organizationSlug: organization.slug,
+    });
+    const archivedAddResponse = await addChecklistItem({
+      controlId: secondControl.id,
+      headers,
+      organizationSlug: organization.slug,
+      projectChecklistId,
+    });
+    const enforceResponse = await enforceArchivedControl({
+      controlId: secondControl.id,
+      headers,
+      organizationSlug: organization.slug,
+      projectChecklistId,
+    });
+
+    expect(addResponse.status).toBe(201);
+    expect(addResponse.body.projectChecklist.items).toEqual([
+      expect.objectContaining({ controlId: firstControl.id, itemStatus: 'active' }),
+      expect.objectContaining({
+        checked: false,
+        controlId: secondControl.id,
+        controlVersionId: secondControl.currentVersion.id,
+        itemStatus: 'active',
+      }),
+    ]);
+    expect(duplicateAddResponse.status).toBe(400);
+    expect(archiveControlResponse.status).toBe(200);
+    expect(archivedAddResponse.status).toBe(400);
+    expect(enforceResponse.status).toBe(200);
+    expect(enforceResponse.body.projectChecklist.items).toEqual([
+      expect.objectContaining({ controlId: firstControl.id, itemStatus: 'active' }),
+      expect.objectContaining({ controlId: secondControl.id, itemStatus: 'removed' }),
+    ]);
+  });
+
+  it('keeps Project Checklists on Archived Projects read-only', async () => {
+    const { headers, organization } = await createSignedInOwner('checklist-archived-project');
+    const ownerMembership = await getFirstMembership(organization.id);
+    const project = await createProject({
+      headers,
+      organizationSlug: organization.slug,
+      projectOwnerMemberId: ownerMembership.id,
+    });
+    const control = await createActiveControl({
+      headers,
+      organizationSlug: organization.slug,
+      title: 'Verify archived project control',
+    });
+    const extraControl = await createActiveControl({
+      headers,
+      organizationSlug: organization.slug,
+      title: 'Verify archived project extra control',
+    });
+    const createResponse = await createProjectChecklist({
+      controlIds: [control.id],
+      headers,
+      name: 'Archived project checklist',
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+    const projectChecklistId = createResponse.body.projectChecklist.id;
+    const checklistItemId = createResponse.body.projectChecklist.items[0]?.id;
+
+    expect(checklistItemId).toBeTruthy();
+
+    if (!checklistItemId) {
+      throw new Error('Expected a Checklist Item.');
+    }
+
+    const archiveProjectResponse = await archiveProject({
+      headers,
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+    const listResponse = await listProjectChecklists({
+      headers,
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+    const createOnArchivedProjectResponse = await createProjectChecklist({
+      controlIds: [extraControl.id],
+      headers,
+      name: 'Blocked archived project checklist',
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+    const checkResponse = await setChecklistItemChecked({
+      checked: true,
+      checklistItemId,
+      headers,
+      organizationSlug: organization.slug,
+    });
+    const addResponse = await addChecklistItem({
+      controlId: extraControl.id,
+      headers,
+      organizationSlug: organization.slug,
+      projectChecklistId,
+    });
+    const renameResponse = await renameProjectChecklist({
+      headers,
+      name: 'Blocked rename',
+      organizationSlug: organization.slug,
+      projectChecklistId,
+    });
+    const archiveChecklistResponse = await archiveProjectChecklist({
+      headers,
+      organizationSlug: organization.slug,
+      projectChecklistId,
+    });
+
+    expect(archiveProjectResponse.status).toBe(200);
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.projectChecklists).toEqual([
+      expect.objectContaining({
+        id: projectChecklistId,
+        status: 'active',
+      }),
+    ]);
+    expect(createOnArchivedProjectResponse.status).toBe(404);
+    expect(checkResponse.status).toBe(400);
+    expect(addResponse.status).toBe(400);
+    expect(renameResponse.status).toBe(400);
+    expect(archiveChecklistResponse.status).toBe(400);
+  });
+});

--- a/apps/backend-hono/test/checklists.spec.ts
+++ b/apps/backend-hono/test/checklists.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { db } from '../src/db/client';
 import { checklistItems, members, users } from '../src/db/schema';
+import { createChecklistTemplateForMember } from '../src/contexts/checklists/checklists';
 import { auth } from '../src/lib/auth';
 import { callTRPC } from './trpc-test-utils';
 
@@ -543,6 +544,26 @@ describe('Project Checklists', () => {
         itemStatus: 'active',
       }),
     ]);
+  });
+
+  it('rejects empty Checklist Templates at the domain service boundary', async () => {
+    const { organization } = await createSignedInOwner('checklist-empty-template-owner');
+    const ownerMembership = await getFirstMembership(organization.id);
+
+    await expect(
+      createChecklistTemplateForMember(
+        {
+          id: ownerMembership.id,
+          organizationId: organization.id,
+          organizationSlug: organization.slug,
+          role: 'owner',
+        },
+        {
+          controlIds: [],
+          name: 'Empty template',
+        },
+      ),
+    ).rejects.toThrow('Checklist Template needs at least one selected Control.');
   });
 
   it('rejects Checklist Items whose Control Version belongs to another Control', async () => {

--- a/apps/backend-hono/test/draft-controls.spec.ts
+++ b/apps/backend-hono/test/draft-controls.spec.ts
@@ -329,6 +329,17 @@ async function submitControlProposedUpdatePublishRequest(
   );
 }
 
+async function rejectControlProposedUpdateRequest(
+  organizationSlug: string,
+  controlId: string,
+  proposedUpdateId: string,
+  headers: Headers,
+) {
+  return callTRPC(headers, (caller) =>
+    caller.controls.rejectProposedUpdate({ controlId, organizationSlug, proposedUpdateId }),
+  );
+}
+
 beforeEach(() => {
   const originalFetch = globalThis.fetch;
 
@@ -1501,6 +1512,69 @@ describe('Draft Controls', () => {
       },
       status: 400,
     });
+  });
+
+  it('lets Organization owners and admins reject open proposed Control updates', async () => {
+    const { headers: ownerHeaders, organization } =
+      await createSignedInOwner('proposal-reject-owner');
+    const member = await createSignedInMember({
+      ownerHeaders,
+      organizationId: organization.id,
+      prefix: 'proposal-reject-member',
+      role: 'member',
+    });
+
+    const createResponse = await createDraftControlRequest(organization.slug, ownerHeaders, {
+      controlCode: 'AUTH-040',
+      title: 'Require MFA before rejected update',
+    });
+    const draftControl = createResponse.body.draftControl as { id: string };
+    const publishResponse = await publishDraftControlRequest(
+      organization.slug,
+      draftControl.id,
+      ownerHeaders,
+    );
+    const control = publishResponse.body.control as { id: string };
+
+    const proposedResponse = await createControlProposedUpdateRequest(
+      organization.slug,
+      control.id,
+      member.headers,
+      {
+        ...completePublishBody,
+        businessMeaning: 'Rejected release assurance meaning.',
+        controlCode: 'AUTH-040',
+        title: 'Require MFA after rejected update',
+      },
+    );
+    const proposedUpdate = proposedResponse.body.proposedUpdate as { id: string };
+
+    await expect(
+      rejectControlProposedUpdateRequest(
+        organization.slug,
+        control.id,
+        proposedUpdate.id,
+        member.headers,
+      ),
+    ).resolves.toMatchObject({
+      body: { error: 'Only Organization owners and admins can reject proposed Control updates.' },
+      status: 403,
+    });
+
+    await expect(
+      rejectControlProposedUpdateRequest(
+        organization.slug,
+        control.id,
+        proposedUpdate.id,
+        ownerHeaders,
+      ),
+    ).resolves.toMatchObject({
+      body: { rejected: true },
+      status: 200,
+    });
+    await expect(
+      listControlProposedUpdatesRequest(organization.slug, ownerHeaders),
+    ).resolves.toMatchObject({ body: { proposedUpdates: [] }, status: 200 });
   });
 
   it('restricts archived Control access and archive actions to Organization owners and admins', async () => {

--- a/apps/backend-hono/test/project-detail.spec.ts
+++ b/apps/backend-hono/test/project-detail.spec.ts
@@ -172,6 +172,10 @@ async function updateProject(
   );
 }
 
+async function listOrganizationMembers(headers: Headers, organizationSlug: string) {
+  return callTRPC(headers, (caller) => caller.organizations.members({ organizationSlug }));
+}
+
 describe('Project detail API', () => {
   it('requires authentication', async () => {
     const response = await callTRPC(undefined, (caller) =>
@@ -297,6 +301,56 @@ describe('Project detail API', () => {
 
     expect(renamedProject.status).toBe(200);
     expect(renamedProject.body.project?.slug).toBe('vendor-risk');
+  });
+
+  it('lets Organization owners set an accepted member as Project Owner', async () => {
+    const owner = await createSignedInOwner('project-settings-invited-owner');
+    const memberCredentials = createCredentials('project-settings-invited-member');
+
+    await signUpUser(memberCredentials);
+
+    const invitation = await auth.api.createInvitation({
+      body: {
+        email: memberCredentials.email,
+        organizationId: owner.organization.id,
+        role: 'member',
+      },
+      headers: owner.headers,
+    });
+    const memberHeaders = await signInUser(memberCredentials);
+
+    await auth.api.acceptInvitation({
+      body: { invitationId: invitation.id },
+      headers: memberHeaders,
+    });
+
+    await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'vendor-risk',
+    });
+
+    const membersResponse = await listOrganizationMembers(owner.headers, owner.organization.slug);
+    const projectOwner = membersResponse.body.members.find(
+      (organizationMember: { email: string }) =>
+        organizationMember.email === memberCredentials.email,
+    ) as { id: string } | undefined;
+
+    expect(projectOwner?.id).toBeTruthy();
+
+    const response = await updateProject(owner.headers, owner.organization.slug, 'vendor-risk', {
+      description: 'Updated governance work for critical vendor risk.',
+      name: 'Critical Vendor Risk',
+      projectOwnerMemberId: projectOwner?.id,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.project).toMatchObject({
+      projectOwner: {
+        email: memberCredentials.email,
+        id: projectOwner?.id,
+      },
+    });
   });
 
   it('prevents members from mutating Project settings', async () => {

--- a/apps/backend-hono/test/projects.spec.ts
+++ b/apps/backend-hono/test/projects.spec.ts
@@ -114,6 +114,10 @@ async function listProjectsRequest(
   return callTRPC(headers, (caller) => caller.projects.list({ organizationSlug, status }));
 }
 
+async function listOrganizationMembersRequest(organizationSlug: string, headers: Headers) {
+  return callTRPC(headers, (caller) => caller.organizations.members({ organizationSlug }));
+}
+
 beforeEach(() => {
   const originalFetch = globalThis.fetch;
 
@@ -216,6 +220,51 @@ describe('organization projects', () => {
     expect(listResponse.status).toBe(200);
     expect(listResponse.body).toMatchObject({
       projects: [{ slug: 'vendor-review' }],
+    });
+  });
+
+  it('allows accepted Organization members to be assigned as Project Owner', async () => {
+    const { headers: ownerHeaders, organization } =
+      await createSignedInOwner('project-invite-owner');
+    const member = createCredentials('project-invite-member');
+
+    await signUpUser(member);
+
+    const invitation = await auth.api.createInvitation({
+      body: {
+        email: member.email,
+        organizationId: organization.id,
+        role: 'member',
+      },
+      headers: ownerHeaders,
+    });
+    const memberHeaders = await signInUser(member);
+
+    await auth.api.acceptInvitation({
+      body: { invitationId: invitation.id },
+      headers: memberHeaders,
+    });
+
+    const membersResponse = await listOrganizationMembersRequest(organization.slug, ownerHeaders);
+    const projectOwner = membersResponse.body.members.find(
+      (organizationMember: { email: string }) => organizationMember.email === member.email,
+    ) as { id: string } | undefined;
+
+    expect(projectOwner?.id).toBeTruthy();
+
+    const createResponse = await createProjectRequest(organization.slug, ownerHeaders, {
+      description: 'Project owned by an invited Organization member.',
+      name: 'Invited Owner',
+      projectOwnerMemberId: projectOwner?.id,
+      slug: 'invited-owner',
+    });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body.project).toMatchObject({
+      projectOwner: {
+        email: member.email,
+        id: projectOwner?.id,
+      },
     });
   });
 

--- a/apps/web/src/features/checklists/api/checklist-api.ts
+++ b/apps/web/src/features/checklists/api/checklist-api.ts
@@ -1,0 +1,15 @@
+import type { RouterOutputs } from '@/lib/trpc';
+
+export type ChecklistTemplate = NonNullable<
+  RouterOutputs['checklists']['listTemplates']['checklistTemplates'][number]
+>;
+
+export type ProjectChecklist = NonNullable<
+  RouterOutputs['checklists']['listProjectChecklists']['projectChecklists'][number]
+>;
+
+export type ProjectChecklistItem = ProjectChecklist['items'][number];
+
+export function canManageChecklists(role: string | null) {
+  return role === 'owner' || role === 'admin';
+}

--- a/apps/web/src/features/checklists/components/project-checklists-section.tsx
+++ b/apps/web/src/features/checklists/components/project-checklists-section.tsx
@@ -1,0 +1,664 @@
+import { useState } from 'react';
+import type { SyntheticEvent } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { AlertCircle, Archive, CheckCircle2, Circle, Plus, RotateCcw, Trash2 } from 'lucide-react';
+import { humanizeAuthError } from '@/features/auth/api/auth-errors';
+import type { ChecklistTemplate, ProjectChecklist } from '@/features/checklists/api/checklist-api';
+import type { ControlListItem } from '@/features/controls/api/control-api';
+import { queryClient, trpc } from '@/lib/trpc';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+type ProjectChecklistsSectionProps = {
+  canManage: boolean;
+  currentMemberId: string | null;
+  organizationSlug: string;
+  projectArchived: boolean;
+  projectOwnerMemberId: string | null;
+  projectSlug: string;
+};
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleDateString(undefined, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+export function ProjectChecklistsSection({
+  canManage,
+  currentMemberId,
+  organizationSlug,
+  projectArchived,
+  projectOwnerMemberId,
+  projectSlug,
+}: ProjectChecklistsSectionProps) {
+  const [statusFilter, setStatusFilter] = useState<'active' | 'archived'>('active');
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const hasProjectIdentity = Boolean(organizationSlug && projectSlug);
+  const archivedView = statusFilter === 'archived';
+  const canManageActiveProject = canManage && !projectArchived;
+  const canCheckItems =
+    !projectArchived && Boolean(projectOwnerMemberId && projectOwnerMemberId === currentMemberId);
+
+  const projectChecklistQuery = useQuery(
+    trpc.checklists.listProjectChecklists.queryOptions(
+      { organizationSlug, projectSlug, status: statusFilter },
+      { enabled: hasProjectIdentity },
+    ),
+  );
+  const templateQuery = useQuery(
+    trpc.checklists.listTemplates.queryOptions(
+      { organizationSlug, status: 'active' },
+      { enabled: hasProjectIdentity && canManageActiveProject },
+    ),
+  );
+  const activeControlsQuery = useQuery(
+    trpc.controls.list.queryOptions(
+      { organizationSlug, status: 'active' },
+      { enabled: hasProjectIdentity && canManageActiveProject },
+    ),
+  );
+  const archivedControlsQuery = useQuery(
+    trpc.controls.list.queryOptions(
+      { organizationSlug, status: 'archived' },
+      { enabled: hasProjectIdentity && canManageActiveProject },
+    ),
+  );
+
+  const createProjectChecklistMutation = useMutation(
+    trpc.checklists.createProjectChecklist.mutationOptions({
+      onError: (caughtError) => {
+        setError(
+          humanizeAuthError(null, caughtError.message, 'Unable to create Project Checklist.'),
+        );
+      },
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+        setStatus('Project Checklist created.');
+      },
+    }),
+  );
+  const renameProjectChecklistMutation = useMutation(
+    trpc.checklists.renameProjectChecklist.mutationOptions({
+      onError: (caughtError) => {
+        setError(
+          humanizeAuthError(null, caughtError.message, 'Unable to rename Project Checklist.'),
+        );
+      },
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+        setStatus('Project Checklist renamed.');
+      },
+    }),
+  );
+  const archiveProjectChecklistMutation = useMutation(
+    trpc.checklists.archiveProjectChecklist.mutationOptions({
+      onError: (caughtError) => {
+        setError(
+          humanizeAuthError(null, caughtError.message, 'Unable to archive Project Checklist.'),
+        );
+      },
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+        setStatus('Project Checklist archived.');
+      },
+    }),
+  );
+  const restoreProjectChecklistMutation = useMutation(
+    trpc.checklists.restoreProjectChecklist.mutationOptions({
+      onError: (caughtError) => {
+        setError(
+          humanizeAuthError(null, caughtError.message, 'Unable to restore Project Checklist.'),
+        );
+      },
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+        setStatus('Project Checklist restored.');
+      },
+    }),
+  );
+  const addChecklistItemMutation = useMutation(
+    trpc.checklists.addChecklistItem.mutationOptions({
+      onError: (caughtError) => {
+        setError(humanizeAuthError(null, caughtError.message, 'Unable to add Checklist Item.'));
+      },
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+        setStatus('Checklist Item added.');
+      },
+    }),
+  );
+  const removeChecklistItemMutation = useMutation(
+    trpc.checklists.removeChecklistItem.mutationOptions({
+      onError: (caughtError) => {
+        setError(humanizeAuthError(null, caughtError.message, 'Unable to remove Checklist Item.'));
+      },
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+        setStatus('Checklist Item removed.');
+      },
+    }),
+  );
+  const refreshChecklistItemMutation = useMutation(
+    trpc.checklists.refreshChecklistItem.mutationOptions({
+      onError: (caughtError) => {
+        setError(humanizeAuthError(null, caughtError.message, 'Unable to refresh Checklist Item.'));
+      },
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+        setStatus('Checklist Item refreshed.');
+      },
+    }),
+  );
+  const enforceArchivedControlMutation = useMutation(
+    trpc.checklists.enforceArchivedControl.mutationOptions({
+      onError: (caughtError) => {
+        setError(
+          humanizeAuthError(null, caughtError.message, 'Unable to enforce Archived Control.'),
+        );
+      },
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+        setStatus('Archived Control enforced.');
+      },
+    }),
+  );
+  const setChecklistItemCheckedMutation = useMutation(
+    trpc.checklists.setChecklistItemChecked.mutationOptions({
+      onError: (caughtError) => {
+        setError(humanizeAuthError(null, caughtError.message, 'Unable to update Checklist Item.'));
+      },
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+      },
+    }),
+  );
+
+  const projectChecklists: ProjectChecklist[] = (
+    projectChecklistQuery.data?.projectChecklists ?? []
+  ).filter((checklist): checklist is ProjectChecklist => Boolean(checklist));
+  const templates: ChecklistTemplate[] = (templateQuery.data?.checklistTemplates ?? []).filter(
+    (template): template is ChecklistTemplate => Boolean(template),
+  );
+  const activeControls: ControlListItem[] = activeControlsQuery.data?.controls ?? [];
+  const archivedControls: ControlListItem[] = archivedControlsQuery.data?.controls ?? [];
+  const loadError =
+    projectChecklistQuery.error ??
+    templateQuery.error ??
+    activeControlsQuery.error ??
+    archivedControlsQuery.error;
+  const displayError =
+    error ??
+    (loadError
+      ? humanizeAuthError(null, loadError.message, 'Unable to load Project Checklists.')
+      : null);
+  const isLoading =
+    projectChecklistQuery.isPending ||
+    (canManageActiveProject &&
+      (templateQuery.isPending ||
+        activeControlsQuery.isPending ||
+        archivedControlsQuery.isPending));
+
+  const clearMessages = () => {
+    setError(null);
+    setStatus(null);
+  };
+
+  const handleCreateProjectChecklist = (event: SyntheticEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const name = String(formData.get('name') ?? '').trim();
+    const checklistTemplateId = String(formData.get('checklistTemplateId') ?? '');
+    const controlIds = formData.getAll('controlId').map((value) => String(value));
+
+    clearMessages();
+    createProjectChecklistMutation.mutate(
+      checklistTemplateId
+        ? { checklistTemplateId, name, organizationSlug, projectSlug }
+        : { controlIds, name, organizationSlug, projectSlug },
+      {
+        onSuccess: () => form.reset(),
+      },
+    );
+  };
+
+  const handleRenameProjectChecklist = (
+    event: SyntheticEvent<HTMLFormElement>,
+    checklist: ProjectChecklist,
+  ) => {
+    event.preventDefault();
+
+    const formData = new FormData(event.currentTarget);
+    const name = String(formData.get('name') ?? '').trim();
+
+    clearMessages();
+    renameProjectChecklistMutation.mutate({
+      name,
+      organizationSlug,
+      projectChecklistId: checklist.id,
+    });
+  };
+
+  const handleArchiveStateChange = (checklist: ProjectChecklist) => {
+    clearMessages();
+
+    if (archivedView) {
+      restoreProjectChecklistMutation.mutate({
+        organizationSlug,
+        projectChecklistId: checklist.id,
+      });
+      return;
+    }
+
+    archiveProjectChecklistMutation.mutate({
+      organizationSlug,
+      projectChecklistId: checklist.id,
+    });
+  };
+
+  const handleAddChecklistItem = (
+    event: SyntheticEvent<HTMLFormElement>,
+    checklist: ProjectChecklist,
+  ) => {
+    event.preventDefault();
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const controlId = String(formData.get('controlId') ?? '');
+
+    clearMessages();
+    addChecklistItemMutation.mutate(
+      { controlId, organizationSlug, projectChecklistId: checklist.id },
+      {
+        onSuccess: () => form.reset(),
+      },
+    );
+  };
+
+  const handleSetChecklistItemChecked = (checklistItemId: string, checked: boolean) => {
+    clearMessages();
+    setChecklistItemCheckedMutation.mutate({ checked, checklistItemId, organizationSlug });
+  };
+
+  const handleRemoveChecklistItem = (checklistItemId: string) => {
+    clearMessages();
+    removeChecklistItemMutation.mutate({ checklistItemId, organizationSlug });
+  };
+
+  const handleRefreshChecklistItem = (checklistItemId: string) => {
+    clearMessages();
+    refreshChecklistItemMutation.mutate({ checklistItemId, organizationSlug });
+  };
+
+  const handleEnforceArchivedControl = (checklist: ProjectChecklist, controlId: string) => {
+    clearMessages();
+    enforceArchivedControlMutation.mutate({
+      controlId,
+      organizationSlug,
+      projectChecklistId: checklist.id,
+    });
+  };
+
+  const emptyTitle = archivedView ? 'No archived Project Checklists' : 'No Project Checklists yet';
+  const emptyDescription = archivedView
+    ? 'Archived Project Checklists will appear here after they are hidden from active work.'
+    : 'Create a Project Checklist to start checking Controls for this Project.';
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold tracking-tight">Project Checklists</h2>
+          <p className="text-sm text-muted-foreground">
+            Project Owners check Controls; Organization owners and admins manage checklist
+            structure.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant={archivedView ? 'outline' : 'default'}
+            onClick={() => setStatusFilter('active')}
+          >
+            Active
+          </Button>
+          {canManage ? (
+            <Button
+              type="button"
+              variant={archivedView ? 'default' : 'outline'}
+              onClick={() => setStatusFilter('archived')}
+            >
+              Archived
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      {displayError ? (
+        <Alert variant="destructive">
+          <AlertCircle />
+          <AlertTitle>Something went wrong</AlertTitle>
+          <AlertDescription>{displayError}</AlertDescription>
+        </Alert>
+      ) : null}
+      {status ? (
+        <Alert>
+          <CheckCircle2 />
+          <AlertTitle>Done</AlertTitle>
+          <AlertDescription>{status}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      {canManageActiveProject && !archivedView ? (
+        <form className="rounded-xl border bg-card p-5" onSubmit={handleCreateProjectChecklist}>
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold">Create Project Checklist</h3>
+            <p className="text-sm text-muted-foreground">
+              Start from a Checklist Template or select active Controls directly.
+            </p>
+          </div>
+          <div className="mt-5 grid gap-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="project-checklist-name">Name</Label>
+                <Input id="project-checklist-name" name="name" required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="project-checklist-template">Checklist Template</Label>
+                <select
+                  id="project-checklist-template"
+                  name="checklistTemplateId"
+                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                >
+                  <option value="">Selected Controls</option>
+                  {templates.map((template) => (
+                    <option key={template.id} value={template.id}>
+                      {template.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>Controls</Label>
+              {activeControls.length === 0 ? (
+                <p className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+                  No active Controls are available for Project Checklists.
+                </p>
+              ) : (
+                <div className="grid gap-2 rounded-lg border p-3 md:grid-cols-2">
+                  {activeControls.map((control) => (
+                    <label
+                      key={control.id}
+                      className="flex items-start gap-3 rounded-md border bg-background p-3 text-sm"
+                    >
+                      <input
+                        className="mt-1 size-4"
+                        name="controlId"
+                        type="checkbox"
+                        value={control.id}
+                      />
+                      <span className="space-y-1">
+                        <span className="block font-medium">
+                          {control.controlCode} · {control.title}
+                        </span>
+                        <span className="block text-xs text-muted-foreground">
+                          v{control.currentVersion.versionNumber}
+                        </span>
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="mt-4 flex justify-end">
+            <Button
+              type="submit"
+              disabled={
+                createProjectChecklistMutation.isPending ||
+                (activeControls.length === 0 && templates.length === 0)
+              }
+            >
+              <Plus />
+              {createProjectChecklistMutation.isPending ? 'Creating...' : 'Create Checklist'}
+            </Button>
+          </div>
+        </form>
+      ) : null}
+
+      {projectArchived ? (
+        <Alert>
+          <Archive />
+          <AlertTitle>Archived Project</AlertTitle>
+          <AlertDescription>
+            Project Checklists are read-only while this Project is archived.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading Project Checklists...</p>
+      ) : projectChecklists.length === 0 ? (
+        <div className="rounded-xl border border-dashed p-8 text-center">
+          <h3 className="text-lg font-medium">{emptyTitle}</h3>
+          <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">{emptyDescription}</p>
+        </div>
+      ) : (
+        <div className="grid gap-4">
+          {projectChecklists.map((checklist) => {
+            const activeItems = checklist.items.filter((item) => item.itemStatus === 'active');
+            const completedCount = activeItems.filter((item) => item.checked).length;
+
+            return (
+              <article key={checklist.id} className="rounded-xl border bg-card p-5">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="space-y-1">
+                    <h3 className="text-base font-semibold">{checklist.name}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      {completedCount}/{activeItems.length} active Controls checked · Created{' '}
+                      {formatDate(checklist.createdAt)}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <span className="inline-flex h-9 items-center rounded-md border px-3 text-sm">
+                      {checklist.isComplete ? (
+                        <>
+                          <CheckCircle2 className="mr-2 size-4 text-green-600" />
+                          Complete
+                        </>
+                      ) : (
+                        <>
+                          <Circle className="mr-2 size-4 text-muted-foreground" />
+                          Open
+                        </>
+                      )}
+                    </span>
+                    {canManageActiveProject ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={
+                          archiveProjectChecklistMutation.isPending ||
+                          restoreProjectChecklistMutation.isPending
+                        }
+                        onClick={() => handleArchiveStateChange(checklist)}
+                      >
+                        {archivedView ? <RotateCcw /> : <Archive />}
+                        {archivedView ? 'Restore' : 'Archive'}
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
+
+                {canManageActiveProject && !archivedView ? (
+                  <form
+                    className="mt-4 flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-end"
+                    onSubmit={(event) => handleRenameProjectChecklist(event, checklist)}
+                  >
+                    <div className="flex-1 space-y-2">
+                      <Label htmlFor={`${checklist.id}-name`}>Checklist name</Label>
+                      <Input
+                        id={`${checklist.id}-name`}
+                        name="name"
+                        defaultValue={checklist.name}
+                      />
+                    </div>
+                    <Button
+                      type="submit"
+                      variant="outline"
+                      disabled={renameProjectChecklistMutation.isPending}
+                    >
+                      Rename
+                    </Button>
+                  </form>
+                ) : null}
+
+                <div className="mt-4 divide-y rounded-lg border">
+                  {checklist.items.length === 0 ? (
+                    <p className="p-4 text-sm text-muted-foreground">No Checklist Items.</p>
+                  ) : (
+                    checklist.items.map((item) => {
+                      const currentControl = activeControls.find(
+                        (control) => control.id === item.controlId,
+                      );
+                      const archivedControl = archivedControls.find(
+                        (control) => control.id === item.controlId,
+                      );
+                      const usesOldVersion =
+                        item.itemStatus === 'active' &&
+                        currentControl &&
+                        currentControl.currentVersion.id !== item.controlVersionId;
+                      const canAddOrRemoveItem =
+                        canManageActiveProject && item.itemStatus === 'active';
+
+                      return (
+                        <div
+                          key={item.id}
+                          className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
+                        >
+                          <label className="flex min-w-0 items-start gap-3">
+                            <input
+                              className="mt-1 size-4"
+                              type="checkbox"
+                              checked={item.checked}
+                              disabled={
+                                !canCheckItems ||
+                                item.itemStatus !== 'active' ||
+                                setChecklistItemCheckedMutation.isPending
+                              }
+                              onChange={(event) =>
+                                handleSetChecklistItemChecked(item.id, event.target.checked)
+                              }
+                            />
+                            <span className="min-w-0 space-y-1">
+                              <span className="block text-sm font-medium">
+                                {item.controlCode} · {item.controlTitle}
+                              </span>
+                              <span className="block text-xs text-muted-foreground">
+                                Checklist Item {item.itemStatus} · Control Version v
+                                {item.controlVersionNumber}
+                                {usesOldVersion
+                                  ? ` · latest v${currentControl.currentVersion.versionNumber}`
+                                  : ''}
+                                {archivedControl ? ' · Archived Control' : ''}
+                              </span>
+                            </span>
+                          </label>
+                          {canAddOrRemoveItem ? (
+                            <div className="flex flex-wrap gap-2 sm:justify-end">
+                              {usesOldVersion ? (
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  size="sm"
+                                  disabled={refreshChecklistItemMutation.isPending}
+                                  onClick={() => handleRefreshChecklistItem(item.id)}
+                                >
+                                  <RotateCcw />
+                                  Refresh
+                                </Button>
+                              ) : null}
+                              {archivedControl ? (
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  size="sm"
+                                  disabled={enforceArchivedControlMutation.isPending}
+                                  onClick={() =>
+                                    handleEnforceArchivedControl(checklist, item.controlId)
+                                  }
+                                >
+                                  <Archive />
+                                  Enforce Archived
+                                </Button>
+                              ) : null}
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                disabled={removeChecklistItemMutation.isPending}
+                                onClick={() => handleRemoveChecklistItem(item.id)}
+                              >
+                                <Trash2 />
+                                Remove
+                              </Button>
+                            </div>
+                          ) : null}
+                        </div>
+                      );
+                    })
+                  )}
+                </div>
+
+                {canManageActiveProject && !archivedView ? (
+                  <form
+                    className="mt-4 flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-end"
+                    onSubmit={(event) => handleAddChecklistItem(event, checklist)}
+                  >
+                    <div className="flex-1 space-y-2">
+                      <Label htmlFor={`${checklist.id}-control`}>Add Control</Label>
+                      <select
+                        id={`${checklist.id}-control`}
+                        name="controlId"
+                        required
+                        className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                      >
+                        <option value="">Select Control</option>
+                        {activeControls
+                          .filter(
+                            (control) => !activeItems.some((item) => item.controlId === control.id),
+                          )
+                          .map((control) => (
+                            <option key={control.id} value={control.id}>
+                              {control.controlCode} · {control.title}
+                            </option>
+                          ))}
+                      </select>
+                    </div>
+                    <Button
+                      type="submit"
+                      variant="outline"
+                      disabled={addChecklistItemMutation.isPending}
+                    >
+                      <Plus />
+                      Add
+                    </Button>
+                  </form>
+                ) : null}
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/features/checklists/pages/checklists.tsx
+++ b/apps/web/src/features/checklists/pages/checklists.tsx
@@ -1,0 +1,387 @@
+import { useState } from 'react';
+import type { SyntheticEvent } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { AlertCircle, Archive, CheckCircle2, ListChecks, Plus, RotateCcw } from 'lucide-react';
+import { useParams, useSearchParams } from 'react-router';
+import { humanizeAuthError } from '@/features/auth/api/auth-errors';
+import {
+  canManageChecklists,
+  type ChecklistTemplate,
+} from '@/features/checklists/api/checklist-api';
+import type { ControlListItem } from '@/features/controls/api/control-api';
+import { queryClient, trpc } from '@/lib/trpc';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleDateString(undefined, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function isArchivedView(value: string | null) {
+  return value === 'archived';
+}
+
+export function ChecklistsPage() {
+  const { organizationSlug } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const archivedView = isArchivedView(searchParams.get('status'));
+  const checklistStatus = archivedView ? 'archived' : 'active';
+  const hasOrganization = Boolean(organizationSlug);
+
+  const resolutionQuery = useQuery(
+    trpc.organizations.membershipResolution.queryOptions(undefined, { enabled: hasOrganization }),
+  );
+  const organization = resolutionQuery.data?.organizations.find(
+    (org) => org.slug === organizationSlug,
+  );
+  const canManage = canManageChecklists(organization?.role ?? null);
+
+  const templateQuery = useQuery(
+    trpc.checklists.listTemplates.queryOptions(
+      { organizationSlug: organizationSlug ?? '', status: checklistStatus },
+      { enabled: hasOrganization && canManage },
+    ),
+  );
+  const controlQuery = useQuery(
+    trpc.controls.list.queryOptions(
+      { organizationSlug: organizationSlug ?? '', status: 'active' },
+      { enabled: hasOrganization && canManage && !archivedView },
+    ),
+  );
+
+  const createTemplateMutation = useMutation(
+    trpc.checklists.createTemplate.mutationOptions({
+      onError: (caughtError) => {
+        setError(
+          humanizeAuthError(null, caughtError.message, 'Unable to create Checklist Template.'),
+        );
+      },
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+        setStatus('Checklist Template created.');
+      },
+    }),
+  );
+  const renameTemplateMutation = useMutation(
+    trpc.checklists.renameTemplate.mutationOptions({
+      onError: (caughtError) => {
+        setError(
+          humanizeAuthError(null, caughtError.message, 'Unable to rename Checklist Template.'),
+        );
+      },
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+        setStatus('Checklist Template renamed.');
+      },
+    }),
+  );
+  const archiveTemplateMutation = useMutation(
+    trpc.checklists.archiveTemplate.mutationOptions({
+      onError: (caughtError) => {
+        setError(
+          humanizeAuthError(null, caughtError.message, 'Unable to archive Checklist Template.'),
+        );
+      },
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+        setStatus('Checklist Template archived.');
+      },
+    }),
+  );
+  const restoreTemplateMutation = useMutation(
+    trpc.checklists.restoreTemplate.mutationOptions({
+      onError: (caughtError) => {
+        setError(
+          humanizeAuthError(null, caughtError.message, 'Unable to restore Checklist Template.'),
+        );
+      },
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+        setStatus('Checklist Template restored.');
+      },
+    }),
+  );
+
+  const templates: ChecklistTemplate[] = (templateQuery.data?.checklistTemplates ?? []).filter(
+    (template): template is ChecklistTemplate => Boolean(template),
+  );
+  const controls: ControlListItem[] = controlQuery.data?.controls ?? [];
+  const loadError = resolutionQuery.error ?? templateQuery.error ?? controlQuery.error;
+  const displayError =
+    error ??
+    (loadError
+      ? humanizeAuthError(null, loadError.message, 'Unable to load Checklist Templates.')
+      : null);
+  const isLoading =
+    hasOrganization &&
+    (resolutionQuery.isPending ||
+      (canManage && templateQuery.isPending) ||
+      (canManage && !archivedView && controlQuery.isPending));
+  const emptyTitle = archivedView
+    ? 'No archived Checklist Templates'
+    : 'No Checklist Templates yet';
+  const emptyDescription = archivedView
+    ? 'Archived Checklist Templates will appear here after they are hidden from new Project use.'
+    : 'Create reusable Checklist Templates from active Controls.';
+
+  const clearMessages = () => {
+    setError(null);
+    setStatus(null);
+  };
+
+  const handleCreateTemplate = (event: SyntheticEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!organizationSlug) return;
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const name = String(formData.get('name') ?? '').trim();
+    const controlIds = formData.getAll('controlId').map((value) => String(value));
+
+    clearMessages();
+    createTemplateMutation.mutate(
+      { controlIds, name, organizationSlug },
+      {
+        onSuccess: () => form.reset(),
+      },
+    );
+  };
+
+  const handleRenameTemplate = (
+    event: SyntheticEvent<HTMLFormElement>,
+    template: ChecklistTemplate,
+  ) => {
+    event.preventDefault();
+    if (!organizationSlug) return;
+
+    const formData = new FormData(event.currentTarget);
+    const name = String(formData.get('name') ?? '').trim();
+
+    clearMessages();
+    renameTemplateMutation.mutate({ checklistTemplateId: template.id, name, organizationSlug });
+  };
+
+  const handleArchiveStateChange = (template: ChecklistTemplate) => {
+    if (!organizationSlug) return;
+
+    clearMessages();
+
+    if (archivedView) {
+      restoreTemplateMutation.mutate({ checklistTemplateId: template.id, organizationSlug });
+      return;
+    }
+
+    archiveTemplateMutation.mutate({ checklistTemplateId: template.id, organizationSlug });
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-6">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight">Checklists</h1>
+          <p className="text-sm text-muted-foreground">
+            {archivedView
+              ? 'Review Checklist Templates hidden from new Project Checklist creation.'
+              : 'Manage reusable Checklist Templates for Project governance work.'}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant={archivedView ? 'outline' : 'default'}
+            onClick={() => setSearchParams({})}
+          >
+            Active
+          </Button>
+          {canManage ? (
+            <Button
+              type="button"
+              variant={archivedView ? 'default' : 'outline'}
+              onClick={() => setSearchParams({ status: 'archived' })}
+            >
+              Archived
+            </Button>
+          ) : null}
+        </div>
+      </header>
+
+      {displayError ? (
+        <Alert variant="destructive">
+          <AlertCircle />
+          <AlertTitle>Something went wrong</AlertTitle>
+          <AlertDescription>{displayError}</AlertDescription>
+        </Alert>
+      ) : null}
+      {status ? (
+        <Alert>
+          <CheckCircle2 />
+          <AlertTitle>Done</AlertTitle>
+          <AlertDescription>{status}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      {!canManage && !resolutionQuery.isPending ? (
+        <Alert>
+          <ListChecks />
+          <AlertTitle>Checklist Templates are restricted</AlertTitle>
+          <AlertDescription>
+            Only Organization owners and admins can view and manage Checklist Templates.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {canManage && !archivedView ? (
+        <section className="rounded-xl border bg-card p-5">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold">Create Checklist Template</h2>
+            <p className="text-sm text-muted-foreground">
+              Select active Controls that should be copied into new Project Checklists.
+            </p>
+          </div>
+          <form className="mt-5 grid gap-4" onSubmit={handleCreateTemplate}>
+            <div className="space-y-2">
+              <Label htmlFor="checklist-template-name">Name</Label>
+              <Input id="checklist-template-name" name="name" required />
+            </div>
+            <div className="space-y-2">
+              <Label>Controls</Label>
+              {controls.length === 0 ? (
+                <p className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+                  No active Controls are available for Checklist Templates.
+                </p>
+              ) : (
+                <div className="grid gap-2 rounded-lg border p-3 md:grid-cols-2">
+                  {controls.map((control) => (
+                    <label
+                      key={control.id}
+                      className="flex items-start gap-3 rounded-md border bg-background p-3 text-sm"
+                    >
+                      <input
+                        className="mt-1 size-4"
+                        name="controlId"
+                        type="checkbox"
+                        value={control.id}
+                      />
+                      <span className="space-y-1">
+                        <span className="block font-medium">
+                          {control.controlCode} · {control.title}
+                        </span>
+                        <span className="block text-xs text-muted-foreground">
+                          v{control.currentVersion.versionNumber}
+                        </span>
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+            <div className="flex justify-end">
+              <Button
+                type="submit"
+                disabled={createTemplateMutation.isPending || controls.length === 0}
+              >
+                <Plus />
+                {createTemplateMutation.isPending ? 'Creating...' : 'Create Template'}
+              </Button>
+            </div>
+          </form>
+        </section>
+      ) : null}
+
+      {canManage ? (
+        <section className="space-y-3">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold">
+              {archivedView ? 'Archived Checklist Templates' : 'Active Checklist Templates'}
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              {archivedView
+                ? 'Archived templates are retained but unavailable for new Project Checklists.'
+                : 'Templates can be renamed or archived without changing existing Project Checklists.'}
+            </p>
+          </div>
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground">Loading Checklist Templates...</p>
+          ) : templates.length === 0 ? (
+            <div className="rounded-xl border border-dashed p-8 text-center">
+              <h3 className="text-lg font-medium">{emptyTitle}</h3>
+              <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
+                {emptyDescription}
+              </p>
+            </div>
+          ) : (
+            <div className="grid gap-3">
+              {templates.map((template) => (
+                <article key={template.id} className="rounded-xl border bg-card p-5">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="space-y-1">
+                      <h3 className="text-base font-semibold">{template.name}</h3>
+                      <p className="text-sm text-muted-foreground">
+                        {template.controls.length} Controls · Created{' '}
+                        {formatDate(template.createdAt)}
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={
+                        archiveTemplateMutation.isPending || restoreTemplateMutation.isPending
+                      }
+                      onClick={() => handleArchiveStateChange(template)}
+                    >
+                      {archivedView ? <RotateCcw /> : <Archive />}
+                      {archivedView ? 'Restore' : 'Archive'}
+                    </Button>
+                  </div>
+                  <div className="mt-4 grid gap-2 md:grid-cols-2">
+                    {template.controls.map((control) => (
+                      <div key={control.controlId} className="rounded-lg border bg-muted/30 p-3">
+                        <p className="text-sm font-medium">
+                          {control.controlCode} · {control.controlTitle}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          Current Control Version v{control.currentVersionNumber}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                  {!archivedView ? (
+                    <form
+                      className="mt-4 flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-end"
+                      onSubmit={(event) => handleRenameTemplate(event, template)}
+                    >
+                      <div className="flex-1 space-y-2">
+                        <Label htmlFor={`${template.id}-name`}>Template name</Label>
+                        <Input
+                          id={`${template.id}-name`}
+                          name="name"
+                          defaultValue={template.name}
+                        />
+                      </div>
+                      <Button
+                        type="submit"
+                        variant="outline"
+                        disabled={renameTemplateMutation.isPending}
+                      >
+                        Rename
+                      </Button>
+                    </form>
+                  ) : null}
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/controls/pages/controls.tsx
+++ b/apps/web/src/features/controls/pages/controls.tsx
@@ -200,6 +200,18 @@ export function ControlsPage() {
       onSettled: () => setPublishingProposalId(null),
     }),
   );
+  const rejectProposedUpdateMutation = useMutation(
+    trpc.controls.rejectProposedUpdate.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+        setStatus('Proposed update rejected.');
+      },
+      onError: (caughtError) => {
+        setError(humanizeAuthError(null, caughtError.message, 'Unable to reject proposed update.'));
+      },
+      onSettled: () => setReviewingRequestId(null),
+    }),
+  );
   const submitProposedUpdateMutation = useMutation(
     trpc.controls.submitProposedUpdatePublishRequest.mutationOptions({
       onSuccess: () => {
@@ -433,6 +445,19 @@ export function ControlsPage() {
     setError(null);
     setStatus(null);
     publishProposedUpdateMutation.mutate({
+      controlId: proposedUpdate.controlId,
+      organizationSlug,
+      proposedUpdateId: proposedUpdate.id,
+    });
+  };
+
+  const handleRejectControlProposedUpdate = (proposedUpdate: ControlProposedUpdateListItem) => {
+    if (!organizationSlug) return;
+
+    setReviewingRequestId(proposedUpdate.id);
+    setError(null);
+    setStatus(null);
+    rejectProposedUpdateMutation.mutate({
       controlId: proposedUpdate.controlId,
       organizationSlug,
       proposedUpdateId: proposedUpdate.id,
@@ -761,32 +786,58 @@ export function ControlsPage() {
                           </p>
                         </div>
                         {approvalPolicyEnabled ? (
-                          <Button
-                            type="button"
-                            disabled={
-                              publishingProposalId === proposedUpdate.id ||
-                              Boolean(submittedProposedUpdatePublishRequest)
-                            }
-                            onClick={() => void handleSubmitControlProposedUpdate(proposedUpdate)}
-                          >
-                            <CheckCircle2 />
-                            {submittedProposedUpdatePublishRequest
-                              ? 'Request Submitted'
-                              : publishingProposalId === proposedUpdate.id
-                                ? 'Submitting...'
-                                : 'Submit for Review'}
-                          </Button>
+                          <div className="flex flex-wrap gap-2">
+                            {canPublish && !submittedProposedUpdatePublishRequest ? (
+                              <Button
+                                type="button"
+                                variant="outline"
+                                disabled={reviewingRequestId === proposedUpdate.id}
+                                onClick={() =>
+                                  void handleRejectControlProposedUpdate(proposedUpdate)
+                                }
+                              >
+                                Reject
+                              </Button>
+                            ) : null}
+                            <Button
+                              type="button"
+                              disabled={
+                                publishingProposalId === proposedUpdate.id ||
+                                Boolean(submittedProposedUpdatePublishRequest)
+                              }
+                              onClick={() => void handleSubmitControlProposedUpdate(proposedUpdate)}
+                            >
+                              <CheckCircle2 />
+                              {submittedProposedUpdatePublishRequest
+                                ? 'Request Submitted'
+                                : publishingProposalId === proposedUpdate.id
+                                  ? 'Submitting...'
+                                  : 'Submit for Review'}
+                            </Button>
+                          </div>
                         ) : canPublish ? (
-                          <Button
-                            type="button"
-                            disabled={publishingProposalId === proposedUpdate.id}
-                            onClick={() => void handlePublishControlProposedUpdate(proposedUpdate)}
-                          >
-                            <CheckCircle2 />
-                            {publishingProposalId === proposedUpdate.id
-                              ? 'Publishing...'
-                              : 'Publish Proposed Update'}
-                          </Button>
+                          <div className="flex flex-wrap gap-2">
+                            <Button
+                              type="button"
+                              variant="outline"
+                              disabled={reviewingRequestId === proposedUpdate.id}
+                              onClick={() => void handleRejectControlProposedUpdate(proposedUpdate)}
+                            >
+                              Reject
+                            </Button>
+                            <Button
+                              type="button"
+                              disabled={publishingProposalId === proposedUpdate.id}
+                              onClick={() =>
+                                void handlePublishControlProposedUpdate(proposedUpdate)
+                              }
+                            >
+                              <CheckCircle2 />
+                              {publishingProposalId === proposedUpdate.id
+                                ? 'Publishing...'
+                                : 'Publish Proposed Update'}
+                            </Button>
+                          </div>
                         ) : null}
                       </div>
                     </div>

--- a/apps/web/src/features/controls/pages/controls.tsx
+++ b/apps/web/src/features/controls/pages/controls.tsx
@@ -738,6 +738,10 @@ export function ControlsPage() {
                     publishRequests,
                   })
                 : null;
+              const proposedUpdateActionPending =
+                proposedUpdate &&
+                (publishingProposalId === proposedUpdate.id ||
+                  reviewingRequestId === proposedUpdate.id);
 
               return (
                 <article key={control.id} className="rounded-xl border bg-card p-5">
@@ -791,7 +795,7 @@ export function ControlsPage() {
                               <Button
                                 type="button"
                                 variant="outline"
-                                disabled={reviewingRequestId === proposedUpdate.id}
+                                disabled={Boolean(proposedUpdateActionPending)}
                                 onClick={() =>
                                   void handleRejectControlProposedUpdate(proposedUpdate)
                                 }
@@ -802,7 +806,7 @@ export function ControlsPage() {
                             <Button
                               type="button"
                               disabled={
-                                publishingProposalId === proposedUpdate.id ||
+                                Boolean(proposedUpdateActionPending) ||
                                 Boolean(submittedProposedUpdatePublishRequest)
                               }
                               onClick={() => void handleSubmitControlProposedUpdate(proposedUpdate)}
@@ -820,14 +824,14 @@ export function ControlsPage() {
                             <Button
                               type="button"
                               variant="outline"
-                              disabled={reviewingRequestId === proposedUpdate.id}
+                              disabled={Boolean(proposedUpdateActionPending)}
                               onClick={() => void handleRejectControlProposedUpdate(proposedUpdate)}
                             >
                               Reject
                             </Button>
                             <Button
                               type="button"
-                              disabled={publishingProposalId === proposedUpdate.id}
+                              disabled={Boolean(proposedUpdateActionPending)}
                               onClick={() =>
                                 void handlePublishControlProposedUpdate(proposedUpdate)
                               }

--- a/apps/web/src/features/projects/api/project-workspace.ts
+++ b/apps/web/src/features/projects/api/project-workspace.ts
@@ -35,6 +35,7 @@ export function useProjectAccess(organizationSlug: string | undefined) {
 
   return {
     canManageProjects: canManageProjects(currentRole),
+    currentMemberId: organization?.memberId ?? null,
     currentRole,
     error: resolutionQuery.error,
     isPending: hasOrganization && resolutionQuery.isPending,

--- a/apps/web/src/features/projects/pages/project-detail.tsx
+++ b/apps/web/src/features/projects/pages/project-detail.tsx
@@ -12,6 +12,7 @@ import {
   buildProjectSettingsPath,
   buildProjectsPath,
 } from '@/features/projects/routing/project-routing';
+import { ProjectChecklistsSection } from '@/features/checklists/components/project-checklists-section';
 import {
   useProjectAccess,
   useProjectArchiveActions,
@@ -182,21 +183,14 @@ export function ProjectDetailPage() {
         </Card>
       </div>
 
-      <Card className="border-dashed bg-muted/30">
-        <CardHeader>
-          <CardTitle>Governance work will appear here</CardTitle>
-          <CardDescription>
-            Controls, checklists, exceptions, and audit evidence will connect to this Project in
-            future slices.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="rounded-lg border bg-background p-6 text-sm text-muted-foreground">
-            This Project is ready. Start by adding governance workflows when those areas become
-            available.
-          </div>
-        </CardContent>
-      </Card>
+      <ProjectChecklistsSection
+        canManage={canManage}
+        currentMemberId={projectAccess.currentMemberId}
+        organizationSlug={organizationSlug}
+        projectArchived={Boolean(project.archivedAt)}
+        projectOwnerMemberId={project.projectOwner?.id ?? null}
+        projectSlug={project.slug}
+      />
     </div>
   );
 }

--- a/apps/web/src/providers/router.tsx
+++ b/apps/web/src/providers/router.tsx
@@ -121,6 +121,14 @@ const router = createBrowserRouter([
                     },
                   },
                   {
+                    path: 'checklists',
+                    lazy: async () => {
+                      const { ChecklistsPage } =
+                        await import('../features/checklists/pages/checklists');
+                      return { Component: ChecklistsPage };
+                    },
+                  },
+                  {
                     path: 'p/:projectSlug',
                     lazy: async () => {
                       const { ProjectDetailPage } =
@@ -136,7 +144,7 @@ const router = createBrowserRouter([
                       return { Component: ProjectSettingsPage };
                     },
                   },
-                  ...['checklists', 'exceptions', 'audit'].map((path) => ({
+                  ...['exceptions', 'audit'].map((path) => ({
                     path,
                     lazy: async () => {
                       const { StaticAppPage } =

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      zod: path.resolve(__dirname, './node_modules/zod'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Add Checklist domain docs, D1 schema, backend services, and tRPC procedures
- Add organization-level Checklist Template management for owners/admins
- Add Project Checklist creation, lifecycle, item management, and Project Owner check/uncheck UI
- Add owner/admin rejection for open proposed Control updates
- Add regression coverage for Checklist behavior and Project Owner assignment from accepted members

## Validation
- pnpm --filter backend-hono format:check
- pnpm --filter backend-hono check-types
- pnpm --filter backend-hono test -- test/checklists.spec.ts
- pnpm --filter backend-hono test -- test/draft-controls.spec.ts
- pnpm --filter backend-hono test -- test/projects.spec.ts test/project-detail.spec.ts
- pnpm --filter backend-hono build
- pnpm --filter web format:check
- pnpm --filter web check-types
- pnpm --filter web test
- pnpm --filter web build

Refs #73

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add organization checklist templates and project checklists with owner/admin management and Project Owner item completion. Adds reject action for proposed Control updates, blocks concurrent proposal actions, and enforces Control Version ownership on checklist items. Requires a DB migration. Addresses #73.

- **New Features**
  - Organization owners/admins manage Checklist Templates (create, rename, archive/restore, attach Controls).
  - Project Checklists from a template or selected Controls; items capture Control Version; rename and archive/restore; Project Owners check/uncheck; owners/admins add, refresh, remove; Archived Controls enforced.
  - New UI: Organization “Checklists” page and Project “Checklists” section; Controls page adds “reject proposed update.”
  - Backend adds tRPC procedures and tables for templates, project checklists, and items; composite FK ensures Checklist Item Control Versions belong to the recorded Control; integration tests cover checklist flows and Project Owner assignment.

- **Bug Fixes**
  - Block concurrent reject/submit/publish actions for proposed Control updates to avoid conflicting requests.
  - Reject empty Checklist Templates at the service layer to prevent invalid inserts.
  - Pin `zod` resolution in the web app to stabilize production builds.

<sup>Written for commit c6214c17c808f74523853f3d8fb1e6f1b2e2b16a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

