### PR TITLE
Implement Project assignments and scoped visibility

### DIFF
--- a/apps/backend-hono/drizzle/migrations/0010_project_assignments.sql
+++ b/apps/backend-hono/drizzle/migrations/0010_project_assignments.sql
@@ -1,0 +1,41 @@
+CREATE TABLE `project_assignments` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`organization_member_id` text NOT NULL,
+	`role` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`organization_member_id`) REFERENCES `members`(`id`) ON UPDATE no action ON DELETE cascade,
+	CHECK (`role` IN ('project_owner', 'project_contributor'))
+);
+--> statement-breakpoint
+INSERT INTO `project_assignments` (
+	`id`,
+	`project_id`,
+	`organization_member_id`,
+	`role`,
+	`created_at`,
+	`updated_at`
+)
+SELECT
+	lower(hex(randomblob(4))) || '-' ||
+	lower(hex(randomblob(2))) || '-' ||
+	'4' || substr(lower(hex(randomblob(2))), 2) || '-' ||
+	substr('89ab', abs(random()) % 4 + 1, 1) || substr(lower(hex(randomblob(2))), 2) || '-' ||
+	lower(hex(randomblob(6))),
+	`id`,
+	`project_owner_member_id`,
+	'project_owner',
+	`created_at`,
+	`updated_at`
+FROM `projects`
+WHERE `project_owner_member_id` IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX `project_assignment_project_id_idx` ON `project_assignments` (`project_id`);
+--> statement-breakpoint
+CREATE INDEX `project_assignment_organization_member_id_idx` ON `project_assignments` (`organization_member_id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `project_assignment_project_member_unique` ON `project_assignments` (`project_id`, `organization_member_id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `project_assignment_one_owner_per_project_unique` ON `project_assignments` (`project_id`) WHERE `role` = 'project_owner';

--- a/apps/backend-hono/drizzle/migrations/0011_drop_project_owner_member_id.sql
+++ b/apps/backend-hono/drizzle/migrations/0011_drop_project_owner_member_id.sql
@@ -1,0 +1,44 @@
+PRAGMA foreign_keys=OFF;
+--> statement-breakpoint
+CREATE TABLE `projects_without_owner_member_id` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`name` text NOT NULL,
+	`description` text NOT NULL,
+	`slug` text NOT NULL,
+	`archived_at` integer,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `projects_without_owner_member_id` (
+	`id`,
+	`organization_id`,
+	`name`,
+	`description`,
+	`slug`,
+	`archived_at`,
+	`created_at`,
+	`updated_at`
+)
+SELECT
+	`id`,
+	`organization_id`,
+	`name`,
+	`description`,
+	`slug`,
+	`archived_at`,
+	`created_at`,
+	`updated_at`
+FROM `projects`;
+--> statement-breakpoint
+DROP TABLE `projects`;
+--> statement-breakpoint
+ALTER TABLE `projects_without_owner_member_id` RENAME TO `projects`;
+--> statement-breakpoint
+CREATE INDEX `project_organization_id_idx` ON `projects` (`organization_id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `project_organization_slug_unique` ON `projects` (`organization_id`,`slug`);
+--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/apps/backend-hono/drizzle/migrations/0012_project_assignment_organization_integrity.sql
+++ b/apps/backend-hono/drizzle/migrations/0012_project_assignment_organization_integrity.sql
@@ -1,0 +1,57 @@
+CREATE UNIQUE INDEX `member_id_organization_id_unique` ON `members` (`id`, `organization_id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `project_id_organization_id_unique` ON `projects` (`id`, `organization_id`);
+--> statement-breakpoint
+PRAGMA foreign_keys=OFF;
+--> statement-breakpoint
+CREATE TABLE `project_assignments_with_organization` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`project_id` text NOT NULL,
+	`organization_member_id` text NOT NULL,
+	`role` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`project_id`, `organization_id`) REFERENCES `projects`(`id`, `organization_id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`organization_member_id`, `organization_id`) REFERENCES `members`(`id`, `organization_id`) ON UPDATE no action ON DELETE cascade,
+	CHECK (`role` IN ('project_owner', 'project_contributor'))
+);
+--> statement-breakpoint
+INSERT INTO `project_assignments_with_organization` (
+	`id`,
+	`organization_id`,
+	`project_id`,
+	`organization_member_id`,
+	`role`,
+	`created_at`,
+	`updated_at`
+)
+SELECT
+	`project_assignments`.`id`,
+	`projects`.`organization_id`,
+	`project_assignments`.`project_id`,
+	`project_assignments`.`organization_member_id`,
+	`project_assignments`.`role`,
+	`project_assignments`.`created_at`,
+	`project_assignments`.`updated_at`
+FROM `project_assignments`
+INNER JOIN `projects` ON `project_assignments`.`project_id` = `projects`.`id`
+INNER JOIN `members`
+	ON `project_assignments`.`organization_member_id` = `members`.`id`
+	AND `members`.`organization_id` = `projects`.`organization_id`;
+--> statement-breakpoint
+DROP TABLE `project_assignments`;
+--> statement-breakpoint
+ALTER TABLE `project_assignments_with_organization` RENAME TO `project_assignments`;
+--> statement-breakpoint
+CREATE INDEX `project_assignment_organization_id_idx` ON `project_assignments` (`organization_id`);
+--> statement-breakpoint
+CREATE INDEX `project_assignment_project_id_idx` ON `project_assignments` (`project_id`);
+--> statement-breakpoint
+CREATE INDEX `project_assignment_organization_member_id_idx` ON `project_assignments` (`organization_member_id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `project_assignment_project_member_unique` ON `project_assignments` (`project_id`, `organization_member_id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `project_assignment_one_owner_per_project_unique` ON `project_assignments` (`project_id`) WHERE `role` = 'project_owner';
+--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/apps/backend-hono/src/contexts/checklists/checklists.ts
+++ b/apps/backend-hono/src/contexts/checklists/checklists.ts
@@ -7,6 +7,7 @@ import {
   checklistTemplates,
   controls,
   controlVersions,
+  projectAssignments,
   projectChecklists,
   projects,
 } from '../../db/schema';
@@ -29,6 +30,7 @@ type CreateChecklistTemplateInput = {
 export type ChecklistArchiveStatus = 'active' | 'archived';
 
 const checklistManagerRoles = ['owner', 'admin'] as const;
+const projectOwnerAssignmentRole = 'project_owner';
 
 export const checklistAuthorizationActions = {
   createTemplate: {
@@ -95,6 +97,10 @@ export const checklistAuthorizationActions = {
 
 export class ChecklistInputError extends Error {}
 export class ChecklistPermissionError extends Error {}
+
+function canViewAllProjectsForOrganizationRole(role: string) {
+  return checklistManagerRoles.includes(role as (typeof checklistManagerRoles)[number]);
+}
 
 export async function createChecklistTemplateForMember(
   membership: AuthorizedOrganizationMember,
@@ -652,7 +658,7 @@ async function getProjectForChecklistAction(
   projectSlug: string,
   options: { allowArchivedProject: boolean },
 ) {
-  return db
+  const project = await db
     .select({
       archivedAt: projects.archivedAt,
       id: projects.id,
@@ -668,6 +674,24 @@ async function getProjectForChecklistAction(
     )
     .limit(1)
     .then((rows) => rows[0] ?? null);
+
+  if (!project || canViewAllProjectsForOrganizationRole(membership.role)) {
+    return project;
+  }
+
+  const assignment = await db
+    .select({ id: projectAssignments.id })
+    .from(projectAssignments)
+    .where(
+      and(
+        eq(projectAssignments.projectId, project.id),
+        eq(projectAssignments.organizationMemberId, membership.id),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  return assignment ? project : null;
 }
 
 async function getProjectChecklistForManagement(
@@ -844,7 +868,7 @@ export async function setChecklistItemCheckedForMember(
       itemStatus: checklistItems.status,
       projectArchivedAt: projects.archivedAt,
       projectChecklistId: projectChecklists.id,
-      projectOwnerMemberId: projects.projectOwnerMemberId,
+      projectId: projects.id,
       projectSlug: projects.slug,
     })
     .from(checklistItems)
@@ -864,7 +888,20 @@ export async function setChecklistItemCheckedForMember(
     return null;
   }
 
-  if (checklistItem.projectOwnerMemberId !== membership.id) {
+  const projectOwnerAssignment = await db
+    .select({ id: projectAssignments.id })
+    .from(projectAssignments)
+    .where(
+      and(
+        eq(projectAssignments.projectId, checklistItem.projectId),
+        eq(projectAssignments.organizationMemberId, membership.id),
+        eq(projectAssignments.role, projectOwnerAssignmentRole),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!projectOwnerAssignment) {
     throw new ChecklistPermissionError('Only the Project Owner can check Checklist Items.');
   }
 

--- a/apps/backend-hono/src/contexts/identity-organization/organization-membership.ts
+++ b/apps/backend-hono/src/contexts/identity-organization/organization-membership.ts
@@ -8,6 +8,10 @@ export const organizationMembershipAuthorizationActions = {
     allowedRoles: 'any-member',
     deniedMessage: 'Only Organization members can view Organization Members.',
   },
+  removeMember: {
+    allowedRoles: ['owner', 'admin'],
+    deniedMessage: 'Only Organization owners and admins can remove Organization Members.',
+  },
 } satisfies Record<string, OrganizationAuthorizationPolicy>;
 
 export async function getOrganizationMembership(organizationSlug: string, userId: string) {
@@ -39,3 +43,41 @@ export async function listOrganizationMembers(organizationId: string) {
     .where(eq(members.organizationId, organizationId))
     .orderBy(asc(users.name), asc(users.email));
 }
+
+export async function removeOrganizationMember(input: {
+  actorMemberId: string;
+  organizationId: string;
+  organizationMemberId: string;
+}) {
+  if (input.actorMemberId === input.organizationMemberId) {
+    throw new OrganizationMembershipInputError('Organization Members cannot remove themselves.');
+  }
+
+  const member = await db
+    .select({
+      email: users.email,
+      id: members.id,
+      name: users.name,
+      role: members.role,
+    })
+    .from(members)
+    .innerJoin(users, eq(members.userId, users.id))
+    .where(
+      and(
+        eq(members.id, input.organizationMemberId),
+        eq(members.organizationId, input.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!member) {
+    return null;
+  }
+
+  await db.delete(members).where(eq(members.id, member.id));
+
+  return member;
+}
+
+export class OrganizationMembershipInputError extends Error {}

--- a/apps/backend-hono/src/contexts/identity-organization/organization-schemas.ts
+++ b/apps/backend-hono/src/contexts/identity-organization/organization-schemas.ts
@@ -4,6 +4,10 @@ export const organizationSlugInput = z.object({
   organizationSlug: z.string().min(1),
 });
 
+export const organizationMemberIdentityInput = organizationSlugInput.extend({
+  organizationMemberId: z.string().min(1),
+});
+
 export const invitationEntryStateInput = z.object({
   invitationId: z.string().min(1),
 });

--- a/apps/backend-hono/src/contexts/identity-organization/organizations-router.ts
+++ b/apps/backend-hono/src/contexts/identity-organization/organizations-router.ts
@@ -2,13 +2,19 @@ import { TRPCError } from '@trpc/server';
 import { resolveInvitationEntryState, resolveMembershipResolution } from './auth-organization';
 import {
   listOrganizationMembers,
+  OrganizationMembershipInputError,
   organizationMembershipAuthorizationActions,
+  removeOrganizationMember,
 } from './organization-membership';
 import {
   authorizeOrganizationAction,
   OrganizationAuthorizationError,
 } from './organization-authorization';
-import { invitationEntryStateInput, organizationSlugInput } from './organization-schemas';
+import {
+  invitationEntryStateInput,
+  organizationMemberIdentityInput,
+  organizationSlugInput,
+} from './organization-schemas';
 import { protectedProcedure, publicProcedure, router } from '../../trpc/core';
 
 export const organizationsRouter = router({
@@ -55,4 +61,40 @@ export const organizationsRouter = router({
       throw caughtError;
     }
   }),
+
+  removeMember: protectedProcedure
+    .input(organizationMemberIdentityInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: organizationMembershipAuthorizationActions.removeMember,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const member = await removeOrganizationMember({
+          actorMemberId: membership.id,
+          organizationId: membership.organizationId,
+          organizationMemberId: input.organizationMemberId,
+        });
+
+        if (!member) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Organization Member unavailable' });
+        }
+
+        return { member };
+      } catch (caughtError) {
+        if (caughtError instanceof OrganizationAuthorizationError) {
+          throw new TRPCError({
+            code: caughtError.reason === 'not-found' ? 'NOT_FOUND' : 'FORBIDDEN',
+            message: caughtError.message,
+          });
+        }
+
+        if (caughtError instanceof OrganizationMembershipInputError) {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: caughtError.message });
+        }
+
+        throw caughtError;
+      }
+    }),
 });

--- a/apps/backend-hono/src/contexts/projects/docs/adr/0001-project-assignments-and-owner-role.md
+++ b/apps/backend-hono/src/contexts/projects/docs/adr/0001-project-assignments-and-owner-role.md
@@ -14,7 +14,7 @@ Model Project participation with Project Assignments. A Project Assignment belon
 
 Project Owner is not stored as a separate Project field; it is the Project Assignment whose role is Project Owner. A Project can have at most one Project Owner assignment and at most one assignment for the same Organization Member. Projects may still be created without assignments, in which case only Organization owners and admins can see and manage them until assignments are added.
 
-Organization owners and admins can see and manage all Projects and Project Assignments in their Organization regardless of assignment. Assigned Contributors can view their assigned Projects and the Project Assignment roster, but Project Assignment does not grant Project management, checklist management, or Control Library permissions.
+Organization owners and admins can see and manage all Projects and Project Assignments in their Organization regardless of assignment. Assigned Contributors can view their assigned Projects, but they cannot view the Project Assignment roster for MVP. Project Assignment does not grant Project management, checklist management, or Control Library permissions.
 
 Project Assignment changes are governance-relevant actions. Creating, removing, or changing Project Assignments must produce Audit Events because these changes affect access and Project accountability. Stable audit actions are `project_assignment.created`, `project_assignment.role_changed`, and `project_assignment.removed`.
 

--- a/apps/backend-hono/src/contexts/projects/projects-router.ts
+++ b/apps/backend-hono/src/contexts/projects/projects-router.ts
@@ -5,6 +5,7 @@ import {
 } from '../identity-organization/organization-authorization';
 import {
   archiveProjectForMember,
+  createProjectAssignmentForMember,
   createProjectForMember,
   listProjectsForMember,
   projectAuthorizationActions,
@@ -15,6 +16,7 @@ import {
 } from './projects';
 import {
   projectCreateInput,
+  projectAssignmentCreateInput,
   projectIdentityInput,
   projectListInput,
   projectUpdateInput,
@@ -93,6 +95,31 @@ export const projectsRouter = router({
       toProjectInputError(caughtError);
     }
   }),
+
+  createAssignment: protectedProcedure
+    .input(projectAssignmentCreateInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: projectAuthorizationActions.createAssignment,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const assignment = await createProjectAssignmentForMember({
+          assignment: input,
+          membership,
+          projectSlug: input.projectSlug,
+        });
+
+        if (!assignment) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Project unavailable' });
+        }
+
+        return { assignment };
+      } catch (caughtError) {
+        toProjectInputError(caughtError);
+      }
+    }),
 
   update: protectedProcedure.input(projectUpdateInput).mutation(async ({ ctx, input }) => {
     try {

--- a/apps/backend-hono/src/contexts/projects/projects-router.ts
+++ b/apps/backend-hono/src/contexts/projects/projects-router.ts
@@ -7,6 +7,7 @@ import {
   archiveProjectForMember,
   createProjectAssignmentForMember,
   createProjectForMember,
+  listProjectAssignmentsForMember,
   listProjectsForMember,
   projectAuthorizationActions,
   ProjectInputError,
@@ -57,6 +58,28 @@ export const projectsRouter = router({
       return {
         projects: await listProjectsForMember(membership, input.status),
       };
+    } catch (caughtError) {
+      toProjectInputError(caughtError);
+    }
+  }),
+
+  assignments: protectedProcedure.input(projectIdentityInput).query(async ({ ctx, input }) => {
+    try {
+      const membership = await authorizeOrganizationAction({
+        action: projectAuthorizationActions.listAssignments,
+        organizationSlug: input.organizationSlug,
+        userId: ctx.session.user.id,
+      });
+      const assignments = await listProjectAssignmentsForMember({
+        membership,
+        projectSlug: input.projectSlug,
+      });
+
+      if (!assignments) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Project unavailable' });
+      }
+
+      return { assignments };
     } catch (caughtError) {
       toProjectInputError(caughtError);
     }

--- a/apps/backend-hono/src/contexts/projects/projects-router.ts
+++ b/apps/backend-hono/src/contexts/projects/projects-router.ts
@@ -10,13 +10,17 @@ import {
   listProjectsForMember,
   projectAuthorizationActions,
   ProjectInputError,
+  removeProjectAssignmentForMember,
   restoreProjectForMember,
   updateProjectSettingsForMember,
+  updateProjectAssignmentForMember,
   viewProjectForMember,
 } from './projects';
 import {
   projectCreateInput,
   projectAssignmentCreateInput,
+  projectAssignmentRemoveInput,
+  projectAssignmentUpdateInput,
   projectIdentityInput,
   projectListInput,
   projectUpdateInput,
@@ -113,6 +117,56 @@ export const projectsRouter = router({
 
         if (!assignment) {
           throw new TRPCError({ code: 'NOT_FOUND', message: 'Project unavailable' });
+        }
+
+        return { assignment };
+      } catch (caughtError) {
+        toProjectInputError(caughtError);
+      }
+    }),
+
+  updateAssignment: protectedProcedure
+    .input(projectAssignmentUpdateInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: projectAuthorizationActions.updateAssignment,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const assignment = await updateProjectAssignmentForMember({
+          assignment: input,
+          membership,
+          projectSlug: input.projectSlug,
+        });
+
+        if (!assignment) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Project Assignment unavailable' });
+        }
+
+        return { assignment };
+      } catch (caughtError) {
+        toProjectInputError(caughtError);
+      }
+    }),
+
+  removeAssignment: protectedProcedure
+    .input(projectAssignmentRemoveInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const membership = await authorizeOrganizationAction({
+          action: projectAuthorizationActions.removeAssignment,
+          organizationSlug: input.organizationSlug,
+          userId: ctx.session.user.id,
+        });
+        const assignment = await removeProjectAssignmentForMember({
+          assignment: input,
+          membership,
+          projectSlug: input.projectSlug,
+        });
+
+        if (!assignment) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Project Assignment unavailable' });
         }
 
         return { assignment };

--- a/apps/backend-hono/src/contexts/projects/projects-schemas.ts
+++ b/apps/backend-hono/src/contexts/projects/projects-schemas.ts
@@ -26,3 +26,12 @@ export const projectAssignmentCreateInput = projectIdentityInput.extend({
   organizationMemberId: z.string().min(1),
   role: z.enum(['project_owner', 'project_contributor']),
 });
+
+export const projectAssignmentUpdateInput = projectIdentityInput.extend({
+  assignmentId: z.string().min(1),
+  role: z.enum(['project_owner', 'project_contributor']),
+});
+
+export const projectAssignmentRemoveInput = projectIdentityInput.extend({
+  assignmentId: z.string().min(1),
+});

--- a/apps/backend-hono/src/contexts/projects/projects-schemas.ts
+++ b/apps/backend-hono/src/contexts/projects/projects-schemas.ts
@@ -21,3 +21,8 @@ export const projectUpdateInput = projectIdentityInput.extend({
   name: z.string(),
   projectOwnerMemberId: z.string().nullable().optional(),
 });
+
+export const projectAssignmentCreateInput = projectIdentityInput.extend({
+  organizationMemberId: z.string().min(1),
+  role: z.enum(['project_owner', 'project_contributor']),
+});

--- a/apps/backend-hono/src/contexts/projects/projects-schemas.ts
+++ b/apps/backend-hono/src/contexts/projects/projects-schemas.ts
@@ -12,14 +12,12 @@ export const projectListInput = organizationSlugInput.extend({
 export const projectCreateInput = organizationSlugInput.extend({
   description: z.string(),
   name: z.string(),
-  projectOwnerMemberId: z.string().nullable().optional(),
   slug: z.string(),
 });
 
 export const projectUpdateInput = projectIdentityInput.extend({
   description: z.string(),
   name: z.string(),
-  projectOwnerMemberId: z.string().nullable().optional(),
 });
 
 export const projectAssignmentCreateInput = projectIdentityInput.extend({

--- a/apps/backend-hono/src/contexts/projects/projects.ts
+++ b/apps/backend-hono/src/contexts/projects/projects.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, exists, isNotNull, isNull } from 'drizzle-orm';
+import { and, asc, eq, exists, isNotNull, isNull, ne } from 'drizzle-orm';
 import { db } from '../../db/client';
 import { auditEvents, members, projectAssignments, projects, users } from '../../db/schema';
 import type { AuthorizedOrganizationMember } from '../../types/organization-types';
@@ -384,20 +384,27 @@ export async function createProjectAssignmentForMember(input: {
     updatedAt: now,
   };
 
-  await db.batch([
-    db.insert(projectAssignments).values(assignment),
-    db.insert(auditEvents).values(
-      await buildProjectAuditEventValues({
-        action: 'project_assignment.created',
-        membership: input.membership,
-        metadata: {
-          organizationMemberId: assignment.organizationMemberId,
-          role: assignment.role,
-        },
-        project,
-      }),
-    ),
-  ]);
+  const auditEvent = db.insert(auditEvents).values(
+    await buildProjectAuditEventValues({
+      action: 'project_assignment.created',
+      membership: input.membership,
+      metadata: {
+        organizationMemberId: assignment.organizationMemberId,
+        role: assignment.role,
+      },
+      project,
+    }),
+  );
+
+  if (assignment.role === projectOwnerAssignmentRole) {
+    await db.batch([
+      demoteExistingProjectOwner(project.id),
+      db.insert(projectAssignments).values(assignment),
+      auditEvent,
+    ]);
+  } else {
+    await db.batch([db.insert(projectAssignments).values(assignment), auditEvent]);
+  }
 
   return {
     id: assignment.id,
@@ -504,30 +511,38 @@ export async function updateProjectAssignmentForMember(input: {
     throw new ProjectInputError('Project Assignments cannot be changed while a Project is archived.');
   }
 
-  await db.batch([
-    db
-      .update(projectAssignments)
-      .set({ role: input.assignment.role, updatedAt: new Date() })
-      .where(eq(projectAssignments.id, assignment.id)),
-    db.insert(auditEvents).values(
-      await buildProjectAuditEventValues({
-        action: 'project_assignment.role_changed',
-        membership: input.membership,
-        metadata: {
-          organizationMemberId: assignment.organizationMemberId,
-          role: {
-            from: assignment.role,
-            to: input.assignment.role,
-          },
+  const updateAssignment = db
+    .update(projectAssignments)
+    .set({ role: input.assignment.role, updatedAt: new Date() })
+    .where(eq(projectAssignments.id, assignment.id));
+  const auditEvent = db.insert(auditEvents).values(
+    await buildProjectAuditEventValues({
+      action: 'project_assignment.role_changed',
+      membership: input.membership,
+      metadata: {
+        organizationMemberId: assignment.organizationMemberId,
+        role: {
+          from: assignment.role,
+          to: input.assignment.role,
         },
-        project: {
-          id: assignment.projectId,
-          name: assignment.name,
-          slug: assignment.projectSlug,
-        },
-      }),
-    ),
-  ]);
+      },
+      project: {
+        id: assignment.projectId,
+        name: assignment.name,
+        slug: assignment.projectSlug,
+      },
+    }),
+  );
+
+  if (input.assignment.role === projectOwnerAssignmentRole) {
+    await db.batch([
+      demoteExistingProjectOwner(assignment.projectId, assignment.id),
+      updateAssignment,
+      auditEvent,
+    ]);
+  } else {
+    await db.batch([updateAssignment, auditEvent]);
+  }
 
   return {
     id: assignment.id,
@@ -772,6 +787,19 @@ export class ProjectInputError extends Error {}
 
 function canViewAllProjectsForOrganizationRole(role: string) {
   return projectManagerRoles.includes(role as (typeof projectManagerRoles)[number]);
+}
+
+function demoteExistingProjectOwner(projectId: string, exceptAssignmentId?: string) {
+  return db
+    .update(projectAssignments)
+    .set({ role: 'project_contributor', updatedAt: new Date() })
+    .where(
+      and(
+        eq(projectAssignments.projectId, projectId),
+        eq(projectAssignments.role, projectOwnerAssignmentRole),
+        exceptAssignmentId ? ne(projectAssignments.id, exceptAssignmentId) : undefined,
+      ),
+    );
 }
 
 function validateProjectInput(input: CreateProjectInput) {

--- a/apps/backend-hono/src/contexts/projects/projects.ts
+++ b/apps/backend-hono/src/contexts/projects/projects.ts
@@ -374,6 +374,24 @@ export async function createProjectAssignmentForMember(input: {
     throw new ProjectInputError('Project Assignment member must be a member of this Organization.');
   }
 
+  const existingAssignment = await db
+    .select({ id: projectAssignments.id })
+    .from(projectAssignments)
+    .where(
+      and(
+        eq(projectAssignments.projectId, project.id),
+        eq(projectAssignments.organizationMemberId, input.assignment.organizationMemberId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existingAssignment) {
+    throw new ProjectInputError(
+      'Organization Member already has a Project Assignment for this Project.',
+    );
+  }
+
   const now = new Date();
   const assignment = {
     createdAt: now,

--- a/apps/backend-hono/src/contexts/projects/projects.ts
+++ b/apps/backend-hono/src/contexts/projects/projects.ts
@@ -369,7 +369,9 @@ export async function createProjectAssignmentForMember(input: {
   }
 
   if (project.archivedAt) {
-    throw new ProjectInputError('Project Assignments cannot be changed while a Project is archived.');
+    throw new ProjectInputError(
+      'Project Assignments cannot be changed while a Project is archived.',
+    );
   }
 
   const organizationMember = await db
@@ -478,7 +480,9 @@ export async function removeProjectAssignmentForMember(input: {
   }
 
   if (assignment.archivedAt) {
-    throw new ProjectInputError('Project Assignments cannot be changed while a Project is archived.');
+    throw new ProjectInputError(
+      'Project Assignments cannot be changed while a Project is archived.',
+    );
   }
 
   await db.batch([
@@ -540,7 +544,9 @@ export async function updateProjectAssignmentForMember(input: {
   }
 
   if (assignment.archivedAt) {
-    throw new ProjectInputError('Project Assignments cannot be changed while a Project is archived.');
+    throw new ProjectInputError(
+      'Project Assignments cannot be changed while a Project is archived.',
+    );
   }
 
   const updateAssignment = db

--- a/apps/backend-hono/src/contexts/projects/projects.ts
+++ b/apps/backend-hono/src/contexts/projects/projects.ts
@@ -20,6 +20,11 @@ type UpdateProjectSettingsInput = {
   projectOwnerMemberId?: string | null;
 };
 
+type CreateProjectAssignmentInput = {
+  organizationMemberId: string;
+  role: 'project_contributor' | 'project_owner';
+};
+
 const projectManagerRoles = ['owner', 'admin'] as const;
 const projectSlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const projectOwnerAssignmentRole = 'project_owner';
@@ -32,6 +37,10 @@ export const projectAuthorizationActions = {
   create: {
     allowedRoles: projectManagerRoles,
     deniedMessage: 'Only Organization owners and admins can create Projects.',
+  },
+  createAssignment: {
+    allowedRoles: projectManagerRoles,
+    deniedMessage: 'Only Organization owners and admins can create Project Assignments.',
   },
   listActive: {
     allowedRoles: 'any-member',
@@ -74,7 +83,14 @@ export async function listProjectsForMember(
       slug: projects.slug,
     })
     .from(projects)
-    .leftJoin(members, eq(projects.projectOwnerMemberId, members.id))
+    .leftJoin(
+      projectAssignments,
+      and(
+        eq(projectAssignments.projectId, projects.id),
+        eq(projectAssignments.role, projectOwnerAssignmentRole),
+      ),
+    )
+    .leftJoin(members, eq(projectAssignments.organizationMemberId, members.id))
     .leftJoin(users, eq(members.userId, users.id))
     .where(
       and(
@@ -148,25 +164,25 @@ export async function viewProjectForMember(
     }
   }
 
-  const projectOwner = project.projectOwnerMemberId
-    ? await db
-        .select({
-          email: users.email,
-          id: members.id,
-          name: users.name,
-          role: members.role,
-        })
-        .from(members)
-        .innerJoin(users, eq(users.id, members.userId))
-        .where(
-          and(
-            eq(members.id, project.projectOwnerMemberId),
-            eq(members.organizationId, membership.organizationId),
-          ),
-        )
-        .limit(1)
-        .then((rows) => rows[0] ?? null)
-    : null;
+  const projectOwner = await db
+    .select({
+      email: users.email,
+      id: members.id,
+      name: users.name,
+      role: members.role,
+    })
+    .from(projectAssignments)
+    .innerJoin(members, eq(projectAssignments.organizationMemberId, members.id))
+    .innerJoin(users, eq(users.id, members.userId))
+    .where(
+      and(
+        eq(projectAssignments.projectId, project.id),
+        eq(projectAssignments.role, projectOwnerAssignmentRole),
+        eq(members.organizationId, membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
 
   return {
     id: project.id,
@@ -266,7 +282,12 @@ export async function createProjectForMember(
 }
 
 async function buildProjectAuditEventValues(input: {
-  action: 'project.created' | 'project.archived' | 'project.restored' | 'project.updated';
+  action:
+    | 'project.created'
+    | 'project.archived'
+    | 'project.restored'
+    | 'project.updated'
+    | 'project_assignment.created';
   membership: AuthorizedOrganizationMember;
   metadata?: unknown;
   project: {
@@ -286,6 +307,85 @@ async function buildProjectAuditEventValues(input: {
       type: 'project',
     },
   });
+}
+
+export async function createProjectAssignmentForMember(input: {
+  assignment: CreateProjectAssignmentInput;
+  membership: AuthorizedOrganizationMember;
+  projectSlug: string;
+}) {
+  const project = await db
+    .select({
+      archivedAt: projects.archivedAt,
+      id: projects.id,
+      name: projects.name,
+      slug: projects.slug,
+    })
+    .from(projects)
+    .where(
+      and(
+        eq(projects.organizationId, input.membership.organizationId),
+        eq(projects.slug, input.projectSlug),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!project) {
+    return null;
+  }
+
+  if (project.archivedAt) {
+    throw new ProjectInputError('Project Assignments cannot be changed while a Project is archived.');
+  }
+
+  const organizationMember = await db
+    .select({ id: members.id })
+    .from(members)
+    .where(
+      and(
+        eq(members.id, input.assignment.organizationMemberId),
+        eq(members.organizationId, input.membership.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!organizationMember) {
+    throw new ProjectInputError('Project Assignment member must be a member of this Organization.');
+  }
+
+  const now = new Date();
+  const assignment = {
+    createdAt: now,
+    id: crypto.randomUUID(),
+    organizationMemberId: input.assignment.organizationMemberId,
+    projectId: project.id,
+    role: input.assignment.role,
+    updatedAt: now,
+  };
+
+  await db.batch([
+    db.insert(projectAssignments).values(assignment),
+    db.insert(auditEvents).values(
+      await buildProjectAuditEventValues({
+        action: 'project_assignment.created',
+        membership: input.membership,
+        metadata: {
+          organizationMemberId: assignment.organizationMemberId,
+          role: assignment.role,
+        },
+        project,
+      }),
+    ),
+  ]);
+
+  return {
+    id: assignment.id,
+    organizationMemberId: assignment.organizationMemberId,
+    projectId: assignment.projectId,
+    role: assignment.role,
+  };
 }
 
 export async function archiveProjectForMember(input: {
@@ -405,6 +505,26 @@ export async function updateProjectSettingsForMember(input: {
 
   await db.batch([
     db.update(projects).set(updatedProject).where(eq(projects.id, existingProject.id)),
+    db
+      .delete(projectAssignments)
+      .where(
+        and(
+          eq(projectAssignments.projectId, existingProject.id),
+          eq(projectAssignments.role, projectOwnerAssignmentRole),
+        ),
+      ),
+    ...(settings.projectOwnerMemberId
+      ? [
+          db.insert(projectAssignments).values({
+            createdAt: new Date(),
+            id: crypto.randomUUID(),
+            organizationMemberId: settings.projectOwnerMemberId,
+            projectId: existingProject.id,
+            role: projectOwnerAssignmentRole,
+            updatedAt: new Date(),
+          }),
+        ]
+      : []),
     db.insert(auditEvents).values(
       await buildProjectAuditEventValues({
         action: 'project.updated',

--- a/apps/backend-hono/src/contexts/projects/projects.ts
+++ b/apps/backend-hono/src/contexts/projects/projects.ts
@@ -412,6 +412,7 @@ export async function createProjectAssignmentForMember(input: {
   const assignment = {
     createdAt: now,
     id: crypto.randomUUID(),
+    organizationId: input.membership.organizationId,
     organizationMemberId: input.assignment.organizationMemberId,
     projectId: project.id,
     role: input.assignment.role,

--- a/apps/backend-hono/src/contexts/projects/projects.ts
+++ b/apps/backend-hono/src/contexts/projects/projects.ts
@@ -10,14 +10,12 @@ export type ProjectListStatus = 'active' | 'archived';
 type CreateProjectInput = {
   description: string;
   name: string;
-  projectOwnerMemberId?: string | null;
   slug: string;
 };
 
 type UpdateProjectSettingsInput = {
   description: string;
   name: string;
-  projectOwnerMemberId?: string | null;
 };
 
 type CreateProjectAssignmentInput = {
@@ -285,24 +283,6 @@ export async function createProjectForMember(
     throw new ProjectInputError('Project slug is already used in this Organization.');
   }
 
-  if (projectInput.projectOwnerMemberId) {
-    const ownerMembership = await db
-      .select({ id: members.id })
-      .from(members)
-      .where(
-        and(
-          eq(members.id, projectInput.projectOwnerMemberId),
-          eq(members.organizationId, membership.organizationId),
-        ),
-      )
-      .limit(1)
-      .then((rows) => rows[0] ?? null);
-
-    if (!ownerMembership) {
-      throw new ProjectInputError('Project Owner must be a member of this Organization.');
-    }
-  }
-
   const now = new Date();
   const project = {
     createdAt: now,
@@ -310,25 +290,12 @@ export async function createProjectForMember(
     id: crypto.randomUUID(),
     name: projectInput.name.trim(),
     organizationId: membership.organizationId,
-    projectOwnerMemberId: projectInput.projectOwnerMemberId,
     slug: projectInput.slug,
     updatedAt: now,
   };
 
   await db.batch([
     db.insert(projects).values(project),
-    ...(projectInput.projectOwnerMemberId
-      ? [
-          db.insert(projectAssignments).values({
-            createdAt: now,
-            id: crypto.randomUUID(),
-            organizationMemberId: projectInput.projectOwnerMemberId,
-            projectId: project.id,
-            role: projectOwnerAssignmentRole,
-            updatedAt: now,
-          }),
-        ]
-      : []),
     db.insert(auditEvents).values(
       await buildProjectAuditEventValues({
         action: 'project.created',
@@ -690,7 +657,6 @@ export async function updateProjectSettingsForMember(input: {
       description: projects.description,
       id: projects.id,
       name: projects.name,
-      projectOwnerMemberId: projects.projectOwnerMemberId,
       slug: projects.slug,
     })
     .from(projects)
@@ -707,53 +673,14 @@ export async function updateProjectSettingsForMember(input: {
     return null;
   }
 
-  if (settings.projectOwnerMemberId) {
-    const ownerMembership = await db
-      .select({ id: members.id })
-      .from(members)
-      .where(
-        and(
-          eq(members.id, settings.projectOwnerMemberId),
-          eq(members.organizationId, input.membership.organizationId),
-        ),
-      )
-      .limit(1)
-      .then((rows) => rows[0] ?? null);
-
-    if (!ownerMembership) {
-      throw new ProjectInputError('Project Owner must be a member of this Organization.');
-    }
-  }
-
   const updatedProject = {
     description: settings.description.trim(),
     name: settings.name.trim(),
-    projectOwnerMemberId: settings.projectOwnerMemberId,
     updatedAt: new Date(),
   };
 
   await db.batch([
     db.update(projects).set(updatedProject).where(eq(projects.id, existingProject.id)),
-    db
-      .delete(projectAssignments)
-      .where(
-        and(
-          eq(projectAssignments.projectId, existingProject.id),
-          eq(projectAssignments.role, projectOwnerAssignmentRole),
-        ),
-      ),
-    ...(settings.projectOwnerMemberId
-      ? [
-          db.insert(projectAssignments).values({
-            createdAt: new Date(),
-            id: crypto.randomUUID(),
-            organizationMemberId: settings.projectOwnerMemberId,
-            projectId: existingProject.id,
-            role: projectOwnerAssignmentRole,
-            updatedAt: new Date(),
-          }),
-        ]
-      : []),
     db.insert(auditEvents).values(
       await buildProjectAuditEventValues({
         action: 'project.updated',
@@ -780,12 +707,10 @@ async function buildProjectUpdateAuditDeltas(input: {
   after: {
     description: string;
     name: string;
-    projectOwnerMemberId: string | null;
   };
   before: {
     description: string;
     name: string;
-    projectOwnerMemberId: string | null;
   };
 }) {
   return {
@@ -805,35 +730,7 @@ async function buildProjectUpdateAuditDeltas(input: {
             to: input.after.description,
           },
         }),
-    ...(input.before.projectOwnerMemberId === input.after.projectOwnerMemberId
-      ? {}
-      : {
-          projectOwner: {
-            from: await getProjectOwnerAuditLabel(input.before.projectOwnerMemberId),
-            to: await getProjectOwnerAuditLabel(input.after.projectOwnerMemberId),
-          },
-        }),
   };
-}
-
-async function getProjectOwnerAuditLabel(organizationMemberId: string | null) {
-  if (!organizationMemberId) {
-    return null;
-  }
-
-  const member = await db
-    .select({
-      displayName: users.name,
-      email: users.email,
-      organizationMemberId: members.id,
-    })
-    .from(members)
-    .innerJoin(users, eq(users.id, members.userId))
-    .where(eq(members.id, organizationMemberId))
-    .limit(1)
-    .then((rows) => rows[0] ?? null);
-
-  return member ?? { organizationMemberId };
 }
 
 export function slugifyProjectName(value: string) {
@@ -905,10 +802,6 @@ function normalizeProjectCreateBody(body: unknown) {
   return {
     description: typeof record.description === 'string' ? record.description : '',
     name: typeof record.name === 'string' ? record.name : '',
-    projectOwnerMemberId:
-      typeof record.projectOwnerMemberId === 'string' && record.projectOwnerMemberId
-        ? record.projectOwnerMemberId
-        : null,
     slug: typeof record.slug === 'string' ? slugifyProjectName(record.slug) : '',
   };
 }
@@ -920,9 +813,5 @@ function normalizeProjectUpdateBody(body: unknown) {
   return {
     description: typeof record.description === 'string' ? record.description : '',
     name: typeof record.name === 'string' ? record.name : '',
-    projectOwnerMemberId:
-      typeof record.projectOwnerMemberId === 'string' && record.projectOwnerMemberId
-        ? record.projectOwnerMemberId
-        : null,
   };
 }

--- a/apps/backend-hono/src/contexts/projects/projects.ts
+++ b/apps/backend-hono/src/contexts/projects/projects.ts
@@ -1,6 +1,6 @@
-import { and, asc, eq, isNotNull, isNull } from 'drizzle-orm';
+import { and, asc, eq, exists, isNotNull, isNull } from 'drizzle-orm';
 import { db } from '../../db/client';
-import { auditEvents, members, projects, users } from '../../db/schema';
+import { auditEvents, members, projectAssignments, projects, users } from '../../db/schema';
 import type { AuthorizedOrganizationMember } from '../../types/organization-types';
 import { buildOrganizationMemberAuditEvent } from '../audit-log/audit-events';
 import type { OrganizationAuthorizationPolicy } from '../identity-organization/organization-authorization';
@@ -22,6 +22,7 @@ type UpdateProjectSettingsInput = {
 
 const projectManagerRoles = ['owner', 'admin'] as const;
 const projectSlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const projectOwnerAssignmentRole = 'project_owner';
 
 export const projectAuthorizationActions = {
   archive: {
@@ -58,6 +59,8 @@ export async function listProjectsForMember(
   membership: AuthorizedOrganizationMember,
   status: ProjectListStatus,
 ) {
+  const canViewAllProjects = canViewAllProjectsForOrganizationRole(membership.role);
+
   const rows = await db
     .select({
       archivedAt: projects.archivedAt,
@@ -77,6 +80,19 @@ export async function listProjectsForMember(
       and(
         eq(projects.organizationId, membership.organizationId),
         status === 'archived' ? isNotNull(projects.archivedAt) : isNull(projects.archivedAt),
+        canViewAllProjects
+          ? undefined
+          : exists(
+              db
+                .select({ id: projectAssignments.id })
+                .from(projectAssignments)
+                .where(
+                  and(
+                    eq(projectAssignments.projectId, projects.id),
+                    eq(projectAssignments.organizationMemberId, membership.id),
+                  ),
+                ),
+            ),
       ),
     )
     .orderBy(asc(projects.createdAt), asc(projects.name));
@@ -100,6 +116,7 @@ export async function viewProjectForMember(
   membership: AuthorizedOrganizationMember,
   projectSlug: string,
 ) {
+  const canViewAllProjects = canViewAllProjectsForOrganizationRole(membership.role);
   const project = await db
     .select()
     .from(projects)
@@ -111,6 +128,24 @@ export async function viewProjectForMember(
 
   if (!project) {
     return null;
+  }
+
+  if (!canViewAllProjects) {
+    const assignment = await db
+      .select({ id: projectAssignments.id })
+      .from(projectAssignments)
+      .where(
+        and(
+          eq(projectAssignments.projectId, project.id),
+          eq(projectAssignments.organizationMemberId, membership.id),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+
+    if (!assignment) {
+      return null;
+    }
   }
 
   const projectOwner = project.projectOwnerMemberId
@@ -202,6 +237,18 @@ export async function createProjectForMember(
 
   await db.batch([
     db.insert(projects).values(project),
+    ...(projectInput.projectOwnerMemberId
+      ? [
+          db.insert(projectAssignments).values({
+            createdAt: now,
+            id: crypto.randomUUID(),
+            organizationMemberId: projectInput.projectOwnerMemberId,
+            projectId: project.id,
+            role: projectOwnerAssignmentRole,
+            updatedAt: now,
+          }),
+        ]
+      : []),
     db.insert(auditEvents).values(
       await buildProjectAuditEventValues({
         action: 'project.created',
@@ -453,6 +500,10 @@ export function slugifyProjectName(value: string) {
 }
 
 export class ProjectInputError extends Error {}
+
+function canViewAllProjectsForOrganizationRole(role: string) {
+  return projectManagerRoles.includes(role as (typeof projectManagerRoles)[number]);
+}
 
 function validateProjectInput(input: CreateProjectInput) {
   const name = input.name.trim();

--- a/apps/backend-hono/src/contexts/projects/projects.ts
+++ b/apps/backend-hono/src/contexts/projects/projects.ts
@@ -51,6 +51,10 @@ export const projectAuthorizationActions = {
     allowedRoles: projectManagerRoles,
     deniedMessage: 'Only Organization owners and admins can create Project Assignments.',
   },
+  listAssignments: {
+    allowedRoles: projectManagerRoles,
+    deniedMessage: 'Only Organization owners and admins can view Project Assignments.',
+  },
   listActive: {
     allowedRoles: 'any-member',
     deniedMessage: 'Only Organization members can view Projects.',
@@ -213,6 +217,49 @@ export async function viewProjectForMember(
 }
 
 export type ProjectDetailResponse = NonNullable<Awaited<ReturnType<typeof viewProjectForMember>>>;
+
+export async function listProjectAssignmentsForMember(input: {
+  membership: AuthorizedOrganizationMember;
+  projectSlug: string;
+}) {
+  const project = await db
+    .select({ id: projects.id })
+    .from(projects)
+    .where(
+      and(
+        eq(projects.organizationId, input.membership.organizationId),
+        eq(projects.slug, input.projectSlug),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!project) {
+    return null;
+  }
+
+  const assignments = await db
+    .select({
+      email: users.email,
+      id: projectAssignments.id,
+      name: users.name,
+      organizationMemberId: members.id,
+      organizationRole: members.role,
+      role: projectAssignments.role,
+    })
+    .from(projectAssignments)
+    .innerJoin(members, eq(projectAssignments.organizationMemberId, members.id))
+    .innerJoin(users, eq(users.id, members.userId))
+    .where(
+      and(
+        eq(projectAssignments.projectId, project.id),
+        eq(members.organizationId, input.membership.organizationId),
+      ),
+    )
+    .orderBy(asc(users.name), asc(users.email));
+
+  return assignments;
+}
 
 export async function createProjectForMember(
   membership: AuthorizedOrganizationMember,

--- a/apps/backend-hono/src/contexts/projects/projects.ts
+++ b/apps/backend-hono/src/contexts/projects/projects.ts
@@ -25,6 +25,15 @@ type CreateProjectAssignmentInput = {
   role: 'project_contributor' | 'project_owner';
 };
 
+type UpdateProjectAssignmentInput = {
+  assignmentId: string;
+  role: 'project_contributor' | 'project_owner';
+};
+
+type RemoveProjectAssignmentInput = {
+  assignmentId: string;
+};
+
 const projectManagerRoles = ['owner', 'admin'] as const;
 const projectSlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const projectOwnerAssignmentRole = 'project_owner';
@@ -54,9 +63,17 @@ export const projectAuthorizationActions = {
     allowedRoles: projectManagerRoles,
     deniedMessage: 'Only Organization owners and admins can restore Projects.',
   },
+  removeAssignment: {
+    allowedRoles: projectManagerRoles,
+    deniedMessage: 'Only Organization owners and admins can remove Project Assignments.',
+  },
   update: {
     allowedRoles: projectManagerRoles,
     deniedMessage: 'Only Organization owners and admins can edit Projects.',
+  },
+  updateAssignment: {
+    allowedRoles: projectManagerRoles,
+    deniedMessage: 'Only Organization owners and admins can change Project Assignments.',
   },
   view: {
     allowedRoles: 'any-member',
@@ -287,7 +304,9 @@ async function buildProjectAuditEventValues(input: {
     | 'project.archived'
     | 'project.restored'
     | 'project.updated'
-    | 'project_assignment.created';
+    | 'project_assignment.created'
+    | 'project_assignment.role_changed'
+    | 'project_assignment.removed';
   membership: AuthorizedOrganizationMember;
   metadata?: unknown;
   project: {
@@ -385,6 +404,136 @@ export async function createProjectAssignmentForMember(input: {
     organizationMemberId: assignment.organizationMemberId,
     projectId: assignment.projectId,
     role: assignment.role,
+  };
+}
+
+export async function removeProjectAssignmentForMember(input: {
+  assignment: RemoveProjectAssignmentInput;
+  membership: AuthorizedOrganizationMember;
+  projectSlug: string;
+}) {
+  const assignment = await db
+    .select({
+      archivedAt: projects.archivedAt,
+      id: projectAssignments.id,
+      name: projects.name,
+      organizationMemberId: projectAssignments.organizationMemberId,
+      projectId: projects.id,
+      projectSlug: projects.slug,
+      role: projectAssignments.role,
+    })
+    .from(projectAssignments)
+    .innerJoin(projects, eq(projectAssignments.projectId, projects.id))
+    .where(
+      and(
+        eq(projectAssignments.id, input.assignment.assignmentId),
+        eq(projects.organizationId, input.membership.organizationId),
+        eq(projects.slug, input.projectSlug),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!assignment) {
+    return null;
+  }
+
+  if (assignment.archivedAt) {
+    throw new ProjectInputError('Project Assignments cannot be changed while a Project is archived.');
+  }
+
+  await db.batch([
+    db.delete(projectAssignments).where(eq(projectAssignments.id, assignment.id)),
+    db.insert(auditEvents).values(
+      await buildProjectAuditEventValues({
+        action: 'project_assignment.removed',
+        membership: input.membership,
+        metadata: {
+          organizationMemberId: assignment.organizationMemberId,
+          role: assignment.role,
+        },
+        project: {
+          id: assignment.projectId,
+          name: assignment.name,
+          slug: assignment.projectSlug,
+        },
+      }),
+    ),
+  ]);
+
+  return {
+    id: assignment.id,
+    organizationMemberId: assignment.organizationMemberId,
+    projectId: assignment.projectId,
+    role: assignment.role,
+  };
+}
+
+export async function updateProjectAssignmentForMember(input: {
+  assignment: UpdateProjectAssignmentInput;
+  membership: AuthorizedOrganizationMember;
+  projectSlug: string;
+}) {
+  const assignment = await db
+    .select({
+      archivedAt: projects.archivedAt,
+      id: projectAssignments.id,
+      name: projects.name,
+      organizationMemberId: projectAssignments.organizationMemberId,
+      projectId: projects.id,
+      projectSlug: projects.slug,
+      role: projectAssignments.role,
+    })
+    .from(projectAssignments)
+    .innerJoin(projects, eq(projectAssignments.projectId, projects.id))
+    .where(
+      and(
+        eq(projectAssignments.id, input.assignment.assignmentId),
+        eq(projects.organizationId, input.membership.organizationId),
+        eq(projects.slug, input.projectSlug),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!assignment) {
+    return null;
+  }
+
+  if (assignment.archivedAt) {
+    throw new ProjectInputError('Project Assignments cannot be changed while a Project is archived.');
+  }
+
+  await db.batch([
+    db
+      .update(projectAssignments)
+      .set({ role: input.assignment.role, updatedAt: new Date() })
+      .where(eq(projectAssignments.id, assignment.id)),
+    db.insert(auditEvents).values(
+      await buildProjectAuditEventValues({
+        action: 'project_assignment.role_changed',
+        membership: input.membership,
+        metadata: {
+          organizationMemberId: assignment.organizationMemberId,
+          role: {
+            from: assignment.role,
+            to: input.assignment.role,
+          },
+        },
+        project: {
+          id: assignment.projectId,
+          name: assignment.name,
+          slug: assignment.projectSlug,
+        },
+      }),
+    ),
+  ]);
+
+  return {
+    id: assignment.id,
+    organizationMemberId: assignment.organizationMemberId,
+    projectId: assignment.projectId,
+    role: input.assignment.role,
   };
 }
 

--- a/apps/backend-hono/src/db/schema.ts
+++ b/apps/backend-hono/src/db/schema.ts
@@ -174,9 +174,6 @@ export const projects = sqliteTable(
     name: text('name').notNull(),
     description: text('description').notNull(),
     slug: text('slug').notNull(),
-    projectOwnerMemberId: text('project_owner_member_id').references(() => members.id, {
-      onDelete: 'set null',
-    }),
     archivedAt: integer('archived_at', { mode: 'timestamp_ms' }),
     createdAt: integer('created_at', { mode: 'timestamp_ms' })
       .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
@@ -188,7 +185,6 @@ export const projects = sqliteTable(
   },
   (table) => [
     index('project_organization_id_idx').on(table.organizationId),
-    index('project_owner_member_id_idx').on(table.projectOwnerMemberId),
     uniqueIndex('project_organization_slug_unique').on(table.organizationId, table.slug),
   ],
 );

--- a/apps/backend-hono/src/db/schema.ts
+++ b/apps/backend-hono/src/db/schema.ts
@@ -193,6 +193,38 @@ export const projects = sqliteTable(
   ],
 );
 
+export const projectAssignments = sqliteTable(
+  'project_assignments',
+  {
+    id: text('id').primaryKey(),
+    projectId: text('project_id')
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    organizationMemberId: text('organization_member_id')
+      .notNull()
+      .references(() => members.id, { onDelete: 'cascade' }),
+    role: text('role').notNull(),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    index('project_assignment_project_id_idx').on(table.projectId),
+    index('project_assignment_organization_member_id_idx').on(table.organizationMemberId),
+    uniqueIndex('project_assignment_project_member_unique').on(
+      table.projectId,
+      table.organizationMemberId,
+    ),
+    uniqueIndex('project_assignment_one_owner_per_project_unique')
+      .on(table.projectId)
+      .where(sql`${table.role} = 'project_owner'`),
+  ],
+);
+
 export const auditEvents = sqliteTable(
   'audit_events',
   {

--- a/apps/backend-hono/src/db/schema.ts
+++ b/apps/backend-hono/src/db/schema.ts
@@ -135,6 +135,7 @@ export const members = sqliteTable(
   (table) => [
     index('member_organization_id_idx').on(table.organizationId),
     index('member_user_id_idx').on(table.userId),
+    uniqueIndex('member_id_organization_id_unique').on(table.id, table.organizationId),
     uniqueIndex('member_organization_user_unique').on(table.organizationId, table.userId),
   ],
 );
@@ -185,6 +186,7 @@ export const projects = sqliteTable(
   },
   (table) => [
     index('project_organization_id_idx').on(table.organizationId),
+    uniqueIndex('project_id_organization_id_unique').on(table.id, table.organizationId),
     uniqueIndex('project_organization_slug_unique').on(table.organizationId, table.slug),
   ],
 );
@@ -193,6 +195,7 @@ export const projectAssignments = sqliteTable(
   'project_assignments',
   {
     id: text('id').primaryKey(),
+    organizationId: text('organization_id').notNull(),
     projectId: text('project_id')
       .notNull()
       .references(() => projects.id, { onDelete: 'cascade' }),
@@ -209,8 +212,19 @@ export const projectAssignments = sqliteTable(
       .notNull(),
   },
   (table) => [
+    index('project_assignment_organization_id_idx').on(table.organizationId),
     index('project_assignment_project_id_idx').on(table.projectId),
     index('project_assignment_organization_member_id_idx').on(table.organizationMemberId),
+    foreignKey({
+      columns: [table.projectId, table.organizationId],
+      foreignColumns: [projects.id, projects.organizationId],
+      name: 'project_assignment_project_organization_fk',
+    }).onDelete('cascade'),
+    foreignKey({
+      columns: [table.organizationMemberId, table.organizationId],
+      foreignColumns: [members.id, members.organizationId],
+      name: 'project_assignment_member_organization_fk',
+    }).onDelete('cascade'),
     uniqueIndex('project_assignment_project_member_unique').on(
       table.projectId,
       table.organizationMemberId,

--- a/apps/backend-hono/test/checklists.spec.ts
+++ b/apps/backend-hono/test/checklists.spec.ts
@@ -143,7 +143,7 @@ async function getFirstMembership(organizationId: string) {
 async function createProject(input: {
   headers: Headers;
   organizationSlug: string;
-  projectOwnerMemberId: string;
+  projectOwnerMemberId?: string | null;
 }) {
   const projectToken = crypto.randomUUID().slice(0, 8);
   const response = await callTRPC(
@@ -153,7 +153,7 @@ async function createProject(input: {
         description: 'Checklist readiness work for this Organization.',
         name: `Checklist Readiness ${projectToken}`,
         organizationSlug: input.organizationSlug,
-        projectOwnerMemberId: input.projectOwnerMemberId,
+        projectOwnerMemberId: input.projectOwnerMemberId ?? null,
         slug: `checklist-readiness-${projectToken}`,
       }),
     201,
@@ -162,6 +162,26 @@ async function createProject(input: {
   expect(response.status).toBe(201);
 
   return response.body.project;
+}
+
+async function createProjectAssignment(input: {
+  headers: Headers;
+  organizationMemberId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  role: 'project_contributor' | 'project_owner';
+}) {
+  return callTRPC(
+    input.headers,
+    (caller) =>
+      caller.projects.createAssignment({
+        organizationMemberId: input.organizationMemberId,
+        organizationSlug: input.organizationSlug,
+        projectSlug: input.projectSlug,
+        role: input.role,
+      }),
+    201,
+  );
 }
 
 async function archiveProject(input: {
@@ -672,6 +692,155 @@ describe('Project Checklists', () => {
     expect(uncheckedResponse.body.projectChecklist).toMatchObject({
       isComplete: false,
       items: [expect.objectContaining({ checked: false, id: checklistItemId })],
+    });
+  });
+
+  it('uses Project Assignments for Project Checklist visibility and checking', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'checklist-assignment-owner',
+    );
+    const projectOwner = await createSignedInMember({
+      organizationId: organization.id,
+      ownerHeaders,
+      prefix: 'checklist-assignment-project-owner',
+      role: 'member',
+    });
+    const contributor = await createSignedInMember({
+      organizationId: organization.id,
+      ownerHeaders,
+      prefix: 'checklist-assignment-contributor',
+      role: 'member',
+    });
+    const unassigned = await createSignedInMember({
+      organizationId: organization.id,
+      ownerHeaders,
+      prefix: 'checklist-assignment-unassigned',
+      role: 'member',
+    });
+    const project = await createProject({
+      headers: ownerHeaders,
+      organizationSlug: organization.slug,
+      projectOwnerMemberId: projectOwner.membership.id,
+    });
+
+    await createProjectAssignment({
+      headers: ownerHeaders,
+      organizationMemberId: contributor.membership.id,
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+      role: 'project_contributor',
+    });
+
+    const control = await createActiveControl({
+      headers: ownerHeaders,
+      organizationSlug: organization.slug,
+      title: 'Verify assignment-scoped checklist access',
+    });
+    const checklistResponse = await createProjectChecklist({
+      controlIds: [control.id],
+      headers: ownerHeaders,
+      name: 'Assignment-scoped checklist',
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+    const checklistItemId = checklistResponse.body.projectChecklist.items[0]?.id;
+
+    expect(checklistItemId).toBeTruthy();
+
+    if (!checklistItemId) {
+      throw new Error('Expected a Checklist Item.');
+    }
+
+    await expect(
+      listProjectChecklists({
+        headers: contributor.headers,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+      }),
+    ).resolves.toMatchObject({
+      body: { projectChecklists: [{ name: 'Assignment-scoped checklist' }] },
+      status: 200,
+    });
+    await expect(
+      listProjectChecklists({
+        headers: unassigned.headers,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+      }),
+    ).resolves.toMatchObject({ body: { error: 'Project unavailable' }, status: 404 });
+    await expect(
+      setChecklistItemChecked({
+        checked: true,
+        checklistItemId,
+        headers: contributor.headers,
+        organizationSlug: organization.slug,
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Only the Project Owner can check Checklist Items.' },
+      status: 403,
+    });
+    await expect(
+      setChecklistItemChecked({
+        checked: true,
+        checklistItemId,
+        headers: ownerHeaders,
+        organizationSlug: organization.slug,
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Only the Project Owner can check Checklist Items.' },
+      status: 403,
+    });
+
+    const checkedResponse = await setChecklistItemChecked({
+      checked: true,
+      checklistItemId,
+      headers: projectOwner.headers,
+      organizationSlug: organization.slug,
+    });
+
+    expect(checkedResponse.status).toBe(200);
+    expect(checkedResponse.body.projectChecklist).toMatchObject({
+      items: [expect.objectContaining({ checked: true, id: checklistItemId })],
+    });
+  });
+
+  it('blocks Checklist Item checking on ownerless Projects', async () => {
+    const { headers, organization } = await createSignedInOwner('checklist-ownerless-owner');
+    const project = await createProject({
+      headers,
+      organizationSlug: organization.slug,
+      projectOwnerMemberId: null,
+    });
+    const control = await createActiveControl({
+      headers,
+      organizationSlug: organization.slug,
+      title: 'Verify ownerless checklist completion',
+    });
+    const checklistResponse = await createProjectChecklist({
+      controlIds: [control.id],
+      headers,
+      name: 'Ownerless checklist',
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+    const checklistItemId = checklistResponse.body.projectChecklist.items[0]?.id;
+
+    expect(checklistItemId).toBeTruthy();
+
+    if (!checklistItemId) {
+      throw new Error('Expected a Checklist Item.');
+    }
+
+    await expect(
+      setChecklistItemChecked({
+        checked: true,
+        checklistItemId,
+        headers,
+        organizationSlug: organization.slug,
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Only the Project Owner can check Checklist Items.' },
+      status: 403,
     });
   });
 

--- a/apps/backend-hono/test/checklists.spec.ts
+++ b/apps/backend-hono/test/checklists.spec.ts
@@ -143,7 +143,7 @@ async function getFirstMembership(organizationId: string) {
 async function createProject(input: {
   headers: Headers;
   organizationSlug: string;
-  projectOwnerMemberId?: string | null;
+  projectOwnerAssignmentMemberId?: string | null;
 }) {
   const projectToken = crypto.randomUUID().slice(0, 8);
   const response = await callTRPC(
@@ -153,13 +153,22 @@ async function createProject(input: {
         description: 'Checklist readiness work for this Organization.',
         name: `Checklist Readiness ${projectToken}`,
         organizationSlug: input.organizationSlug,
-        projectOwnerMemberId: input.projectOwnerMemberId ?? null,
         slug: `checklist-readiness-${projectToken}`,
       }),
     201,
   );
 
   expect(response.status).toBe(201);
+
+  if (input.projectOwnerAssignmentMemberId) {
+    await createProjectAssignment({
+      headers: input.headers,
+      organizationMemberId: input.projectOwnerAssignmentMemberId,
+      organizationSlug: input.organizationSlug,
+      projectSlug: response.body.project.slug,
+      role: 'project_owner',
+    });
+  }
 
   return response.body.project;
 }
@@ -534,7 +543,7 @@ describe('Project Checklists', () => {
     const project = await createProject({
       headers,
       organizationSlug: organization.slug,
-      projectOwnerMemberId: ownerMembership.id,
+      projectOwnerAssignmentMemberId: ownerMembership.id,
     });
     const control = await createActiveControl({
       headers,
@@ -596,7 +605,7 @@ describe('Project Checklists', () => {
     const project = await createProject({
       headers,
       organizationSlug: organization.slug,
-      projectOwnerMemberId: ownerMembership.id,
+      projectOwnerAssignmentMemberId: ownerMembership.id,
     });
     const firstControl = await createActiveControl({
       headers,
@@ -641,7 +650,7 @@ describe('Project Checklists', () => {
     const project = await createProject({
       headers: ownerHeaders,
       organizationSlug: organization.slug,
-      projectOwnerMemberId: projectOwner.membership.id,
+      projectOwnerAssignmentMemberId: projectOwner.membership.id,
     });
     const control = await createActiveControl({
       headers: ownerHeaders,
@@ -720,7 +729,7 @@ describe('Project Checklists', () => {
     const project = await createProject({
       headers: ownerHeaders,
       organizationSlug: organization.slug,
-      projectOwnerMemberId: projectOwner.membership.id,
+      projectOwnerAssignmentMemberId: projectOwner.membership.id,
     });
 
     await createProjectAssignment({
@@ -809,7 +818,7 @@ describe('Project Checklists', () => {
     const project = await createProject({
       headers,
       organizationSlug: organization.slug,
-      projectOwnerMemberId: null,
+      projectOwnerAssignmentMemberId: null,
     });
     const control = await createActiveControl({
       headers,
@@ -856,7 +865,7 @@ describe('Project Checklists', () => {
     const project = await createProject({
       headers: ownerHeaders,
       organizationSlug: organization.slug,
-      projectOwnerMemberId: projectOwner.membership.id,
+      projectOwnerAssignmentMemberId: projectOwner.membership.id,
     });
     const control = await createActiveControl({
       headers: ownerHeaders,
@@ -950,7 +959,7 @@ describe('Project Checklists', () => {
     const project = await createProject({
       headers: ownerHeaders,
       organizationSlug: organization.slug,
-      projectOwnerMemberId: ownerMembership.id,
+      projectOwnerAssignmentMemberId: ownerMembership.id,
     });
     const control = await createActiveControl({
       headers: ownerHeaders,
@@ -1019,7 +1028,7 @@ describe('Project Checklists', () => {
     const project = await createProject({
       headers,
       organizationSlug: organization.slug,
-      projectOwnerMemberId: ownerMembership.id,
+      projectOwnerAssignmentMemberId: ownerMembership.id,
     });
     const control = await createActiveControl({
       headers,
@@ -1100,7 +1109,7 @@ describe('Project Checklists', () => {
     const project = await createProject({
       headers,
       organizationSlug: organization.slug,
-      projectOwnerMemberId: ownerMembership.id,
+      projectOwnerAssignmentMemberId: ownerMembership.id,
     });
     const checkedControl = await createActiveControl({
       headers,
@@ -1176,7 +1185,7 @@ describe('Project Checklists', () => {
     const project = await createProject({
       headers,
       organizationSlug: organization.slug,
-      projectOwnerMemberId: ownerMembership.id,
+      projectOwnerAssignmentMemberId: ownerMembership.id,
     });
     const control = await createActiveControl({
       headers,
@@ -1400,7 +1409,7 @@ describe('Project Checklists', () => {
     const project = await createProject({
       headers,
       organizationSlug: organization.slug,
-      projectOwnerMemberId: ownerMembership.id,
+      projectOwnerAssignmentMemberId: ownerMembership.id,
     });
     const firstControl = await createActiveControl({
       headers,
@@ -1496,7 +1505,7 @@ describe('Project Checklists', () => {
     const project = await createProject({
       headers,
       organizationSlug: organization.slug,
-      projectOwnerMemberId: ownerMembership.id,
+      projectOwnerAssignmentMemberId: ownerMembership.id,
     });
     const control = await createActiveControl({
       headers,

--- a/apps/backend-hono/test/project-detail.spec.ts
+++ b/apps/backend-hono/test/project-detail.spec.ts
@@ -2,7 +2,7 @@ import { and, eq } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 
 import { db } from '../src/db/client';
-import { members, projects, users } from '../src/db/schema';
+import { members, projectAssignments, projects, users } from '../src/db/schema';
 import { auth } from '../src/lib/auth';
 import { callTRPC } from './trpc-test-utils';
 
@@ -154,6 +154,17 @@ async function createProject(input: {
     updatedAt: now,
   });
 
+  if (input.projectOwnerMemberId) {
+    await db.insert(projectAssignments).values({
+      createdAt: now,
+      id: crypto.randomUUID(),
+      organizationMemberId: input.projectOwnerMemberId,
+      projectId: id,
+      role: 'project_owner',
+      updatedAt: now,
+    });
+  }
+
   return id;
 }
 
@@ -185,13 +196,13 @@ describe('Project detail API', () => {
     expect(response.status).toBe(401);
   });
 
-  it('loads a Project by organization-local slug for Organization members', async () => {
+  it('loads a Project by organization-local slug for assigned Organization members', async () => {
     const owner = await createSignedInOwner('project-detail-owner');
     const member = await addMemberToOrganization(owner.organization.id, 'project-detail-member');
 
     await createProject({
       organizationId: owner.organization.id,
-      projectOwnerMemberId: owner.member.id,
+      projectOwnerMemberId: member.memberId,
       slug: 'vendor-risk',
     });
 
@@ -203,16 +214,16 @@ describe('Project detail API', () => {
       description: 'Governance work for reviewing critical vendor risk.',
       slug: 'vendor-risk',
       projectOwner: {
-        email: owner.credentials.email,
-        name: owner.credentials.name,
-        role: 'owner',
+        email: member.credentials.email,
+        name: member.credentials.name,
+        role: 'member',
       },
     });
     expect(response.body.project?.createdAt).toBeTruthy();
     expect(response.body.project?.archivedAt).toBeNull();
   });
 
-  it('keeps archived Project detail URLs reachable for Organization members', async () => {
+  it('keeps archived Project detail URLs reachable for assigned Organization members', async () => {
     const owner = await createSignedInOwner('project-detail-archived-owner');
     const member = await addMemberToOrganization(
       owner.organization.id,
@@ -220,7 +231,7 @@ describe('Project detail API', () => {
     );
     const projectId = await createProject({
       organizationId: owner.organization.id,
-      projectOwnerMemberId: null,
+      projectOwnerMemberId: member.memberId,
       slug: 'archived-project',
     });
     const archivedAt = new Date();
@@ -259,6 +270,27 @@ describe('Project detail API', () => {
     await expect(
       getProjectDetail(outsider.headers, outsider.organization.slug, 'internal-controls'),
     ).resolves.toMatchObject({ body: { status: 'unavailable' }, status: 200 });
+  });
+
+  it('hides direct Project URLs from unassigned regular Organization members', async () => {
+    const owner = await createSignedInOwner('project-detail-unassigned-owner');
+    const member = await addMemberToOrganization(owner.organization.id, 'project-detail-unassigned');
+
+    await createProject({
+      organizationId: owner.organization.id,
+      projectOwnerMemberId: null,
+      slug: 'unassigned-project',
+    });
+
+    await expect(
+      getProjectDetail(member.headers, owner.organization.slug, 'unassigned-project'),
+    ).resolves.toMatchObject({ body: { status: 'unavailable' }, status: 200 });
+    await expect(
+      getProjectDetail(owner.headers, owner.organization.slug, 'unassigned-project'),
+    ).resolves.toMatchObject({
+      body: { project: { slug: 'unassigned-project' }, status: 'available' },
+      status: 200,
+    });
   });
 
   it('lets Organization owners edit Project settings without changing the slug', async () => {

--- a/apps/backend-hono/test/project-detail.spec.ts
+++ b/apps/backend-hono/test/project-detail.spec.ts
@@ -137,7 +137,7 @@ async function addMemberToOrganization(organizationId: string, prefix: string) {
 
 async function createProject(input: {
   organizationId: string;
-  projectOwnerMemberId: string | null;
+  projectOwnerAssignmentMemberId: string | null;
   slug: string;
 }) {
   const now = new Date();
@@ -149,16 +149,15 @@ async function createProject(input: {
     name: 'Vendor Risk Review',
     description: 'Governance work for reviewing critical vendor risk.',
     slug: input.slug,
-    projectOwnerMemberId: input.projectOwnerMemberId,
     createdAt: now,
     updatedAt: now,
   });
 
-  if (input.projectOwnerMemberId) {
+  if (input.projectOwnerAssignmentMemberId) {
     await db.insert(projectAssignments).values({
       createdAt: now,
       id: crypto.randomUUID(),
-      organizationMemberId: input.projectOwnerMemberId,
+      organizationMemberId: input.projectOwnerAssignmentMemberId,
       projectId: id,
       role: 'project_owner',
       updatedAt: now,
@@ -183,10 +182,6 @@ async function updateProject(
   );
 }
 
-async function listOrganizationMembers(headers: Headers, organizationSlug: string) {
-  return callTRPC(headers, (caller) => caller.organizations.members({ organizationSlug }));
-}
-
 describe('Project detail API', () => {
   it('requires authentication', async () => {
     const response = await callTRPC(undefined, (caller) =>
@@ -202,7 +197,7 @@ describe('Project detail API', () => {
 
     await createProject({
       organizationId: owner.organization.id,
-      projectOwnerMemberId: member.memberId,
+      projectOwnerAssignmentMemberId: member.memberId,
       slug: 'vendor-risk',
     });
 
@@ -231,7 +226,7 @@ describe('Project detail API', () => {
     );
     const projectId = await createProject({
       organizationId: owner.organization.id,
-      projectOwnerMemberId: member.memberId,
+      projectOwnerAssignmentMemberId: member.memberId,
       slug: 'archived-project',
     });
     const archivedAt = new Date();
@@ -257,7 +252,7 @@ describe('Project detail API', () => {
 
     await createProject({
       organizationId: owner.organization.id,
-      projectOwnerMemberId: null,
+      projectOwnerAssignmentMemberId: null,
       slug: 'internal-controls',
     });
 
@@ -278,7 +273,7 @@ describe('Project detail API', () => {
 
     await createProject({
       organizationId: owner.organization.id,
-      projectOwnerMemberId: null,
+      projectOwnerAssignmentMemberId: null,
       slug: 'unassigned-project',
     });
 
@@ -295,21 +290,16 @@ describe('Project detail API', () => {
 
   it('lets Organization owners edit Project settings without changing the slug', async () => {
     const owner = await createSignedInOwner('project-settings-owner');
-    const projectOwner = await addMemberToOrganization(
-      owner.organization.id,
-      'project-settings-accountable',
-    );
 
     await createProject({
       organizationId: owner.organization.id,
-      projectOwnerMemberId: null,
+      projectOwnerAssignmentMemberId: null,
       slug: 'vendor-risk',
     });
 
     const response = await updateProject(owner.headers, owner.organization.slug, 'vendor-risk', {
       description: 'Updated governance work for critical vendor risk.',
       name: 'Critical Vendor Risk',
-      projectOwnerMemberId: projectOwner.memberId,
       slug: 'ignored-new-slug',
     });
 
@@ -317,11 +307,7 @@ describe('Project detail API', () => {
     expect(response.body.project).toMatchObject({
       description: 'Updated governance work for critical vendor risk.',
       name: 'Critical Vendor Risk',
-      projectOwner: {
-        email: projectOwner.credentials.email,
-        name: projectOwner.credentials.name,
-        role: 'member',
-      },
+      projectOwner: null,
       slug: 'vendor-risk',
     });
 
@@ -335,56 +321,6 @@ describe('Project detail API', () => {
     expect(renamedProject.body.project?.slug).toBe('vendor-risk');
   });
 
-  it('lets Organization owners set an accepted member as Project Owner', async () => {
-    const owner = await createSignedInOwner('project-settings-invited-owner');
-    const memberCredentials = createCredentials('project-settings-invited-member');
-
-    await signUpUser(memberCredentials);
-
-    const invitation = await auth.api.createInvitation({
-      body: {
-        email: memberCredentials.email,
-        organizationId: owner.organization.id,
-        role: 'member',
-      },
-      headers: owner.headers,
-    });
-    const memberHeaders = await signInUser(memberCredentials);
-
-    await auth.api.acceptInvitation({
-      body: { invitationId: invitation.id },
-      headers: memberHeaders,
-    });
-
-    await createProject({
-      organizationId: owner.organization.id,
-      projectOwnerMemberId: null,
-      slug: 'vendor-risk',
-    });
-
-    const membersResponse = await listOrganizationMembers(owner.headers, owner.organization.slug);
-    const projectOwner = membersResponse.body.members.find(
-      (organizationMember: { email: string }) =>
-        organizationMember.email === memberCredentials.email,
-    ) as { id: string } | undefined;
-
-    expect(projectOwner?.id).toBeTruthy();
-
-    const response = await updateProject(owner.headers, owner.organization.slug, 'vendor-risk', {
-      description: 'Updated governance work for critical vendor risk.',
-      name: 'Critical Vendor Risk',
-      projectOwnerMemberId: projectOwner?.id,
-    });
-
-    expect(response.status).toBe(200);
-    expect(response.body.project).toMatchObject({
-      projectOwner: {
-        email: memberCredentials.email,
-        id: projectOwner?.id,
-      },
-    });
-  });
-
   it('prevents members from mutating Project settings', async () => {
     const owner = await createSignedInOwner('project-settings-readonly-owner');
     const member = await addMemberToOrganization(
@@ -394,14 +330,13 @@ describe('Project detail API', () => {
 
     await createProject({
       organizationId: owner.organization.id,
-      projectOwnerMemberId: owner.member.id,
+      projectOwnerAssignmentMemberId: owner.member.id,
       slug: 'vendor-risk',
     });
 
     const response = await updateProject(member.headers, owner.organization.slug, 'vendor-risk', {
       description: 'Member mutation attempt.',
       name: 'Member Mutation',
-      projectOwnerMemberId: null,
     });
 
     expect(response.status).toBe(403);
@@ -414,47 +349,22 @@ describe('Project detail API', () => {
     });
   });
 
-  it('validates Project settings updates and Project Owner membership', async () => {
+  it('validates Project settings updates', async () => {
     const owner = await createSignedInOwner('project-settings-validation-owner');
-    const outsider = await createSignedInOwner('project-settings-validation-outsider');
 
     await createProject({
       organizationId: owner.organization.id,
-      projectOwnerMemberId: null,
+      projectOwnerAssignmentMemberId: null,
       slug: 'vendor-risk',
     });
-
-    const outsiderMembership = await db
-      .select({ id: members.id })
-      .from(members)
-      .where(eq(members.organizationId, outsider.organization.id))
-      .then((rows) => rows[0]);
-
-    expect(outsiderMembership?.id).toBeTruthy();
-
-    if (!outsiderMembership?.id) {
-      throw new Error('Expected outsider membership.');
-    }
 
     await expect(
       updateProject(owner.headers, owner.organization.slug, 'vendor-risk', {
         description: '',
         name: 'Missing Description',
-        projectOwnerMemberId: null,
       }),
     ).resolves.toMatchObject({
       body: { error: 'Project description is required.' },
-      status: 400,
-    });
-
-    await expect(
-      updateProject(owner.headers, owner.organization.slug, 'vendor-risk', {
-        description: 'Wrong owner membership.',
-        name: 'Wrong Owner',
-        projectOwnerMemberId: outsiderMembership.id,
-      }),
-    ).resolves.toMatchObject({
-      body: { error: 'Project Owner must be a member of this Organization.' },
       status: 400,
     });
   });

--- a/apps/backend-hono/test/project-detail.spec.ts
+++ b/apps/backend-hono/test/project-detail.spec.ts
@@ -269,7 +269,10 @@ describe('Project detail API', () => {
 
   it('hides direct Project URLs from unassigned regular Organization members', async () => {
     const owner = await createSignedInOwner('project-detail-unassigned-owner');
-    const member = await addMemberToOrganization(owner.organization.id, 'project-detail-unassigned');
+    const member = await addMemberToOrganization(
+      owner.organization.id,
+      'project-detail-unassigned',
+    );
 
     await createProject({
       organizationId: owner.organization.id,

--- a/apps/backend-hono/test/project-detail.spec.ts
+++ b/apps/backend-hono/test/project-detail.spec.ts
@@ -157,6 +157,7 @@ async function createProject(input: {
     await db.insert(projectAssignments).values({
       createdAt: now,
       id: crypto.randomUUID(),
+      organizationId: input.organizationId,
       organizationMemberId: input.projectOwnerAssignmentMemberId,
       projectId: id,
       role: 'project_owner',

--- a/apps/backend-hono/test/projects.spec.ts
+++ b/apps/backend-hono/test/projects.spec.ts
@@ -1295,7 +1295,9 @@ describe('organization projects', () => {
       })
       .from(projectAssignments)
       .innerJoin(projects, eq(projectAssignments.projectId, projects.id))
-      .where(and(eq(projects.organizationId, organization.id), eq(projects.slug, 'owner-replacement')));
+      .where(
+        and(eq(projects.organizationId, organization.id), eq(projects.slug, 'owner-replacement')),
+      );
 
     expect(assignments).toEqual(
       expect.arrayContaining([
@@ -1560,12 +1562,14 @@ describe('organization projects', () => {
     expect(createResponse.status).toBe(201);
     expect(assignmentResponse.status).toBe(201);
     expect(listResponse.body).toMatchObject({
-      projects: [{
-        projectOwner: {
-          email: member.email,
-          id: projectOwner?.id,
+      projects: [
+        {
+          projectOwner: {
+            email: member.email,
+            id: projectOwner?.id,
+          },
         },
-      }],
+      ],
     });
   });
 

--- a/apps/backend-hono/test/projects.spec.ts
+++ b/apps/backend-hono/test/projects.spec.ts
@@ -169,6 +169,16 @@ async function listOrganizationMembersRequest(organizationSlug: string, headers:
   return callTRPC(headers, (caller) => caller.organizations.members({ organizationSlug }));
 }
 
+async function removeOrganizationMemberRequest(
+  organizationSlug: string,
+  headers: Headers,
+  organizationMemberId: string,
+) {
+  return callTRPC(headers, (caller) =>
+    caller.organizations.removeMember({ organizationMemberId, organizationSlug }),
+  );
+}
+
 async function listAuditEventsRequest(
   organizationSlug: string,
   headers: Headers,
@@ -1377,6 +1387,127 @@ describe('organization projects', () => {
       body: { projects: [] },
       status: 200,
     });
+  });
+
+  it('removes Project Assignments when an Organization Member is removed', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'project-member-removal-owner',
+    );
+    const member = createCredentials('project-member-removal-member');
+
+    await signUpUser(member);
+
+    const invitation = await auth.api.createInvitation({
+      body: {
+        email: member.email,
+        organizationId: organization.id,
+        role: 'member',
+      },
+      headers: ownerHeaders,
+    });
+    const memberHeaders = await signInUser(member);
+
+    await auth.api.acceptInvitation({
+      body: { invitationId: invitation.id },
+      headers: memberHeaders,
+    });
+
+    const membersResponse = await listOrganizationMembersRequest(organization.slug, ownerHeaders);
+    const assignedMember = membersResponse.body.members.find(
+      (organizationMember: { email: string }) => organizationMember.email === member.email,
+    ) as { id: string } | undefined;
+
+    expect(assignedMember?.id).toBeTruthy();
+
+    await createProjectRequest(organization.slug, ownerHeaders, {
+      description: 'Member removal governance work.',
+      name: 'Member Removal',
+      slug: 'member-removal',
+    });
+    const assignmentResponse = await createProjectAssignmentRequest(
+      organization.slug,
+      'member-removal',
+      ownerHeaders,
+      {
+        organizationMemberId: assignedMember?.id ?? '',
+        role: 'project_contributor',
+      },
+    );
+
+    expect(assignmentResponse.status).toBe(201);
+
+    const removeMemberResponse = await removeOrganizationMemberRequest(
+      organization.slug,
+      ownerHeaders,
+      assignedMember?.id ?? '',
+    );
+
+    expect(removeMemberResponse.status).toBe(200);
+    expect(removeMemberResponse.body.member).toMatchObject({ id: assignedMember?.id });
+    await expect(listProjectsRequest(organization.slug, memberHeaders)).resolves.toMatchObject({
+      body: { error: 'Organization not found' },
+      status: 404,
+    });
+
+    const assignments = await db
+      .select({ id: projectAssignments.id })
+      .from(projectAssignments)
+      .where(eq(projectAssignments.organizationMemberId, assignedMember?.id ?? ''));
+
+    expect(assignments).toEqual([]);
+  });
+
+  it('leaves Projects ownerless when the removed Organization Member was Project Owner', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'project-owner-removal-owner',
+    );
+    const projectOwner = createCredentials('project-owner-removal-project-owner');
+
+    await signUpUser(projectOwner);
+
+    const invitation = await auth.api.createInvitation({
+      body: {
+        email: projectOwner.email,
+        organizationId: organization.id,
+        role: 'member',
+      },
+      headers: ownerHeaders,
+    });
+    const projectOwnerHeaders = await signInUser(projectOwner);
+
+    await auth.api.acceptInvitation({
+      body: { invitationId: invitation.id },
+      headers: projectOwnerHeaders,
+    });
+
+    const membersResponse = await listOrganizationMembersRequest(organization.slug, ownerHeaders);
+    const projectOwnerMember = membersResponse.body.members.find(
+      (organizationMember: { email: string }) => organizationMember.email === projectOwner.email,
+    ) as { id: string } | undefined;
+
+    expect(projectOwnerMember?.id).toBeTruthy();
+
+    await createProjectRequest(organization.slug, ownerHeaders, {
+      description: 'Owner removal governance work.',
+      name: 'Owner Removal',
+      projectOwnerMemberId: projectOwnerMember?.id,
+      slug: 'owner-removal',
+    });
+
+    const removeMemberResponse = await removeOrganizationMemberRequest(
+      organization.slug,
+      ownerHeaders,
+      projectOwnerMember?.id ?? '',
+    );
+    const listResponse = await listProjectsRequest(organization.slug, ownerHeaders);
+
+    expect(removeMemberResponse.status).toBe(200);
+    expect(listResponse.body.projects).toEqual([
+      expect.objectContaining({
+        projectOwner: null,
+        slug: 'owner-removal',
+      }),
+    ]);
   });
 
   it('allows accepted Organization members to be assigned as Project Owner', async () => {

--- a/apps/backend-hono/test/projects.spec.ts
+++ b/apps/backend-hono/test/projects.spec.ts
@@ -799,6 +799,7 @@ describe('organization projects', () => {
     await db.insert(projectAssignments).values({
       createdAt: now,
       id: crypto.randomUUID(),
+      organizationId: organization.id,
       organizationMemberId: ownerMembership.id,
       projectId,
       role: 'project_owner',
@@ -818,6 +819,42 @@ describe('organization projects', () => {
       },
       status: 200,
     });
+  });
+
+  it('rejects cross-Organization Project Assignments at the database boundary', async () => {
+    const first = await createSignedInOwner('project-assignment-integrity-first');
+    const second = await createSignedInOwner('project-assignment-integrity-second');
+    const secondOwnerMembership = await db
+      .select({ id: members.id })
+      .from(members)
+      .where(eq(members.organizationId, second.organization.id))
+      .limit(1)
+      .then((rows) => rows[0]);
+
+    expect(secondOwnerMembership?.id).toBeTruthy();
+
+    if (!secondOwnerMembership?.id) {
+      throw new Error('Expected a second Organization owner membership.');
+    }
+
+    const createResponse = await createProjectRequest(first.organization.slug, first.headers, {
+      description: 'Cross-Organization assignment integrity.',
+      name: 'Assignment Integrity',
+      slug: 'assignment-integrity',
+    });
+
+    expect(createResponse.status).toBe(201);
+    await expect(
+      db.insert(projectAssignments).values({
+        createdAt: new Date(),
+        id: crypto.randomUUID(),
+        organizationId: first.organization.id,
+        organizationMemberId: secondOwnerMembership.id,
+        projectId: createResponse.body.project.id,
+        role: 'project_contributor',
+        updatedAt: new Date(),
+      }),
+    ).rejects.toThrow();
   });
 
   it('lets Organization owners assign Contributors to make Projects visible', async () => {

--- a/apps/backend-hono/test/projects.spec.ts
+++ b/apps/backend-hono/test/projects.spec.ts
@@ -755,6 +755,55 @@ describe('organization projects', () => {
     });
   });
 
+  it('rejects duplicate Project Assignments for the same Organization Member', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'project-assignment-duplicate-owner',
+    );
+    const ownerMembership = await db
+      .select({ id: members.id })
+      .from(members)
+      .where(eq(members.organizationId, organization.id))
+      .limit(1)
+      .then((rows) => rows[0]);
+
+    expect(ownerMembership?.id).toBeTruthy();
+
+    if (!ownerMembership?.id) {
+      throw new Error('Expected owner membership.');
+    }
+
+    await createProjectRequest(organization.slug, ownerHeaders, {
+      description: 'Duplicate assignment governance work.',
+      name: 'Duplicate Assignment',
+      slug: 'duplicate-assignment',
+    });
+
+    const firstAssignment = await createProjectAssignmentRequest(
+      organization.slug,
+      'duplicate-assignment',
+      ownerHeaders,
+      {
+        organizationMemberId: ownerMembership.id,
+        role: 'project_contributor',
+      },
+    );
+    const duplicateAssignment = await createProjectAssignmentRequest(
+      organization.slug,
+      'duplicate-assignment',
+      ownerHeaders,
+      {
+        organizationMemberId: ownerMembership.id,
+        role: 'project_owner',
+      },
+    );
+
+    expect(firstAssignment.status).toBe(201);
+    expect(duplicateAssignment.status).toBe(400);
+    expect(duplicateAssignment.body).toMatchObject({
+      error: 'Organization Member already has a Project Assignment for this Project.',
+    });
+  });
+
   it('lets Organization owners change a Contributor assignment to Project Owner', async () => {
     const { headers: ownerHeaders, organization } = await createSignedInOwner(
       'project-assignment-role-owner',

--- a/apps/backend-hono/test/projects.spec.ts
+++ b/apps/backend-hono/test/projects.spec.ts
@@ -327,6 +327,117 @@ describe('organization projects', () => {
     });
   });
 
+  it('records Audit Events for Project Assignment creation, role changes, and removal', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'project-assignment-audit-owner',
+    );
+    const member = createCredentials('project-assignment-audit-member');
+
+    await signUpUser(member);
+
+    const invitation = await auth.api.createInvitation({
+      body: {
+        email: member.email,
+        organizationId: organization.id,
+        role: 'member',
+      },
+      headers: ownerHeaders,
+    });
+    const memberHeaders = await signInUser(member);
+
+    await auth.api.acceptInvitation({
+      body: { invitationId: invitation.id },
+      headers: memberHeaders,
+    });
+
+    const membersResponse = await listOrganizationMembersRequest(organization.slug, ownerHeaders);
+    const assignedMember = membersResponse.body.members.find(
+      (organizationMember: { email: string }) => organizationMember.email === member.email,
+    ) as { id: string } | undefined;
+
+    expect(assignedMember?.id).toBeTruthy();
+
+    const projectResponse = await createProjectRequest(organization.slug, ownerHeaders, {
+      description: 'Assignment audit governance work.',
+      name: 'Assignment Audit',
+      slug: 'assignment-audit',
+    });
+    const createAssignmentResponse = await createProjectAssignmentRequest(
+      organization.slug,
+      'assignment-audit',
+      ownerHeaders,
+      {
+        organizationMemberId: assignedMember?.id ?? '',
+        role: 'project_contributor',
+      },
+    );
+
+    expect(createAssignmentResponse.status).toBe(201);
+
+    const updateAssignmentResponse = await updateProjectAssignmentRequest(
+      organization.slug,
+      'assignment-audit',
+      ownerHeaders,
+      {
+        assignmentId: createAssignmentResponse.body.assignment.id,
+        role: 'project_owner',
+      },
+    );
+    const removeAssignmentResponse = await removeProjectAssignmentRequest(
+      organization.slug,
+      'assignment-audit',
+      ownerHeaders,
+      createAssignmentResponse.body.assignment.id,
+    );
+
+    expect(updateAssignmentResponse.status).toBe(200);
+    expect(removeAssignmentResponse.status).toBe(200);
+
+    const auditResponse = await listAuditEventsRequest(organization.slug, ownerHeaders, {
+      targetId: projectResponse.body.project.id,
+      targetType: 'project',
+    });
+
+    expect(auditResponse.status).toBe(200);
+    expect(auditResponse.body.auditEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'project_assignment.created',
+          metadata: {
+            organizationMemberId: assignedMember?.id,
+            role: 'project_contributor',
+          },
+          targetId: projectResponse.body.project.id,
+          targetSecondaryLabel: 'assignment-audit',
+          targetType: 'project',
+        }),
+        expect.objectContaining({
+          action: 'project_assignment.role_changed',
+          metadata: {
+            organizationMemberId: assignedMember?.id,
+            role: {
+              from: 'project_contributor',
+              to: 'project_owner',
+            },
+          },
+          targetId: projectResponse.body.project.id,
+          targetSecondaryLabel: 'assignment-audit',
+          targetType: 'project',
+        }),
+        expect.objectContaining({
+          action: 'project_assignment.removed',
+          metadata: {
+            organizationMemberId: assignedMember?.id,
+            role: 'project_owner',
+          },
+          targetId: projectResponse.body.project.id,
+          targetSecondaryLabel: 'assignment-audit',
+          targetType: 'project',
+        }),
+      ]),
+    );
+  });
+
   it('filters and bounds Organization Audit Events for read clients', async () => {
     const { headers, organization } = await createSignedInOwner('project-audit-filter-owner');
 

--- a/apps/backend-hono/test/projects.spec.ts
+++ b/apps/backend-hono/test/projects.spec.ts
@@ -147,6 +147,16 @@ async function removeProjectAssignmentRequest(
   );
 }
 
+async function listProjectAssignmentsRequest(
+  organizationSlug: string,
+  projectSlug: string,
+  headers: Headers,
+) {
+  return callTRPC(headers, (caller) =>
+    caller.projects.assignments({ organizationSlug, projectSlug }),
+  );
+}
+
 async function listProjectsRequest(
   organizationSlug: string,
   headers: Headers,
@@ -801,6 +811,221 @@ describe('organization projects', () => {
     expect(duplicateAssignment.status).toBe(400);
     expect(duplicateAssignment.body).toMatchObject({
       error: 'Organization Member already has a Project Assignment for this Project.',
+    });
+  });
+
+  it('rejects Project Assignment changes while the Project is archived', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'project-assignment-archived-owner',
+    );
+    const ownerMembership = await db
+      .select({ id: members.id })
+      .from(members)
+      .where(eq(members.organizationId, organization.id))
+      .limit(1)
+      .then((rows) => rows[0]);
+
+    expect(ownerMembership?.id).toBeTruthy();
+
+    if (!ownerMembership?.id) {
+      throw new Error('Expected owner membership.');
+    }
+
+    await createProjectRequest(organization.slug, ownerHeaders, {
+      description: 'Archived assignment governance work.',
+      name: 'Archived Assignment',
+      slug: 'archived-assignment',
+    });
+    const assignmentResponse = await createProjectAssignmentRequest(
+      organization.slug,
+      'archived-assignment',
+      ownerHeaders,
+      {
+        organizationMemberId: ownerMembership.id,
+        role: 'project_contributor',
+      },
+    );
+
+    expect(assignmentResponse.status).toBe(201);
+
+    await archiveProjectRequest(organization.slug, 'archived-assignment', ownerHeaders);
+
+    await expect(
+      createProjectAssignmentRequest(organization.slug, 'archived-assignment', ownerHeaders, {
+        organizationMemberId: ownerMembership.id,
+        role: 'project_owner',
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Project Assignments cannot be changed while a Project is archived.' },
+      status: 400,
+    });
+    await expect(
+      updateProjectAssignmentRequest(organization.slug, 'archived-assignment', ownerHeaders, {
+        assignmentId: assignmentResponse.body.assignment.id,
+        role: 'project_owner',
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Project Assignments cannot be changed while a Project is archived.' },
+      status: 400,
+    });
+    await expect(
+      removeProjectAssignmentRequest(
+        organization.slug,
+        'archived-assignment',
+        ownerHeaders,
+        assignmentResponse.body.assignment.id,
+      ),
+    ).resolves.toMatchObject({
+      body: { error: 'Project Assignments cannot be changed while a Project is archived.' },
+      status: 400,
+    });
+  });
+
+  it('prevents regular Organization members from managing Project Assignments', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'project-assignment-permission-owner',
+    );
+    const member = createCredentials('project-assignment-permission-member');
+
+    await signUpUser(member);
+
+    const invitation = await auth.api.createInvitation({
+      body: {
+        email: member.email,
+        organizationId: organization.id,
+        role: 'member',
+      },
+      headers: ownerHeaders,
+    });
+    const memberHeaders = await signInUser(member);
+
+    await auth.api.acceptInvitation({
+      body: { invitationId: invitation.id },
+      headers: memberHeaders,
+    });
+
+    const membersResponse = await listOrganizationMembersRequest(organization.slug, ownerHeaders);
+    const assignedMember = membersResponse.body.members.find(
+      (organizationMember: { email: string }) => organizationMember.email === member.email,
+    ) as { id: string } | undefined;
+
+    expect(assignedMember?.id).toBeTruthy();
+
+    await createProjectRequest(organization.slug, ownerHeaders, {
+      description: 'Assignment permission governance work.',
+      name: 'Assignment Permission',
+      slug: 'assignment-permission',
+    });
+    const assignmentResponse = await createProjectAssignmentRequest(
+      organization.slug,
+      'assignment-permission',
+      ownerHeaders,
+      {
+        organizationMemberId: assignedMember?.id ?? '',
+        role: 'project_contributor',
+      },
+    );
+
+    expect(assignmentResponse.status).toBe(201);
+
+    await expect(
+      createProjectAssignmentRequest(organization.slug, 'assignment-permission', memberHeaders, {
+        organizationMemberId: assignedMember?.id ?? '',
+        role: 'project_owner',
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Only Organization owners and admins can create Project Assignments.' },
+      status: 403,
+    });
+    await expect(
+      updateProjectAssignmentRequest(organization.slug, 'assignment-permission', memberHeaders, {
+        assignmentId: assignmentResponse.body.assignment.id,
+        role: 'project_owner',
+      }),
+    ).resolves.toMatchObject({
+      body: { error: 'Only Organization owners and admins can change Project Assignments.' },
+      status: 403,
+    });
+    await expect(
+      removeProjectAssignmentRequest(
+        organization.slug,
+        'assignment-permission',
+        memberHeaders,
+        assignmentResponse.body.assignment.id,
+      ),
+    ).resolves.toMatchObject({
+      body: { error: 'Only Organization owners and admins can remove Project Assignments.' },
+      status: 403,
+    });
+  });
+
+  it('lists the Project Assignment roster for owners but not Contributors', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'project-assignment-roster-owner',
+    );
+    const member = createCredentials('project-assignment-roster-member');
+
+    await signUpUser(member);
+
+    const invitation = await auth.api.createInvitation({
+      body: {
+        email: member.email,
+        organizationId: organization.id,
+        role: 'member',
+      },
+      headers: ownerHeaders,
+    });
+    const memberHeaders = await signInUser(member);
+
+    await auth.api.acceptInvitation({
+      body: { invitationId: invitation.id },
+      headers: memberHeaders,
+    });
+
+    const membersResponse = await listOrganizationMembersRequest(organization.slug, ownerHeaders);
+    const assignedMember = membersResponse.body.members.find(
+      (organizationMember: { email: string }) => organizationMember.email === member.email,
+    ) as { id: string } | undefined;
+
+    expect(assignedMember?.id).toBeTruthy();
+
+    await createProjectRequest(organization.slug, ownerHeaders, {
+      description: 'Assignment roster governance work.',
+      name: 'Assignment Roster',
+      slug: 'assignment-roster',
+    });
+    const assignmentResponse = await createProjectAssignmentRequest(
+      organization.slug,
+      'assignment-roster',
+      ownerHeaders,
+      {
+        organizationMemberId: assignedMember?.id ?? '',
+        role: 'project_contributor',
+      },
+    );
+
+    expect(assignmentResponse.status).toBe(201);
+
+    await expect(
+      listProjectAssignmentsRequest(organization.slug, 'assignment-roster', ownerHeaders),
+    ).resolves.toMatchObject({
+      body: {
+        assignments: [
+          {
+            email: member.email,
+            id: assignmentResponse.body.assignment.id,
+            organizationMemberId: assignedMember?.id,
+            role: 'project_contributor',
+          },
+        ],
+      },
+      status: 200,
+    });
+    await expect(
+      listProjectAssignmentsRequest(organization.slug, 'assignment-roster', memberHeaders),
+    ).resolves.toMatchObject({
+      body: { error: 'Only Organization owners and admins can view Project Assignments.' },
+      status: 403,
     });
   });
 

--- a/apps/backend-hono/test/projects.spec.ts
+++ b/apps/backend-hono/test/projects.spec.ts
@@ -236,7 +236,6 @@ describe('organization projects', () => {
     const createResponse = await createProjectRequest(organization.slug, headers, {
       description: 'SOC 2 readiness work for this Organization.',
       name: 'SOC 2 Readiness',
-      projectOwnerMemberId: ownerMembership.id,
       slug: 'soc-2-readiness',
     });
 
@@ -244,8 +243,12 @@ describe('organization projects', () => {
     expect(createResponse.body.project).toMatchObject({
       description: 'SOC 2 readiness work for this Organization.',
       name: 'SOC 2 Readiness',
-      projectOwner: { id: ownerMembership.id },
+      projectOwner: null,
       slug: 'soc-2-readiness',
+    });
+    await createProjectAssignmentRequest(organization.slug, 'soc-2-readiness', headers, {
+      organizationMemberId: ownerMembership.id,
+      role: 'project_owner',
     });
 
     const listResponse = await listProjectsRequest(organization.slug, headers);
@@ -255,6 +258,7 @@ describe('organization projects', () => {
       projects: [
         {
           name: 'SOC 2 Readiness',
+          projectOwner: { id: ownerMembership.id },
           slug: 'soc-2-readiness',
         },
       ],
@@ -279,7 +283,6 @@ describe('organization projects', () => {
     const createResponse = await createProjectRequest(organization.slug, headers, {
       description: 'Governance launch work.',
       name: 'Governance Launch',
-      projectOwnerMemberId: ownerMembership.id,
       slug: 'governance-launch',
     });
 
@@ -638,7 +641,6 @@ describe('organization projects', () => {
         description: 'Updated governance work.',
         name: 'Updated Project Name',
         organizationSlug: organization.slug,
-        projectOwnerMemberId: ownerMembership.id,
         projectSlug: 'initial-project-name',
       }),
     );
@@ -663,14 +665,6 @@ describe('organization projects', () => {
         name: {
           from: 'Initial Project Name',
           to: 'Updated Project Name',
-        },
-        projectOwner: {
-          from: null,
-          to: {
-            displayName: 'project-audit-update-owner user',
-            email: expect.stringContaining('project-audit-update-owner-'),
-            organizationMemberId: ownerMembership.id,
-          },
         },
       },
     });
@@ -751,8 +745,11 @@ describe('organization projects', () => {
     await createProjectRequest(organization.slug, ownerHeaders, {
       description: 'Assigned governance work.',
       name: 'Assigned Project',
-      projectOwnerMemberId: assignedMember?.id,
       slug: 'assigned-project',
+    });
+    await createProjectAssignmentRequest(organization.slug, 'assigned-project', ownerHeaders, {
+      organizationMemberId: assignedMember?.id ?? '',
+      role: 'project_contributor',
     });
     await createProjectRequest(organization.slug, ownerHeaders, {
       description: 'Unassigned governance work.',
@@ -796,7 +793,6 @@ describe('organization projects', () => {
       id: projectId,
       name: 'Assignment Owner',
       organizationId: organization.id,
-      projectOwnerMemberId: null,
       slug: 'assignment-owner',
       updatedAt: now,
     });
@@ -1273,8 +1269,11 @@ describe('organization projects', () => {
     await createProjectRequest(organization.slug, ownerHeaders, {
       description: 'Owner replacement governance work.',
       name: 'Owner Replacement',
-      projectOwnerMemberId: firstProjectOwner.id,
       slug: 'owner-replacement',
+    });
+    await createProjectAssignmentRequest(organization.slug, 'owner-replacement', ownerHeaders, {
+      organizationMemberId: firstProjectOwner.id,
+      role: 'project_owner',
     });
 
     const nextOwnerAssignment = await createProjectAssignmentRequest(
@@ -1490,8 +1489,11 @@ describe('organization projects', () => {
     await createProjectRequest(organization.slug, ownerHeaders, {
       description: 'Owner removal governance work.',
       name: 'Owner Removal',
-      projectOwnerMemberId: projectOwnerMember?.id,
       slug: 'owner-removal',
+    });
+    await createProjectAssignmentRequest(organization.slug, 'owner-removal', ownerHeaders, {
+      organizationMemberId: projectOwnerMember?.id ?? '',
+      role: 'project_owner',
     });
 
     const removeMemberResponse = await removeOrganizationMemberRequest(
@@ -1542,16 +1544,28 @@ describe('organization projects', () => {
     const createResponse = await createProjectRequest(organization.slug, ownerHeaders, {
       description: 'Project owned by an invited Organization member.',
       name: 'Invited Owner',
-      projectOwnerMemberId: projectOwner?.id,
       slug: 'invited-owner',
     });
+    const assignmentResponse = await createProjectAssignmentRequest(
+      organization.slug,
+      'invited-owner',
+      ownerHeaders,
+      {
+        organizationMemberId: projectOwner?.id ?? '',
+        role: 'project_owner',
+      },
+    );
+    const listResponse = await listProjectsRequest(organization.slug, ownerHeaders);
 
     expect(createResponse.status).toBe(201);
-    expect(createResponse.body.project).toMatchObject({
-      projectOwner: {
-        email: member.email,
-        id: projectOwner?.id,
-      },
+    expect(assignmentResponse.status).toBe(201);
+    expect(listResponse.body).toMatchObject({
+      projects: [{
+        projectOwner: {
+          email: member.email,
+          id: projectOwner?.id,
+        },
+      }],
     });
   });
 
@@ -1586,16 +1600,24 @@ describe('organization projects', () => {
       error: 'Project description is required.',
     });
 
-    const wrongOwnerResponse = await createProjectRequest(first.organization.slug, first.headers, {
+    await createProjectRequest(first.organization.slug, first.headers, {
       description: 'Wrong owner membership.',
       name: 'Wrong Owner',
-      projectOwnerMemberId: secondOwnerMembership.id,
       slug: 'wrong-owner',
     });
+    const wrongOwnerResponse = await createProjectAssignmentRequest(
+      first.organization.slug,
+      'wrong-owner',
+      first.headers,
+      {
+        organizationMemberId: secondOwnerMembership.id,
+        role: 'project_owner',
+      },
+    );
 
     expect(wrongOwnerResponse.status).toBe(400);
     expect(wrongOwnerResponse.body).toMatchObject({
-      error: 'Project Owner must be a member of this Organization.',
+      error: 'Project Assignment member must be a member of this Organization.',
     });
 
     await createProjectRequest(first.organization.slug, first.headers, {
@@ -1738,8 +1760,11 @@ describe('organization projects', () => {
     await createProjectRequest(organization.slug, ownerHeaders, {
       description: 'Member-visible archived work.',
       name: 'Member Visible',
-      projectOwnerMemberId: assignedMember?.id,
       slug: 'member-visible',
+    });
+    await createProjectAssignmentRequest(organization.slug, 'member-visible', ownerHeaders, {
+      organizationMemberId: assignedMember?.id ?? '',
+      role: 'project_contributor',
     });
 
     await expect(

--- a/apps/backend-hono/test/projects.spec.ts
+++ b/apps/backend-hono/test/projects.spec.ts
@@ -504,7 +504,7 @@ describe('organization projects', () => {
     });
   });
 
-  it('prevents members from creating Projects but allows them to list active Projects', async () => {
+  it('prevents members from creating Projects but allows them to list visible active Projects', async () => {
     const { headers: ownerHeaders, organization } =
       await createSignedInOwner('project-member-owner');
     const member = createCredentials('project-member');
@@ -542,7 +542,61 @@ describe('organization projects', () => {
     expect(forbiddenCreateResponse.status).toBe(403);
     expect(listResponse.status).toBe(200);
     expect(listResponse.body).toMatchObject({
-      projects: [{ slug: 'vendor-review' }],
+      projects: [],
+    });
+  });
+
+  it('lists only assigned active Projects for regular Organization members', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'project-assigned-list-owner',
+    );
+    const member = createCredentials('project-assigned-list-member');
+
+    await signUpUser(member);
+
+    const invitation = await auth.api.createInvitation({
+      body: {
+        email: member.email,
+        organizationId: organization.id,
+        role: 'member',
+      },
+      headers: ownerHeaders,
+    });
+    const memberHeaders = await signInUser(member);
+
+    await auth.api.acceptInvitation({
+      body: { invitationId: invitation.id },
+      headers: memberHeaders,
+    });
+
+    const membersResponse = await listOrganizationMembersRequest(organization.slug, ownerHeaders);
+    const assignedMember = membersResponse.body.members.find(
+      (organizationMember: { email: string }) => organizationMember.email === member.email,
+    ) as { id: string } | undefined;
+
+    expect(assignedMember?.id).toBeTruthy();
+
+    await createProjectRequest(organization.slug, ownerHeaders, {
+      description: 'Assigned governance work.',
+      name: 'Assigned Project',
+      projectOwnerMemberId: assignedMember?.id,
+      slug: 'assigned-project',
+    });
+    await createProjectRequest(organization.slug, ownerHeaders, {
+      description: 'Unassigned governance work.',
+      name: 'Unassigned Project',
+      slug: 'unassigned-project',
+    });
+
+    await expect(listProjectsRequest(organization.slug, ownerHeaders)).resolves.toMatchObject({
+      body: {
+        projects: [{ slug: 'assigned-project' }, { slug: 'unassigned-project' }],
+      },
+      status: 200,
+    });
+    await expect(listProjectsRequest(organization.slug, memberHeaders)).resolves.toMatchObject({
+      body: { projects: [{ slug: 'assigned-project' }] },
+      status: 200,
     });
   });
 
@@ -764,9 +818,17 @@ describe('organization projects', () => {
       headers: memberHeaders,
     });
 
+    const membersResponse = await listOrganizationMembersRequest(organization.slug, ownerHeaders);
+    const assignedMember = membersResponse.body.members.find(
+      (organizationMember: { email: string }) => organizationMember.email === member.email,
+    ) as { id: string } | undefined;
+
+    expect(assignedMember?.id).toBeTruthy();
+
     await createProjectRequest(organization.slug, ownerHeaders, {
       description: 'Member-visible archived work.',
       name: 'Member Visible',
+      projectOwnerMemberId: assignedMember?.id,
       slug: 'member-visible',
     });
 

--- a/apps/backend-hono/test/projects.spec.ts
+++ b/apps/backend-hono/test/projects.spec.ts
@@ -2,7 +2,7 @@ import { and, eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { db } from '../src/db/client';
-import { auditEvents, members, projects, users } from '../src/db/schema';
+import { auditEvents, members, projectAssignments, projects, users } from '../src/db/schema';
 import { auth } from '../src/lib/auth';
 import { callTRPC } from './trpc-test-utils';
 
@@ -104,6 +104,22 @@ async function restoreProjectRequest(
   headers: Headers,
 ) {
   return callTRPC(headers, (caller) => caller.projects.restore({ organizationSlug, projectSlug }));
+}
+
+async function createProjectAssignmentRequest(
+  organizationSlug: string,
+  projectSlug: string,
+  headers: Headers,
+  body: {
+    organizationMemberId: string;
+    role: 'project_contributor' | 'project_owner';
+  },
+) {
+  return callTRPC(
+    headers,
+    (caller) => caller.projects.createAssignment({ ...body, organizationSlug, projectSlug }),
+    201,
+  );
 }
 
 async function listProjectsRequest(
@@ -596,6 +612,120 @@ describe('organization projects', () => {
     });
     await expect(listProjectsRequest(organization.slug, memberHeaders)).resolves.toMatchObject({
       body: { projects: [{ slug: 'assigned-project' }] },
+      status: 200,
+    });
+  });
+
+  it('derives Project Owner summaries from Project Assignments in Project lists', async () => {
+    const { headers, organization } = await createSignedInOwner('project-assignment-owner');
+    const ownerMembership = await db
+      .select({ id: members.id })
+      .from(members)
+      .where(eq(members.organizationId, organization.id))
+      .limit(1)
+      .then((rows) => rows[0]);
+
+    expect(ownerMembership?.id).toBeTruthy();
+
+    if (!ownerMembership?.id) {
+      throw new Error('Expected an owner membership.');
+    }
+
+    const now = new Date();
+    const projectId = crypto.randomUUID();
+
+    await db.insert(projects).values({
+      createdAt: now,
+      description: 'Assignment-derived accountability.',
+      id: projectId,
+      name: 'Assignment Owner',
+      organizationId: organization.id,
+      projectOwnerMemberId: null,
+      slug: 'assignment-owner',
+      updatedAt: now,
+    });
+    await db.insert(projectAssignments).values({
+      createdAt: now,
+      id: crypto.randomUUID(),
+      organizationMemberId: ownerMembership.id,
+      projectId,
+      role: 'project_owner',
+      updatedAt: now,
+    });
+
+    await expect(listProjectsRequest(organization.slug, headers)).resolves.toMatchObject({
+      body: {
+        projects: [
+          {
+            projectOwner: {
+              id: ownerMembership.id,
+            },
+            slug: 'assignment-owner',
+          },
+        ],
+      },
+      status: 200,
+    });
+  });
+
+  it('lets Organization owners assign Contributors to make Projects visible', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'project-assignment-create-owner',
+    );
+    const member = createCredentials('project-assignment-create-member');
+
+    await signUpUser(member);
+
+    const invitation = await auth.api.createInvitation({
+      body: {
+        email: member.email,
+        organizationId: organization.id,
+        role: 'member',
+      },
+      headers: ownerHeaders,
+    });
+    const memberHeaders = await signInUser(member);
+
+    await auth.api.acceptInvitation({
+      body: { invitationId: invitation.id },
+      headers: memberHeaders,
+    });
+
+    const membersResponse = await listOrganizationMembersRequest(organization.slug, ownerHeaders);
+    const assignedMember = membersResponse.body.members.find(
+      (organizationMember: { email: string }) => organizationMember.email === member.email,
+    ) as { id: string } | undefined;
+
+    expect(assignedMember?.id).toBeTruthy();
+
+    await createProjectRequest(organization.slug, ownerHeaders, {
+      description: 'Assignment-managed governance work.',
+      name: 'Assignment Managed',
+      slug: 'assignment-managed',
+    });
+
+    await expect(listProjectsRequest(organization.slug, memberHeaders)).resolves.toMatchObject({
+      body: { projects: [] },
+      status: 200,
+    });
+
+    const assignmentResponse = await createProjectAssignmentRequest(
+      organization.slug,
+      'assignment-managed',
+      ownerHeaders,
+      {
+        organizationMemberId: assignedMember?.id ?? '',
+        role: 'project_contributor',
+      },
+    );
+
+    expect(assignmentResponse.status).toBe(201);
+    expect(assignmentResponse.body.assignment).toMatchObject({
+      organizationMemberId: assignedMember?.id,
+      role: 'project_contributor',
+    });
+    await expect(listProjectsRequest(organization.slug, memberHeaders)).resolves.toMatchObject({
+      body: { projects: [{ slug: 'assignment-managed' }] },
       status: 200,
     });
   });

--- a/apps/backend-hono/test/projects.spec.ts
+++ b/apps/backend-hono/test/projects.spec.ts
@@ -122,6 +122,31 @@ async function createProjectAssignmentRequest(
   );
 }
 
+async function updateProjectAssignmentRequest(
+  organizationSlug: string,
+  projectSlug: string,
+  headers: Headers,
+  body: {
+    assignmentId: string;
+    role: 'project_contributor' | 'project_owner';
+  },
+) {
+  return callTRPC(headers, (caller) =>
+    caller.projects.updateAssignment({ ...body, organizationSlug, projectSlug }),
+  );
+}
+
+async function removeProjectAssignmentRequest(
+  organizationSlug: string,
+  projectSlug: string,
+  headers: Headers,
+  assignmentId: string,
+) {
+  return callTRPC(headers, (caller) =>
+    caller.projects.removeAssignment({ assignmentId, organizationSlug, projectSlug }),
+  );
+}
+
 async function listProjectsRequest(
   organizationSlug: string,
   headers: Headers,
@@ -726,6 +751,153 @@ describe('organization projects', () => {
     });
     await expect(listProjectsRequest(organization.slug, memberHeaders)).resolves.toMatchObject({
       body: { projects: [{ slug: 'assignment-managed' }] },
+      status: 200,
+    });
+  });
+
+  it('lets Organization owners change a Contributor assignment to Project Owner', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'project-assignment-role-owner',
+    );
+    const member = createCredentials('project-assignment-role-member');
+
+    await signUpUser(member);
+
+    const invitation = await auth.api.createInvitation({
+      body: {
+        email: member.email,
+        organizationId: organization.id,
+        role: 'member',
+      },
+      headers: ownerHeaders,
+    });
+    const memberHeaders = await signInUser(member);
+
+    await auth.api.acceptInvitation({
+      body: { invitationId: invitation.id },
+      headers: memberHeaders,
+    });
+
+    const membersResponse = await listOrganizationMembersRequest(organization.slug, ownerHeaders);
+    const assignedMember = membersResponse.body.members.find(
+      (organizationMember: { email: string }) => organizationMember.email === member.email,
+    ) as { id: string } | undefined;
+
+    expect(assignedMember?.id).toBeTruthy();
+
+    await createProjectRequest(organization.slug, ownerHeaders, {
+      description: 'Assignment role governance work.',
+      name: 'Assignment Role',
+      slug: 'assignment-role',
+    });
+    const assignmentResponse = await createProjectAssignmentRequest(
+      organization.slug,
+      'assignment-role',
+      ownerHeaders,
+      {
+        organizationMemberId: assignedMember?.id ?? '',
+        role: 'project_contributor',
+      },
+    );
+
+    expect(assignmentResponse.status).toBe(201);
+
+    const updateResponse = await updateProjectAssignmentRequest(
+      organization.slug,
+      'assignment-role',
+      ownerHeaders,
+      {
+        assignmentId: assignmentResponse.body.assignment.id,
+        role: 'project_owner',
+      },
+    );
+
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.body.assignment).toMatchObject({
+      id: assignmentResponse.body.assignment.id,
+      role: 'project_owner',
+    });
+    await expect(listProjectsRequest(organization.slug, memberHeaders)).resolves.toMatchObject({
+      body: {
+        projects: [
+          {
+            projectOwner: {
+              email: member.email,
+              id: assignedMember?.id,
+            },
+            slug: 'assignment-role',
+          },
+        ],
+      },
+      status: 200,
+    });
+  });
+
+  it('lets Organization owners remove Project Assignments to revoke visibility', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'project-assignment-remove-owner',
+    );
+    const member = createCredentials('project-assignment-remove-member');
+
+    await signUpUser(member);
+
+    const invitation = await auth.api.createInvitation({
+      body: {
+        email: member.email,
+        organizationId: organization.id,
+        role: 'member',
+      },
+      headers: ownerHeaders,
+    });
+    const memberHeaders = await signInUser(member);
+
+    await auth.api.acceptInvitation({
+      body: { invitationId: invitation.id },
+      headers: memberHeaders,
+    });
+
+    const membersResponse = await listOrganizationMembersRequest(organization.slug, ownerHeaders);
+    const assignedMember = membersResponse.body.members.find(
+      (organizationMember: { email: string }) => organizationMember.email === member.email,
+    ) as { id: string } | undefined;
+
+    expect(assignedMember?.id).toBeTruthy();
+
+    await createProjectRequest(organization.slug, ownerHeaders, {
+      description: 'Assignment removal governance work.',
+      name: 'Assignment Removal',
+      slug: 'assignment-removal',
+    });
+    const assignmentResponse = await createProjectAssignmentRequest(
+      organization.slug,
+      'assignment-removal',
+      ownerHeaders,
+      {
+        organizationMemberId: assignedMember?.id ?? '',
+        role: 'project_contributor',
+      },
+    );
+
+    expect(assignmentResponse.status).toBe(201);
+    await expect(listProjectsRequest(organization.slug, memberHeaders)).resolves.toMatchObject({
+      body: { projects: [{ slug: 'assignment-removal' }] },
+      status: 200,
+    });
+
+    const removeResponse = await removeProjectAssignmentRequest(
+      organization.slug,
+      'assignment-removal',
+      ownerHeaders,
+      assignmentResponse.body.assignment.id,
+    );
+
+    expect(removeResponse.status).toBe(200);
+    expect(removeResponse.body.assignment).toMatchObject({
+      id: assignmentResponse.body.assignment.id,
+      role: 'project_contributor',
+    });
+    await expect(listProjectsRequest(organization.slug, memberHeaders)).resolves.toMatchObject({
+      body: { projects: [] },
       status: 200,
     });
   });

--- a/apps/backend-hono/test/projects.spec.ts
+++ b/apps/backend-hono/test/projects.spec.ts
@@ -833,6 +833,98 @@ describe('organization projects', () => {
     });
   });
 
+  it('demotes the previous Project Owner when a new Project Owner is assigned', async () => {
+    const { headers: ownerHeaders, organization } = await createSignedInOwner(
+      'project-owner-replacement-owner',
+    );
+    const firstProjectOwner = await db
+      .select({ id: members.id })
+      .from(members)
+      .where(eq(members.organizationId, organization.id))
+      .limit(1)
+      .then((rows) => rows[0]);
+    const nextOwner = createCredentials('project-owner-replacement-next');
+
+    expect(firstProjectOwner?.id).toBeTruthy();
+
+    if (!firstProjectOwner?.id) {
+      throw new Error('Expected first Project Owner membership.');
+    }
+
+    await signUpUser(nextOwner);
+
+    const invitation = await auth.api.createInvitation({
+      body: {
+        email: nextOwner.email,
+        organizationId: organization.id,
+        role: 'member',
+      },
+      headers: ownerHeaders,
+    });
+    const nextOwnerHeaders = await signInUser(nextOwner);
+
+    await auth.api.acceptInvitation({
+      body: { invitationId: invitation.id },
+      headers: nextOwnerHeaders,
+    });
+
+    const membersResponse = await listOrganizationMembersRequest(organization.slug, ownerHeaders);
+    const nextOwnerMember = membersResponse.body.members.find(
+      (organizationMember: { email: string }) => organizationMember.email === nextOwner.email,
+    ) as { id: string } | undefined;
+
+    expect(nextOwnerMember?.id).toBeTruthy();
+
+    await createProjectRequest(organization.slug, ownerHeaders, {
+      description: 'Owner replacement governance work.',
+      name: 'Owner Replacement',
+      projectOwnerMemberId: firstProjectOwner.id,
+      slug: 'owner-replacement',
+    });
+
+    const nextOwnerAssignment = await createProjectAssignmentRequest(
+      organization.slug,
+      'owner-replacement',
+      ownerHeaders,
+      {
+        organizationMemberId: nextOwnerMember?.id ?? '',
+        role: 'project_owner',
+      },
+    );
+
+    expect(nextOwnerAssignment.status).toBe(201);
+
+    const assignments = await db
+      .select({
+        organizationMemberId: projectAssignments.organizationMemberId,
+        role: projectAssignments.role,
+      })
+      .from(projectAssignments)
+      .innerJoin(projects, eq(projectAssignments.projectId, projects.id))
+      .where(and(eq(projects.organizationId, organization.id), eq(projects.slug, 'owner-replacement')));
+
+    expect(assignments).toEqual(
+      expect.arrayContaining([
+        { organizationMemberId: firstProjectOwner.id, role: 'project_contributor' },
+        { organizationMemberId: nextOwnerMember?.id, role: 'project_owner' },
+      ]),
+    );
+    await expect(listProjectsRequest(organization.slug, ownerHeaders)).resolves.toMatchObject({
+      body: {
+        projects: [
+          {
+            projectOwner: {
+              email: nextOwner.email,
+              id: nextOwnerMember?.id,
+            },
+            slug: 'owner-replacement',
+          },
+        ],
+      },
+      status: 200,
+    });
+  });
+
   it('lets Organization owners remove Project Assignments to revoke visibility', async () => {
     const { headers: ownerHeaders, organization } = await createSignedInOwner(
       'project-assignment-remove-owner',

--- a/apps/web/src/features/checklists/components/project-checklists-section.tsx
+++ b/apps/web/src/features/checklists/components/project-checklists-section.tsx
@@ -16,7 +16,7 @@ type ProjectChecklistsSectionProps = {
   currentMemberId: string | null;
   organizationSlug: string;
   projectArchived: boolean;
-  projectOwnerMemberId: string | null;
+  projectOwnerAssignmentMemberId: string | null;
   projectSlug: string;
 };
 
@@ -33,7 +33,7 @@ export function ProjectChecklistsSection({
   currentMemberId,
   organizationSlug,
   projectArchived,
-  projectOwnerMemberId,
+  projectOwnerAssignmentMemberId,
   projectSlug,
 }: ProjectChecklistsSectionProps) {
   const [statusFilter, setStatusFilter] = useState<'active' | 'archived'>('active');
@@ -43,7 +43,8 @@ export function ProjectChecklistsSection({
   const archivedView = statusFilter === 'archived';
   const canManageActiveProject = canManage && !projectArchived;
   const canCheckItems =
-    !projectArchived && Boolean(projectOwnerMemberId && projectOwnerMemberId === currentMemberId);
+    !projectArchived &&
+    Boolean(projectOwnerAssignmentMemberId && projectOwnerAssignmentMemberId === currentMemberId);
 
   const projectChecklistQuery = useQuery(
     trpc.checklists.listProjectChecklists.queryOptions(

--- a/apps/web/src/features/projects/api/project-workspace.ts
+++ b/apps/web/src/features/projects/api/project-workspace.ts
@@ -153,15 +153,16 @@ export function useProjectSettingsMutation(input: {
 }
 
 export function useProjectAssignments(input: {
+  enabled?: boolean;
   organizationSlug: string | undefined;
   projectSlug: string | undefined;
 }) {
-  const hasProjectIdentity = Boolean(input.organizationSlug && input.projectSlug);
+  const isEnabled = Boolean(input.enabled && input.organizationSlug && input.projectSlug);
 
   return useQuery(
     trpc.projects.assignments.queryOptions(
       { organizationSlug: input.organizationSlug ?? '', projectSlug: input.projectSlug ?? '' },
-      { enabled: hasProjectIdentity },
+      { enabled: isEnabled },
     ),
   );
 }

--- a/apps/web/src/features/projects/api/project-workspace.ts
+++ b/apps/web/src/features/projects/api/project-workspace.ts
@@ -6,18 +6,17 @@ type ProjectListStatus = 'active' | 'archived';
 type ProjectCreateValues = {
   description: string;
   name: string;
-  projectOwnerMemberId?: string | null;
   slug: string;
 };
 
 type ProjectSettingsValues = {
   description: string;
   name: string;
-  projectOwnerMemberId?: string | null;
 };
 
 type ProjectMutationResult = RouterOutputs['projects']['create'];
 type ProjectUpdateResult = RouterOutputs['projects']['update'];
+type ProjectAssignmentRole = 'project_contributor' | 'project_owner';
 
 export function canManageProjects(role: string | null) {
   return role === 'owner' || role === 'admin';
@@ -113,7 +112,6 @@ export function useCreateProject(input: {
         description: values.description,
         name: values.name,
         organizationSlug: input.organizationSlug,
-        projectOwnerMemberId: values.projectOwnerMemberId || null,
         slug: values.slug,
       });
     },
@@ -148,9 +146,81 @@ export function useProjectSettingsMutation(input: {
         description: values.description,
         name: values.name,
         organizationSlug: input.organizationSlug,
-        projectOwnerMemberId: values.projectOwnerMemberId || null,
         projectSlug: input.projectSlug,
       });
+    },
+  };
+}
+
+export function useProjectAssignments(input: {
+  organizationSlug: string | undefined;
+  projectSlug: string | undefined;
+}) {
+  const hasProjectIdentity = Boolean(input.organizationSlug && input.projectSlug);
+
+  return useQuery(
+    trpc.projects.assignments.queryOptions(
+      { organizationSlug: input.organizationSlug ?? '', projectSlug: input.projectSlug ?? '' },
+      { enabled: hasProjectIdentity },
+    ),
+  );
+}
+
+export function useProjectAssignmentActions(input: {
+  onError?: (message: string) => void;
+  onSuccess?: (message: string) => void;
+  organizationSlug: string | undefined;
+  projectSlug: string | undefined;
+}) {
+  const createMutation = useMutation(
+    trpc.projects.createAssignment.mutationOptions({
+      onError: (caughtError) => input.onError?.(caughtError.message),
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+        input.onSuccess?.('Project Assignment added.');
+      },
+    }),
+  );
+  const updateMutation = useMutation(
+    trpc.projects.updateAssignment.mutationOptions({
+      onError: (caughtError) => input.onError?.(caughtError.message),
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+        input.onSuccess?.('Project Assignment updated.');
+      },
+    }),
+  );
+  const removeMutation = useMutation(
+    trpc.projects.removeAssignment.mutationOptions({
+      onError: (caughtError) => input.onError?.(caughtError.message),
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+        input.onSuccess?.('Project Assignment removed.');
+      },
+    }),
+  );
+
+  const basePayload =
+    input.organizationSlug && input.projectSlug
+      ? { organizationSlug: input.organizationSlug, projectSlug: input.projectSlug }
+      : null;
+
+  return {
+    addAssignment: (organizationMemberId: string, role: ProjectAssignmentRole) => {
+      if (!basePayload || !organizationMemberId) return;
+
+      createMutation.mutate({ ...basePayload, organizationMemberId, role });
+    },
+    isPending: createMutation.isPending || updateMutation.isPending || removeMutation.isPending,
+    removeAssignment: (assignmentId: string) => {
+      if (!basePayload) return;
+
+      removeMutation.mutate({ ...basePayload, assignmentId });
+    },
+    updateAssignmentRole: (assignmentId: string, role: ProjectAssignmentRole) => {
+      if (!basePayload) return;
+
+      updateMutation.mutate({ ...basePayload, assignmentId, role });
     },
   };
 }

--- a/apps/web/src/features/projects/pages/project-detail.tsx
+++ b/apps/web/src/features/projects/pages/project-detail.tsx
@@ -188,7 +188,7 @@ export function ProjectDetailPage() {
         currentMemberId={projectAccess.currentMemberId}
         organizationSlug={organizationSlug}
         projectArchived={Boolean(project.archivedAt)}
-        projectOwnerMemberId={project.projectOwner?.id ?? null}
+        projectOwnerAssignmentMemberId={project.projectOwner?.id ?? null}
         projectSlug={project.slug}
       />
     </div>

--- a/apps/web/src/features/projects/pages/project-settings.tsx
+++ b/apps/web/src/features/projects/pages/project-settings.tsx
@@ -2,10 +2,20 @@ import { useEffect, useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { Link, useParams } from 'react-router';
-import { AlertCircle, Archive, CheckCircle2, LockKeyhole, RotateCcw } from 'lucide-react';
+import {
+  AlertCircle,
+  Archive,
+  CheckCircle2,
+  LockKeyhole,
+  RotateCcw,
+  Trash2,
+  UserPlus,
+} from 'lucide-react';
 import type { ProjectDetail } from '@/features/projects/api/project-api';
 import {
   useProjectArchiveActions,
+  useProjectAssignmentActions,
+  useProjectAssignments,
   useProjectDetail,
   useProjectOwnerOptions,
   useProjectSettingsMutation,
@@ -26,9 +36,13 @@ import { Skeleton } from '@/components/ui/skeleton';
 export function ProjectSettingsPage() {
   const { organizationSlug = '', projectSlug = '' } = useParams();
   const [projectOverride, setProjectOverride] = useState<ProjectDetail | null>(null);
+  const [newAssignmentMemberId, setNewAssignmentMemberId] = useState('');
+  const [newAssignmentRole, setNewAssignmentRole] = useState<
+    'project_contributor' | 'project_owner'
+  >('project_contributor');
   const projectSettingsForm = useForm<ProjectSettingsFormValues>({
     resolver: zodResolver(projectSettingsFormSchema),
-    defaultValues: { name: '', description: '', projectOwnerMemberId: '' },
+    defaultValues: { name: '', description: '' },
   });
   const [saveError, setSaveError] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
@@ -37,6 +51,7 @@ export function ProjectSettingsPage() {
 
   const detailQuery = useProjectDetail({ organizationSlug, projectSlug });
   const projectOptions = useProjectOwnerOptions(organizationSlug);
+  const assignmentsQuery = useProjectAssignments({ organizationSlug, projectSlug });
   const updateProjectMutation = useProjectSettingsMutation({
     onError: (message) => {
       setSaveError(humanizeAuthError(null, message, 'Unable to save Project settings.'));
@@ -48,7 +63,6 @@ export function ProjectSettingsPage() {
       projectSettingsForm.reset({
         name: updatedProject.name,
         description: updatedProject.description,
-        projectOwnerMemberId: updatedProject.projectOwner?.id ?? '',
       });
       setStatus('Project settings saved.');
     },
@@ -69,16 +83,35 @@ export function ProjectSettingsPage() {
     },
     organizationSlug,
   });
+  const assignmentActions = useProjectAssignmentActions({
+    onError: (message) => {
+      setSaveError(humanizeAuthError(null, message, 'Unable to update Project Assignments.'));
+    },
+    onSuccess: (message) => {
+      setNewAssignmentMemberId('');
+      setNewAssignmentRole('project_contributor');
+      setStatus(message);
+    },
+    organizationSlug,
+    projectSlug,
+  });
 
   const queryProject = detailQuery.data?.status === 'available' ? detailQuery.data.project : null;
   const project = projectOverride ?? queryProject;
   const members = projectOptions.members;
-  const loadError = detailQuery.error ?? projectOptions.error;
+  const assignments = assignmentsQuery.data?.assignments ?? [];
+  const assignedMemberIds = new Set(
+    assignments.map((assignment) => assignment.organizationMemberId),
+  );
+  const assignableMembers = members.filter((member) => !assignedMemberIds.has(member.id));
+  const loadError = detailQuery.error ?? projectOptions.error ?? assignmentsQuery.error;
   const loadErrorMessage = loadError
     ? humanizeAuthError(null, loadError.message, 'Unable to load Project settings.')
     : null;
   const isSaving = updateProjectMutation.isPending;
   const isArchiving = projectArchiveActions.isPending;
+  const isAssignmentSaving = assignmentActions.isPending;
+  const assignmentsLocked = Boolean(project?.archivedAt) || isAssignmentSaving;
 
   useEffect(() => {
     if (!queryProject) return;
@@ -87,7 +120,6 @@ export function ProjectSettingsPage() {
     projectSettingsForm.reset({
       name: queryProject.name,
       description: queryProject.description,
-      projectOwnerMemberId: queryProject.projectOwner?.id ?? '',
     });
   }, [projectSettingsForm, queryProject]);
 
@@ -107,7 +139,19 @@ export function ProjectSettingsPage() {
     projectArchiveActions.setProjectArchived(projectSlug, !project.archivedAt);
   };
 
-  if (hasProjectIdentity && (detailQuery.isPending || projectOptions.isPending) && !project) {
+  const handleAddAssignment = () => {
+    if (!newAssignmentMemberId || assignmentsLocked) return;
+
+    setSaveError(null);
+    setStatus(null);
+    assignmentActions.addAssignment(newAssignmentMemberId, newAssignmentRole);
+  };
+
+  if (
+    hasProjectIdentity &&
+    (detailQuery.isPending || projectOptions.isPending || assignmentsQuery.isPending) &&
+    !project
+  ) {
     return (
       <div className="mx-auto w-full max-w-3xl space-y-6">
         <Skeleton className="h-8 w-56" />
@@ -192,7 +236,7 @@ export function ProjectSettingsPage() {
         <CardHeader>
           <CardTitle>Details</CardTitle>
           <CardDescription>
-            Name, description, and Project Owner can change. The slug remains immutable.
+            Name and description can change. The slug remains immutable.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -224,22 +268,6 @@ export function ProjectSettingsPage() {
               ) : null}
             </div>
             <div className="space-y-2">
-              <Label htmlFor="project-owner">Project Owner</Label>
-              <select
-                id="project-owner"
-                {...projectSettingsForm.register('projectOwnerMemberId')}
-                disabled={!canEdit || isSaving}
-                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
-              >
-                <option value="">No Project Owner</option>
-                {members.map((member) => (
-                  <option key={member.id} value={member.id}>
-                    {member.name} ({member.email})
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div className="space-y-2">
               <Label htmlFor="project-slug">Slug</Label>
               <Input id="project-slug" value={project.slug} disabled />
               <p className="text-xs text-muted-foreground">
@@ -256,6 +284,125 @@ export function ProjectSettingsPage() {
           </form>
         </CardContent>
       </Card>
+
+      {canEdit ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Project Assignments</CardTitle>
+            <CardDescription>
+              Manage Project visibility and the Project Owner role separately from Project details.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {project.archivedAt ? (
+              <Alert>
+                <Archive className="size-4" />
+                <AlertTitle>Assignments locked</AlertTitle>
+                <AlertDescription>
+                  Restore this Archived Project before changing Project Assignments.
+                </AlertDescription>
+              </Alert>
+            ) : null}
+
+            {assignments.length === 0 ? (
+              <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                No Organization Members are assigned to this Project.
+              </p>
+            ) : (
+              <div className="divide-y rounded-md border">
+                {assignments.map((assignment) => (
+                  <div
+                    key={assignment.id}
+                    className="grid gap-3 p-4 md:grid-cols-[1fr_220px_auto] md:items-center"
+                  >
+                    <div>
+                      <p className="text-sm font-medium">{assignment.name}</p>
+                      <p className="text-xs text-muted-foreground">{assignment.email}</p>
+                    </div>
+                    <select
+                      value={assignment.role}
+                      disabled={assignmentsLocked}
+                      onChange={(event) => {
+                        setSaveError(null);
+                        setStatus(null);
+                        assignmentActions.updateAssignmentRole(
+                          assignment.id,
+                          event.target.value as 'project_contributor' | 'project_owner',
+                        );
+                      }}
+                      className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                    >
+                      <option value="project_contributor">Contributor</option>
+                      <option value="project_owner">Project Owner</option>
+                    </select>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={assignmentsLocked}
+                      onClick={() => {
+                        setSaveError(null);
+                        setStatus(null);
+                        assignmentActions.removeAssignment(assignment.id);
+                      }}
+                    >
+                      <Trash2 />
+                      Remove
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="grid gap-3 rounded-md border p-4 md:grid-cols-[1fr_220px_auto] md:items-end">
+              <div className="space-y-2">
+                <Label htmlFor="new-project-assignment-member">Organization Member</Label>
+                <select
+                  id="new-project-assignment-member"
+                  value={newAssignmentMemberId}
+                  disabled={assignmentsLocked || assignableMembers.length === 0}
+                  onChange={(event) => setNewAssignmentMemberId(event.target.value)}
+                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                >
+                  <option value="">
+                    {assignableMembers.length === 0 ? 'All members assigned' : 'Select member'}
+                  </option>
+                  {assignableMembers.map((member) => (
+                    <option key={member.id} value={member.id}>
+                      {member.name} ({member.email})
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="new-project-assignment-role">Role</Label>
+                <select
+                  id="new-project-assignment-role"
+                  value={newAssignmentRole}
+                  disabled={assignmentsLocked}
+                  onChange={(event) =>
+                    setNewAssignmentRole(
+                      event.target.value as 'project_contributor' | 'project_owner',
+                    )
+                  }
+                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                >
+                  <option value="project_contributor">Contributor</option>
+                  <option value="project_owner">Project Owner</option>
+                </select>
+              </div>
+              <Button
+                type="button"
+                disabled={assignmentsLocked || !newAssignmentMemberId}
+                onClick={handleAddAssignment}
+              >
+                <UserPlus />
+                Add
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      ) : null}
 
       {canEdit ? (
         <Card>

--- a/apps/web/src/features/projects/pages/project-settings.tsx
+++ b/apps/web/src/features/projects/pages/project-settings.tsx
@@ -51,7 +51,11 @@ export function ProjectSettingsPage() {
 
   const detailQuery = useProjectDetail({ organizationSlug, projectSlug });
   const projectOptions = useProjectOwnerOptions(organizationSlug);
-  const assignmentsQuery = useProjectAssignments({ organizationSlug, projectSlug });
+  const assignmentsQuery = useProjectAssignments({
+    enabled: projectOptions.canManageProjects,
+    organizationSlug,
+    projectSlug,
+  });
   const updateProjectMutation = useProjectSettingsMutation({
     onError: (message) => {
       setSaveError(humanizeAuthError(null, message, 'Unable to save Project settings.'));
@@ -104,9 +108,12 @@ export function ProjectSettingsPage() {
     assignments.map((assignment) => assignment.organizationMemberId),
   );
   const assignableMembers = members.filter((member) => !assignedMemberIds.has(member.id));
-  const loadError = detailQuery.error ?? projectOptions.error ?? assignmentsQuery.error;
+  const loadError = detailQuery.error ?? projectOptions.error;
   const loadErrorMessage = loadError
     ? humanizeAuthError(null, loadError.message, 'Unable to load Project settings.')
+    : null;
+  const assignmentLoadErrorMessage = assignmentsQuery.error
+    ? humanizeAuthError(null, assignmentsQuery.error.message, 'Unable to load Project Assignments.')
     : null;
   const isSaving = updateProjectMutation.isPending;
   const isArchiving = projectArchiveActions.isPending;
@@ -149,7 +156,9 @@ export function ProjectSettingsPage() {
 
   if (
     hasProjectIdentity &&
-    (detailQuery.isPending || projectOptions.isPending || assignmentsQuery.isPending) &&
+    (detailQuery.isPending ||
+      projectOptions.isPending ||
+      (projectOptions.canManageProjects && assignmentsQuery.isPending)) &&
     !project
   ) {
     return (
@@ -303,8 +312,15 @@ export function ProjectSettingsPage() {
                 </AlertDescription>
               </Alert>
             ) : null}
+            {assignmentLoadErrorMessage ? (
+              <Alert variant="destructive">
+                <AlertCircle className="size-4" />
+                <AlertTitle>Unable to load assignments</AlertTitle>
+                <AlertDescription>{assignmentLoadErrorMessage}</AlertDescription>
+              </Alert>
+            ) : null}
 
-            {assignments.length === 0 ? (
+            {assignmentLoadErrorMessage ? null : assignments.length === 0 ? (
               <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
                 No Organization Members are assigned to this Project.
               </p>
@@ -354,52 +370,54 @@ export function ProjectSettingsPage() {
               </div>
             )}
 
-            <div className="grid gap-3 rounded-md border p-4 md:grid-cols-[1fr_220px_auto] md:items-end">
-              <div className="space-y-2">
-                <Label htmlFor="new-project-assignment-member">Organization Member</Label>
-                <select
-                  id="new-project-assignment-member"
-                  value={newAssignmentMemberId}
-                  disabled={assignmentsLocked || assignableMembers.length === 0}
-                  onChange={(event) => setNewAssignmentMemberId(event.target.value)}
-                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
-                >
-                  <option value="">
-                    {assignableMembers.length === 0 ? 'All members assigned' : 'Select member'}
-                  </option>
-                  {assignableMembers.map((member) => (
-                    <option key={member.id} value={member.id}>
-                      {member.name} ({member.email})
+            {assignmentLoadErrorMessage ? null : (
+              <div className="grid gap-3 rounded-md border p-4 md:grid-cols-[1fr_220px_auto] md:items-end">
+                <div className="space-y-2">
+                  <Label htmlFor="new-project-assignment-member">Organization Member</Label>
+                  <select
+                    id="new-project-assignment-member"
+                    value={newAssignmentMemberId}
+                    disabled={assignmentsLocked || assignableMembers.length === 0}
+                    onChange={(event) => setNewAssignmentMemberId(event.target.value)}
+                    className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                  >
+                    <option value="">
+                      {assignableMembers.length === 0 ? 'All members assigned' : 'Select member'}
                     </option>
-                  ))}
-                </select>
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="new-project-assignment-role">Role</Label>
-                <select
-                  id="new-project-assignment-role"
-                  value={newAssignmentRole}
-                  disabled={assignmentsLocked}
-                  onChange={(event) =>
-                    setNewAssignmentRole(
-                      event.target.value as 'project_contributor' | 'project_owner',
-                    )
-                  }
-                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                    {assignableMembers.map((member) => (
+                      <option key={member.id} value={member.id}>
+                        {member.name} ({member.email})
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="new-project-assignment-role">Role</Label>
+                  <select
+                    id="new-project-assignment-role"
+                    value={newAssignmentRole}
+                    disabled={assignmentsLocked}
+                    onChange={(event) =>
+                      setNewAssignmentRole(
+                        event.target.value as 'project_contributor' | 'project_owner',
+                      )
+                    }
+                    className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                  >
+                    <option value="project_contributor">Contributor</option>
+                    <option value="project_owner">Project Owner</option>
+                  </select>
+                </div>
+                <Button
+                  type="button"
+                  disabled={assignmentsLocked || !newAssignmentMemberId}
+                  onClick={handleAddAssignment}
                 >
-                  <option value="project_contributor">Contributor</option>
-                  <option value="project_owner">Project Owner</option>
-                </select>
+                  <UserPlus />
+                  Add
+                </Button>
               </div>
-              <Button
-                type="button"
-                disabled={assignmentsLocked || !newAssignmentMemberId}
-                onClick={handleAddAssignment}
-              >
-                <UserPlus />
-                Add
-              </Button>
-            </div>
+            )}
           </CardContent>
         </Card>
       ) : null}

--- a/apps/web/src/features/projects/pages/projects.tsx
+++ b/apps/web/src/features/projects/pages/projects.tsx
@@ -42,7 +42,7 @@ export function ProjectsPage() {
   const [status, setStatus] = useState<string | null>(null);
   const createProjectForm = useForm<CreateProjectFormValues>({
     resolver: zodResolver(createProjectFormSchema),
-    defaultValues: { name: '', slug: '', description: '', projectOwnerMemberId: '' },
+    defaultValues: { name: '', slug: '', description: '' },
   });
   const archivedView = isArchivedView(searchParams.get('status'));
   const projectStatus = archivedView ? 'archived' : 'active';
@@ -74,7 +74,6 @@ export function ProjectsPage() {
   });
 
   const projects = projectQuery.data?.projects ?? [];
-  const members = projectOptions.members;
   const loadError = projectQuery.error ?? projectOptions.error;
   const displayError =
     error ??
@@ -278,21 +277,6 @@ export function ProjectsPage() {
                     {createProjectForm.formState.errors.description.message}
                   </p>
                 ) : null}
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="project-owner">Project Owner</Label>
-                <select
-                  id="project-owner"
-                  {...createProjectForm.register('projectOwnerMemberId')}
-                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
-                >
-                  <option value="">No Project Owner</option>
-                  {members.map((member) => (
-                    <option key={member.id} value={member.id}>
-                      {member.name} ({member.email})
-                    </option>
-                  ))}
-                </select>
               </div>
               <div className="flex justify-end gap-2">
                 <Button

--- a/apps/web/src/features/projects/schemas/project-form-schemas.ts
+++ b/apps/web/src/features/projects/schemas/project-form-schemas.ts
@@ -4,13 +4,11 @@ export const createProjectFormSchema = z.object({
   name: z.string().min(1, 'Project name is required.'),
   slug: z.string().min(1, 'Project slug is required.'),
   description: z.string().min(1, 'Project description is required.'),
-  projectOwnerMemberId: z.string(),
 });
 
 export const projectSettingsFormSchema = z.object({
   name: z.string().min(1, 'Project name is required.'),
   description: z.string().min(1, 'Project description is required.'),
-  projectOwnerMemberId: z.string(),
 });
 
 export type CreateProjectFormValues = z.infer<typeof createProjectFormSchema>;


### PR DESCRIPTION
## Summary

- add Project Assignments as the Project participation model and derive Project Owner from the `project_owner` assignment
- scope Project and Project Checklist visibility to assigned members while preserving owner/admin administration
- add assignment create, role change, remove, roster, audit, archived lockout, and member-removal cleanup flows
- remove the legacy `projects.project_owner_member_id` field and migrate existing owners into assignments
- add Project settings UI for explicit assignment management

Closes #77

## Validation

- `pnpm lint`
- `pnpm check-types`
- `pnpm test`
- `pnpm --filter backend-hono build`
- `pnpm --filter web build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Project Assignments for scoped project visibility and ownership. Owners/admins keep org-wide access; assigned members see only their projects (Linear #77).

- New Features
  - Add `project_assignments` with APIs to list roster, create, change role, and remove; block mutations on archived projects (roster is owner/admin-only).
  - Auto-demote the previous owner when a new owner is assigned or promoted.
  - Checklist access respects assignments; only the Project Owner can check/uncheck items.
  - Owners/admins can remove organization members; project assignments are cleaned up automatically.
  - Project Settings UI to manage assignments; emit audit events for create/update/remove; keep assignment roster errors scoped to the panel to avoid page-level failures.

- Migration
  - Run DB migrations to add `project_assignments` (including `organization_id` and composite FKs to enforce same-organization integrity) and drop `projects.project_owner_member_id`; existing owners are migrated to assignments.
  - Projects without assignments are visible only to owners/admins until assignments are added.
  - API change: remove `projectOwnerMemberId` from project create/update; use assignment endpoints for ownership and contributors.

<sup>Written for commit 790498063f05ad323e805d3066edd5994deff762. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

